### PR TITLE
Allow appending puzzlink URL as puzzle data to quickly load in Penpa.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1468,6 +1468,7 @@
                     <a class="button" target="_blank" href="https://github.com/swaroopg92/penpa-edit/wiki/Steps-to-Create-Sudoku-or-Puzzle-in-Penpa">Steps to Create a Sudoku/Puzzle</a>
                     <a class="button" target="_blank" href="https://docs.google.com/document/d/12Mde0ogcpdtgM2nz6Z_nZYJnMJyUOMC5f3FUxzH9q74/edit">Frequently Asked Questions</a>
                     <a class="button" target="_blank" href="https://discord.gg/BbN89j5">Discord Channel</a>
+                    <a class="button" target="_blank" href="javascript:window.location='https://swaroop.github.io/penpa-edit/?m=solve&amp;p='+window.location;">Bookmarklet to Open Puzz.Link/PZV Puzzles in Penpa</a>
                 </div>
                 <h5 class="modal-subheader">Development</h5>
                 <div class="nb_button">

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -1446,8 +1446,8 @@ function export_sudoku() {
     }
 }
 
-function import_url() {
-    let urlstring = document.getElementById("urlstring").value;
+function import_url(urlstring) {
+    urlstring = urlstring || document.getElementById("urlstring").value;
     if (urlstring !== "") {
         if (urlstring.indexOf("/penpa-edit/?") !== -1) {
             urlstring = urlstring.split("/penpa-edit/?")[1];
@@ -1483,6 +1483,12 @@ function load(urlParam, type = 'url') {
     for (var i = 0; i < param.length; i++) {
         var paramItem = param[i].split('=');
         paramArray[paramItem[0]] = paramItem[1];
+    }
+
+    if (paramArray.p.substring(0,4) === 'http') {
+        create();
+        import_url(paramArray.p);
+        return;
     }
 
     // Decrypt P
@@ -3481,18 +3487,20 @@ function decode_puzzlink(url) {
 
     var tabSelect = document.querySelector('ul.multi');
     var tabOptions = UserSettings.tab_settings;
-    for (var child of tabSelect.children) {
-        if (!child.dataset.value) {
-            continue;
-        }
-
-        if (tabOptions.includes(child.dataset.value)) {
-            if (!child.classList.contains('active')) {
-                child.click();
+    if (tabSelect) {
+        for (var child of tabSelect.children) {
+            if (!child.dataset.value) {
+                continue;
             }
-        } else {
-            if (child.classList.contains('active')) {
-                child.click();
+
+            if (tabOptions.includes(child.dataset.value)) {
+                if (!child.classList.contains('active')) {
+                    child.click();
+                }
+            } else {
+                if (child.classList.contains('active')) {
+                    child.click();
+                }
             }
         }
     }

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -1456,7 +1456,7 @@ function import_url(urlstring) {
             if (UserSettings.tab_settings > 0) {
                 selectBox.setValue(UserSettings.tab_settings);
             }
-        } else if (urlstring.indexOf("/puzz.link/p?") !== -1 || urlstring.indexOf("/pzv.jp/p.html?") !== -1) {
+        } else if (urlstring.match(/\/puzz.link\/p\?|pzprxs\.vercel\.app\/p\?|\/pzv\.jp\/p\.html\?/)) {
             decode_puzzlink(urlstring);
             document.getElementById("modal-load").style.display = 'none';
         } else {


### PR DESCRIPTION
With this change, you can now load a puzzle in Penpa by appending a puzzlink URL, e.g. 

https://swaroopg92.github.io/penpa-edit/?m=solve&p=https://puzz.link/p?yajikazu/9/9/c31b32b41a40a22c10e32a1111a43b10a23b44b21a11b34b13a22b33a2121a42e20c10a30a31b42b41c