### PR TITLE
Fix line drawing anomaly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## History
-* 2022/05/11
+* 2022/11/05
 	* Make the answer check table only show one column at a time
 	* Conflict highlighting on hex grid for latin square
 * 2022/08/19 ver 3.0.3

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -1245,6 +1245,7 @@ class Puzzle_square extends Puzzle {
                 }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
+                if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
                 this.ctx.beginPath();
                 if (this[pu].line[i] === 40) {
                     var r = 0.8;
@@ -1306,6 +1307,7 @@ class Puzzle_square extends Puzzle {
                 }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
+                if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
                 this.ctx.beginPath();
                 if (this[pu].lineE[i] === 30) {
                     var r = 0.15 * this.size;
@@ -1335,6 +1337,7 @@ class Puzzle_square extends Puzzle {
             }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
+            if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
             this.ctx.beginPath();
             if (this[pu].freeline[i] === 30) {
                 var r = 0.15 * this.size;
@@ -1359,6 +1362,7 @@ class Puzzle_square extends Puzzle {
             }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
+            if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
             this.ctx.beginPath();
             if (this[pu].freelineE[i] === 30) {
                 var r = 0.15 * this.size;

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -1245,7 +1245,7 @@ class Puzzle_square extends Puzzle {
                 }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
-                if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
+                if (this.point[i1].use === -1 || this.point[i2].use === -1 || [0, 2, 3].indexOf(this.point[i1].type) === -1 || [0, 2, 3].indexOf(this.point[i2].type) === -1) { continue; }
                 this.ctx.beginPath();
                 if (this[pu].line[i] === 40) {
                     var r = 0.8;
@@ -1307,7 +1307,7 @@ class Puzzle_square extends Puzzle {
                 }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
-                if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
+                if (this.point[i1].use === -1 || this.point[i2].use === -1 || [1].indexOf(this.point[i1].type) === -1 || [1].indexOf(this.point[i2].type) === -1) { continue; }
                 this.ctx.beginPath();
                 if (this[pu].lineE[i] === 30) {
                     var r = 0.15 * this.size;
@@ -1337,7 +1337,7 @@ class Puzzle_square extends Puzzle {
             }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
-            if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
+            if (this.point[i1].use === -1 || this.point[i2].use === -1 || [0].indexOf(this.point[i1].type) === -1 || [0].indexOf(this.point[i2].type) === -1) { continue; }
             this.ctx.beginPath();
             if (this[pu].freeline[i] === 30) {
                 var r = 0.15 * this.size;
@@ -1362,7 +1362,7 @@ class Puzzle_square extends Puzzle {
             }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
-            if (this.point[i1].use === -1 || this.point[i2].use === -1) { continue; }
+            if (this.point[i1].use === -1 || this.point[i2].use === -1 || [1].indexOf(this.point[i1].type) === -1 || [1].indexOf(this.point[i2].type) === -1) { continue; }
             this.ctx.beginPath();
             if (this[pu].freelineE[i] === 30) {
                 var r = 0.15 * this.size;
@@ -1391,6 +1391,7 @@ class Puzzle_square extends Puzzle {
             this.ctx.lineCap = "butt";
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
+            if (this.point[i1].use === -1 || this.point[i2].use === -1 || [2, 3].indexOf(this.point[i1].type) === -1 || this.point[i1].type !== this.point[i2].type) { continue; }
             this.ctx.beginPath();
             this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
             this.ctx.lineTo(this.point[i2].x, this.point[i2].y);


### PR DESCRIPTION
Lines which where on the edge of the canvas are not drawn correctly when rows/columns are removed.
This patch suppresses lines where one end is outside the canvas, or when the line point does not make sense, but the effect can still occure.
Fixing the rootcause needs some redesign in handling board resizeing. This is probably not worth the effort.
