### PR TITLE
edgexoi: yellow/blue instead of yellow/green

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -9963,7 +9963,7 @@ class Puzzle {
                 this[this.mode.qa].surface[num] = 7;
             } else if (this[this.mode.qa].surface[num] === 7) {
                 this.record("surface", num);
-                this[this.mode.qa].surface[num] = 2;
+                this[this.mode.qa].surface[num] = 5;
             } else {
                 this.record("surface", num);
                 delete this[this.mode.qa].surface[num];


### PR DESCRIPTION
I am colorblind (I can never remember which particular variety) and I
bright yellow and green nearly impossible to distinguish. When doing
Slitherlink on penpa I am constantly double checking zoomed in
on high brightness to make sure I can tell which color is which. With
this replacement, it's easy to tell the difference. Blue is also light enough
that it should not occlude clues, unlike other potential choices.