### PR TITLE
Add arrow_cross corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## History
-* 2022/05/11
+* 2022/11/05
 	* Make the answer check table only show one column at a time
 	* Conflict highlighting on hex grid for latin square
 * 2022/08/19 ver 3.0.3

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -25,7 +25,7 @@ class Puzzle_square extends Puzzle {
         this.size = size;
         this.onoff_symbolmode_list = {
             "cross": 4,
-            "arrow_cross": 4,
+            "arrow_cross": 8,
             "arrow_fourtip": 4,
             "degital_B": 7,
             "degital_G": 7,
@@ -3281,6 +3281,7 @@ class Puzzle_square extends Puzzle {
         var w2 = 0.12;
         var len1 = 0.5 * w1; //nemoto
         var len2 = 0.45; //tip
+        var len3 = 0.55; //tip 45 deg
         var ri = -0.18;
         var th;
         for (var i = 0; i < 4; i++) {
@@ -3288,6 +3289,15 @@ class Puzzle_square extends Puzzle {
                 th = this.rotate_theta(i * 90 - 180);
                 ctx.beginPath();
                 ctx.arrow(x - len1 * pu.size * Math.cos(th), y - len1 * pu.size * Math.sin(th), x + len2 * pu.size * Math.cos(th), y + len2 * pu.size * Math.sin(th),
+                    [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
+                ctx.fill();
+            }
+        }
+        for (var i = 4; i < 8; i++) {
+            if (num[i] === 1) {
+                th = this.rotate_theta(i * 90 - 135);
+                ctx.beginPath();
+                ctx.arrow(x - len1 * pu.size * Math.cos(th), y - len1 * pu.size * Math.sin(th), x + len3 * pu.size * Math.cos(th), y + len3 * pu.size * Math.sin(th),
                     [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
                 ctx.fill();
             }
@@ -4426,7 +4436,7 @@ class Puzzle_sudoku extends Puzzle_square {
         this.size = size;
         this.onoff_symbolmode_list = {
             "cross": 4,
-            "arrow_cross": 4,
+            "arrow_cross": 8,
             "arrow_fourtip": 4,
             "degital_B": 7,
             "degital_G": 7,
@@ -4513,7 +4523,7 @@ class Puzzle_kakuro extends Puzzle_square {
         this.size = size;
         this.onoff_symbolmode_list = {
             "cross": 4,
-            "arrow_cross": 4,
+            "arrow_cross": 8,
             "arrow_fourtip": 4,
             "degital_B": 7,
             "degital_G": 7,


### PR DESCRIPTION
This PR will add 45 degree arrows to arrow_cross.
grkles on Discord requested this and it actually makes a lot of sense because Triangle grids also have 6-way arrow_cross arrows.
https://discord.com/channels/709370620642852885/741047558331433017/1072874612716753146

Potentionally this could also be added to 'truncated square' grids, but that is very niche.