### PR TITLE
Added Hexagon and Polyhex shapes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -311,6 +311,24 @@
                                                 <li><span id="ms_diamond_SS">XS</span></li>
                                             </ul>
                                         </li>
+                                        <li id="li_hexpoint"><span id="ms1_hexpoint">Hexagon point</span>
+                                            <ul>
+                                                <li><span id="ms_hexpoint_LL">XL</span></li>
+                                                <li><span id="ms_hexpoint_L">L</span></li>
+                                                <li><span id="ms_hexpoint_M">M</span></li>
+                                                <li><span id="ms_hexpoint_S">S</span></li>
+                                                <li><span id="ms_hexpoint_SS">XS</span></li>
+                                            </ul>
+                                        </li>
+                                        <li id="li_hexflat"><span id="ms1_hexflat">Hexagon flat</span>
+                                            <ul>
+                                                <li><span id="ms_hexflat_LL">XL</span></li>
+                                                <li><span id="ms_hexflat_L">L</span></li>
+                                                <li><span id="ms_hexflat_M">M</span></li>
+                                                <li><span id="ms_hexflat_S">S</span></li>
+                                                <li><span id="ms_hexflat_SS">XS</span></li>
+                                            </ul>
+                                        </li>
                                         <li id="li_ox"><span id="ms1_ox">○△□×</span>
                                             <ul>
                                                 <li><span id="ms_ox_B">Black</span></li>
@@ -414,6 +432,7 @@
                                         <li id="li_sudokuetc"><span id="ms_sudokuetc">Sudoku</span></li>
                                         <li id="li_sudokumore"><span id="ms_sudokumore">ArrowSums</span></li>
                                         <li id="li_polyomino"><span id="ms_polyomino">Polyomino</span></li>
+                                        <li id="li_polyhex"><span id="ms_polyhex">Polyhex</span></li>
                                     </ul>
                                 </li>
                                 <li><span id="ms5" class="labelS">Special 2</span>

--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -27,7 +27,8 @@ class Puzzle_hex extends Puzzle {
             "degital_f": 7,
             "arrow_eight": 6,
             "dice": 9,
-            "polyomino": 9
+            "polyomino": 9,
+            "polyhex": 7
         };
         this.reset();
         this.erase_buttons();
@@ -1501,6 +1502,46 @@ class Puzzle_hex extends Puzzle {
                 set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
                 break;
+            case "hexpoint_LL":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.58, 6, 30);
+                break;
+            case "hexpoint_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.43, 6, 30);
+                break;
+                case "hexpoint_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.35, 6, 30);
+                break;
+            case "hexpoint_S":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.22, 6, 30);
+                break;
+            case "hexpoint_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 30);
+                break;
+            case "hexflat_LL":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.58, 6, 0);
+                break;
+            case "hexflat_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.43, 6, 0);
+                break;
+                case "hexflat_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.35, 6, 0);
+                break;
+            case "hexflat_S":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.22, 6, 0);
+                break;
+            case "hexflat_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 0);
+                break;
             case "ox_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
@@ -1696,6 +1737,9 @@ class Puzzle_hex extends Puzzle {
                 break;
             case "polyomino":
                 this.draw_polyomino(ctx, num, x, y, ccolor);
+                break;
+            case "polyhex":
+                this.draw_polyhex(ctx, num, x, y, ccolor);
                 break;
                 //case "pencils":
                 //  this.draw_pencils(ctx,num,x,y);
@@ -3074,7 +3118,30 @@ class Puzzle_hex extends Puzzle {
             }
         }
     }
-
+    draw_polyhex(ctx, num, x, y, ccolor = "none") {
+        ctx.setLineDash([]);
+        if (ccolor !== "none") {
+            ctx.fillStyle = ccolor;
+        } else {
+            ctx.fillStyle = Color.GREY_LIGHT;
+        }
+        ctx.strokeStyle = Color.BLACK;
+        ctx.lineWidth = 1.2;
+        ctx.lineCap = "butt";
+        var r = 0.2;
+        var degrees = [-120,-60,180,null,0,120,60];
+        var r2 = r * 1.23;
+        for (var i = 0; i < 7; i++) {
+            if (num[i] === 1) {
+                if (i==3){
+                    this.draw_polygon(ctx, x, y, r * 0.5 * Math.sqrt(2), 6, 30);
+                }else{
+                    this.draw_polygon(ctx, x + pu.size * r2 * Math.cos(degrees[i] * Math.PI / 180), y + pu.size * r2 * Math.sin(degrees[i] * Math.PI / 180), r * 0.5 * Math.sqrt(2), 6, 30);
+                }
+            }
+        }
+    }
+    
     rotate_theta(th) {
         th = (th + this.theta);
         if (this.reflect[0] === -1) { th = (180 - th + 360) % 360; }

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -2505,6 +2505,16 @@ class Puzzle {
                 case "ms_diamond_M":
                 case "ms_diamond_S":
                 case "ms_diamond_SS":
+                case "ms_hexpoint_LL":
+                case "ms_hexpoint_L":
+                case "ms_hexpoint_M":
+                case "ms_hexpoint_S":
+                case "ms_hexpoint_SS":
+                case "ms_hexflat_LL":
+                case "ms_hexflat_L":
+                case "ms_hexflat_M":
+                case "ms_hexflat_S":
+                case "ms_hexflat_SS":
                 case "ms_star":
                 case "ms_firefly":
                 case "ms_sun_moon":
@@ -2520,6 +2530,7 @@ class Puzzle {
                     break;
                 case "ms_sudokuetc":
                 case "ms_polyomino":
+                case "ms_polyhex":
                 case "ms_neighbors":
                     $("#colorpicker_special").spectrum("set", Color.GREY_LIGHT);
                     break;

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -1234,9 +1234,53 @@ class Puzzle_pyramid extends Puzzle {
                 set_circle_style(ctx, num);
                 this.draw_polygon(ctx, x, y, 0.35, 4, 0);
                 break;
+            case "diamond_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.22, 4, 0);
+                break;
             case "diamond_SS":
                 set_circle_style(ctx, num);
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
+                break;
+            case "hexpoint_LL":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 30);
+                break;
+            case "hexpoint_L":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 30);
+                break;
+            case "hexpoint_M":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 30);
+                break;
+            case "hexpoint_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 30);
+                break;
+            case "hexpoint_SS":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 30);
+                break;            
+            case "hexflat_LL":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 0);
+                break;
+            case "hexflat_L":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 0);
+                break;
+            case "hexflat_M":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 0);
+                break;
+            case "hexflat_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 0);
+                break;
+            case "hexflat_SS":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 0);
                 break;
             case "ox_B":
                 ctx.setLineDash([]);

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -2550,7 +2550,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_polyhex(ctx, num, x, y);
                 }
                 break;
-                        case "pencils":
+            case "pencils":
                 if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_pencils(ctx, num, x, y, this[qamode + "_col"].symbol[i]);

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -36,7 +36,9 @@ class Puzzle_square extends Puzzle {
             "arrow_fouredge_G": 8,
             "arrow_fouredge_E": 8,
             "dice": 9,
-            "polyomino": 9
+            "polyomino": 9,
+            "polyhex": 7
+
         };
         this.reset();
         this.erase_buttons();
@@ -2006,6 +2008,96 @@ class Puzzle_square extends Puzzle {
                 }
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
                 break;
+            case "hexpoint_LL":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.48, 6, 30);
+                break;
+            case "hexpoint_L":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.4, 6, 30);
+                break;
+            case "hexpoint_M":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.3, 6, 30);
+                break;
+            case "hexpoint_S":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.2, 6, 30);
+                break;
+            case "hexpoint_SS":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.13, 6, 30);
+                break;
+            case "hexflat_LL":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.48, 6, 0);
+                break;
+            case "hexflat_L":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.4, 6, 0);
+                break;
+            case "hexflat_M":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.3, 6, 0);
+                break;
+            case "hexflat_S":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.2, 6, 0);
+                break;
+            case "hexflat_SS":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
+                } else {
+                    set_circle_style(ctx, num);
+                }
+                this.draw_polygon(ctx, x, y, 0.13, 6, 0);
+                break;
             case "ox_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
@@ -2450,7 +2542,15 @@ class Puzzle_square extends Puzzle {
                     this.draw_polyomino(ctx, num, x, y);
                 }
                 break;
-            case "pencils":
+            case "polyhex":
+                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    this[qamode + "_col"].symbol[i]) {
+                    this.draw_polyhex(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
+                } else {
+                    this.draw_polyhex(ctx, num, x, y);
+                }
+                break;
+                        case "pencils":
                 if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_pencils(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
@@ -4260,6 +4360,30 @@ class Puzzle_square extends Puzzle {
         }
     }
 
+    draw_polyhex(ctx, num, x, y, ccolor = "none") {
+        ctx.setLineDash([]);
+        if (ccolor !== "none") {
+            ctx.fillStyle = ccolor;
+        } else {
+            ctx.fillStyle = Color.GREY_LIGHT;
+        }
+        ctx.strokeStyle = Color.BLACK;
+        ctx.lineWidth = 1.2;
+        ctx.lineCap = "butt";
+        var r = 0.2;
+        var degrees = [-120,-60,180,null,0,120,60];
+        var r2 = r * 1.23;
+        for (var i = 0; i < 7; i++) {
+            if (num[i] === 1) {
+                if (i==3){
+                    this.draw_polygon(ctx, x, y, r * 0.5 * Math.sqrt(2), 6, 30);
+                }else{
+                    this.draw_polygon(ctx, x + pu.size * r2 * Math.cos(degrees[i] * Math.PI / 180), y + pu.size * r2 * Math.sin(degrees[i] * Math.PI / 180), r * 0.5 * Math.sqrt(2), 6, 30);
+                }
+            }
+        }
+    }
+
     rotate_theta(th) {
         th = (th + this.theta);
         if (this.reflect[0] === -1) { th = (180 - th + 360) % 360; }
@@ -4313,7 +4437,8 @@ class Puzzle_sudoku extends Puzzle_square {
             "arrow_fouredge_G": 8,
             "arrow_fouredge_E": 8,
             "dice": 9,
-            "polyomino": 9
+            "polyomino": 9,
+            "polyhex": 7
         };
         this.reset();
         this.erase_buttons();
@@ -4399,7 +4524,9 @@ class Puzzle_kakuro extends Puzzle_square {
             "arrow_fouredge_G": 8,
             "arrow_fouredge_E": 8,
             "dice": 9,
-            "polyomino": 9
+            "polyomino": 9,
+            "polyhex": 7
+
         };
         this.reset();
         this.erase_buttons();

--- a/docs/js/class_tri.js
+++ b/docs/js/class_tri.js
@@ -1251,9 +1251,53 @@ class Puzzle_tri extends Puzzle {
                 set_circle_style(ctx, num);
                 this.draw_polygon(ctx, x, y, 0.25, 4, 0);
                 break;
+            case "diamond_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.17, 4, 0);
+                break;
             case "diamond_SS":
                 set_circle_style(ctx, num);
-                this.draw_polygon(ctx, x, y, 0.13, 4, 0);
+                this.draw_polygon(ctx, x, y, 0.11, 4, 0);
+                break;
+            case "hexpoint_LL":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 30);
+                break;
+            case "hexpoint_L":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 30);
+                break;
+            case "hexpoint_M":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 30);
+                break;
+            case "hexpoint_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 30);
+                break;
+            case "hexpoint_SS":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 30);
+                break;
+            case "hexflat_LL":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 0);
+                break;
+            case "hexflat_L":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 0);
+                break;
+            case "hexflat_M":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 0);
+                break;
+            case "hexflat_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 0);
+                break;
+            case "hexflat_SS":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 0);
                 break;
             case "ox_B":
                 ctx.setLineDash([]);

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -1260,9 +1260,53 @@ class Puzzle_truncated_square extends Puzzle {
                 set_circle_style(ctx, num);
                 this.draw_polygon(ctx, x, y, 0.35, 4, 0);
                 break;
+            case "diamond_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.22, 4, 0);
+                break;
             case "diamond_SS":
                 set_circle_style(ctx, num);
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
+                break;
+            case "hexpoint_LL":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 30);
+                break;
+            case "hexpoint_L":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 30);
+                break;
+            case "hexpoint_M":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 30);
+                break;
+            case "hexpoint_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 30);
+                break;
+            case "hexpoint_SS":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 30);
+                break;
+            case "hexflat_LL":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 0);
+                break;
+            case "hexflat_L":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 0);
+                break;
+            case "hexflat_M":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 0);
+                break;
+            case "hexflat_S":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 0);
+                break;
+            case "hexflat_SS":
+                set_circle_style(ctx, num);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 0);
                 break;
             case "ox_B":
                 ctx.setLineDash([]);

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -1884,47 +1884,6 @@ function load(urlParam, type = 'url', origurl = null) {
         pu.user_tags = JSON.parse(rtext[17]);
     }
 
-    // Detect tag using title information if author did not define tags
-    // This is to add tags for the previously created URLs
-    if (pu.user_tags.length === 0) {
-        let wordsRegex = /([^\x00-\x7F]|\w)+/g;
-        let title = document.getElementById("saveinfotitle").value;
-        let title_words = title.match(wordsRegex);
-        let allow_genres = ["arrow", "thermo", "even", "consecutive", "killer", "nonconsecutive"];
-
-        // find position of "sudoku"
-        if (title_words) {
-            let sudoku_index = title_words.findIndex(element => {
-                return element.toLowerCase() === "sudoku";
-            });
-
-            if (sudoku_index === 0) {
-                pu.user_tags[0] = "classic";
-            } else if ((sudoku_index === 1 || sudoku_index === 2) &&
-                (allow_genres.includes(title_words[0].toLowerCase()))) {
-                switch (title_words[0].toLowerCase()) {
-                    case "consecutive":
-                        if (title_words[1].toLowerCase() == "pairs") {
-                            pu.user_tags[0] = "consecutivepairs";
-                        } else {
-                            pu.user_tags[0] = "consecutive";
-                        }
-                        break;
-                    case "nonconsecutive":
-                        pu.user_tags[0] = "nonconsecutive";
-                        break;
-                    default:
-                        pu.user_tags[0] = "classic";
-                        break;
-                }
-            } else if (title_words[0].toLowerCase() === "star" && title_words[1].toLowerCase() === "battle") {
-                pu.user_tags[0] = "starbattle";
-            } else if (title_words[0].toLowerCase() === "tomtom") {
-                pu.user_tags[0] = "tomtom";
-            }
-        }
-    }
-
     add_genre_tags(pu.user_tags);
     $('#genre_tags_opt').select2({
         placeholder: 'Search Area',

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -26,10 +26,10 @@ const penpa_modes = {
         'ms': ['cross', 'line', 'frameline', 'tri', 'inequality', 'degital_f', 'dice', 'pills',
             'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip',
             'battleship_B', 'battleship_G', 'battleship_W', 'battleship_B+', 'battleship_G+', 'battleship_W+',
-            'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
+            'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino', 'polyhex',
             'angleloop', 'firefly', 'sun_moon', 'pencils', 'slovak', 'arc', 'darts', 'spans', 'neighbors'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'bars', 'degital'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'bars', 'degital'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_fouredge', 'arrow_GP'],
         'ms4': ['battleship'],
         // styles
@@ -44,7 +44,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -86,7 +86,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon', 'pencils', 'slovak', 'arc', 'darts', 'spans', 'neighbors'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'bars', 'degital'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'bars', 'degital'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_fouredge', 'arrow_GP'],
         'ms4': ['battleship'],
         // styles
@@ -101,7 +101,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -143,7 +143,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon', 'pencils', 'slovak', 'arc', 'darts', 'spans', 'neighbors'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'bars', 'degital'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'bars', 'degital'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_fouredge', 'arrow_GP'],
         'ms4': ['battleship'],
         // styles
@@ -158,7 +158,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -197,10 +197,10 @@ const penpa_modes = {
         'ms': ['cross', 'line', 'frameline', 'inequality', 'degital_f', 'dice', 'pills',
             'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight',
             'battleship_B', 'battleship_G', 'battleship_W',
-            'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'polyomino',
+            'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'polyomino', 'polyhex',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox', 'degital'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox', 'degital'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': ['battleship'],
         // styles
@@ -215,7 +215,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -250,10 +250,10 @@ const penpa_modes = {
         // shapes
         'ms': ['cross', 'line', 'frameline', 'inequality', 'degital_f', 'dice', 'pills',
             'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight',
-            'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
+            'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'polyomino',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox', 'degital'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox', 'degital'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': [],
         // styles
@@ -268,7 +268,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -307,7 +307,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox', 'degital'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox', 'degital'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': ['battleship'],
         // styles
@@ -322,7 +322,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -360,7 +360,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox', 'degital'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox', 'degital'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': [],
         // styles
@@ -375,7 +375,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -413,7 +413,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': [],
         // styles
@@ -428,7 +428,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -466,7 +466,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': [],
         // styles
@@ -481,7 +481,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -519,7 +519,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': [],
         // styles
@@ -534,7 +534,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],
@@ -572,7 +572,7 @@ const penpa_modes = {
             'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'angleloop', 'firefly', 'sun_moon'
         ],
-        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'ox'],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox'],
         'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
         'ms4': [],
         // styles
@@ -587,7 +587,7 @@ const penpa_modes = {
         ],
         'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
             'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
-            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
             'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
             'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
         ],


### PR DESCRIPTION
Added Hexagon Point and Hexagon Flat to Shape/Shape on all boards.
Added Polyhex to Shape/Special 1 for the Square and Hexagon boards.
Added diamond_S drawing logic where it had been missing on several boards.
Removed sudokumore (Shape/Special 1/ArrowSums) from Triangle board, where drawing was not implemented and doesn't make sense given the board shape.