### PR TITLE
Fix arc rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## History
-* 2022/05/11
+* 2022/11/05
 	* Make the answer check table only show one column at a time
 	* Conflict highlighting on hex grid for latin square
 * 2022/08/19 ver 3.0.3

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -4254,8 +4254,7 @@ class Puzzle_square extends Puzzle {
     }
 
     draw_arc(ctx, num, x, y, ccolor = "none") {
-        var r = 0.2,
-            th;
+        var th1, th2, th2a;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
         if (ccolor !== "none") {
@@ -4273,17 +4272,20 @@ class Puzzle_square extends Puzzle {
             case 3:
             case 4:
                 ctx.beginPath();
-                th = this.rotate_theta(90 * (num - 1));
-                ctx.moveTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th + Math.PI * 0.25)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th + Math.PI * 0.25)));
-                ctx.arcTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th - Math.PI * 0.25)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th - Math.PI * 0.25)), (x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th - Math.PI * 0.75)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th - Math.PI * 0.75)), pu.size);
+                th1 = this.rotate_theta(45 + 90 * (num - 1));
+                th2 = this.rotate_theta(225 + 90 * (num - 1));
+                th2a = this.rotate_theta(315 + 90 * (num - 1));
+                ctx.moveTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th1)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th1)));
+                ctx.arcTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th2a)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th2a)), (x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th2)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th2)), pu.size);
                 ctx.stroke();
                 break;
             case 5:
             case 6:
                 ctx.beginPath();
-                th = this.rotate_theta(90 * (num - 5));
-                ctx.moveTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th + Math.PI * 0.25)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th + Math.PI * 0.25)));
-                ctx.lineTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th - Math.PI * 0.75)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th - Math.PI * 0.75)));
+                th1 = this.rotate_theta(45 + 90 * (num - 5));
+                th2 = this.rotate_theta(225 + 90 * (num - 5));
+                ctx.moveTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th1)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th1)));
+                ctx.lineTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th2)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th2)));
                 ctx.stroke();
         }
     }


### PR DESCRIPTION
arc does not render correctly when the board is flipped.
All relative angle calculations should go though rotate_theta()

Consideration: This arc fix *might* break existing puzzles which rely on this drawing bug.