### PR TITLE
tab cycle backward when SHIFT is held

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## History
+* 2021/07/24 ver 2.26.2
+	* Added option to cycle forward or backward with TAB
 * 2021/07/21 ver 2.26.1
 	* Implemented Constraints feature in Square grid types.
 	* Added new Sudoku Normal digits position option in Settings. User can select if the digits must be centered or shifted downward to avoid clash with Killer type clues.

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -736,11 +736,12 @@ onload = function() {
                     if (previous_length != user_choices.length) {
                         previous_length = user_choices.length;
                         counter_index = 0; // reset the counter
-                    } else if (counter_index < (previous_length - 1)) {
-                        counter_index++;
+                    } else if (shift_key) { // if SHIFT is held down cycle backward
+                        counter_index--;
                     } else {
-                        counter_index = 0; // reset the counter
+                        counter_index++;
                     }
+                    counter_index %= previous_length
                     let mode_loc = modes.indexOf(user_choices[counter_index]);
                     if (mode_loc < 4) { // Hard coded, '4', Surface, Shape, Wall, Composite Modes, remaining choices are related to submodes
                         pu.mode_set(modes_mapping[mode_loc])

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -737,11 +737,11 @@ onload = function() {
                         previous_length = user_choices.length;
                         counter_index = 0; // reset the counter
                     } else if (shift_key) { // if SHIFT is held down cycle backward
-                        counter_index--;
+                        counter_index += user_choices.length - 1;
                     } else {
                         counter_index++;
                     }
-                    counter_index %= previous_length
+                    counter_index %= user_choices.length
                     let mode_loc = modes.indexOf(user_choices[counter_index]);
                     if (mode_loc < 4) { // Hard coded, '4', Surface, Shape, Wall, Composite Modes, remaining choices are related to submodes
                         pu.mode_set(modes_mapping[mode_loc])


### PR DESCRIPTION
Holding SHIFT to move in the opposite direction is pretty standard UI (e.g. in a web browser CTRL+TAB moves to the next tab, and CTRL+SHIFT+TAB moves to the previous tab).

Having this option will allow solvers to move around more easily when there are more than 2 modes selected.

I also changed the length check to use modular arithmetic instead, since that seems cleaner.

**Testing:**
- [x] select all of the `Line ***` options and confirmed that TAB, SHIFT+TAB, ENTER, SHIFT+ENTER all function as expected