### PR TITLE
Make custom color setting a UserSetting and convert direct DOM querie…

### DIFF
--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -751,7 +751,7 @@ class Puzzle_hex extends Puzzle {
     draw_surface(pu) {
         for (var i in this[pu].surface) {
             set_surface_style(this.ctx, this[pu].surface[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].surface[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].surface[i]) {
                 this.ctx.fillStyle = this[pu + "_col"].surface[i];
                 this.ctx.strokeStyle = this.ctx.fillStyle;
             }
@@ -784,7 +784,7 @@ class Puzzle_hex extends Puzzle {
             if (this[pu].squareframe[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].squareframe[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].squareframe[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].squareframe[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -804,7 +804,7 @@ class Puzzle_hex extends Puzzle {
         for (var i = 0; i < this[pu].thermo.length; i++) {
             if (this[pu].thermo[i][0]) {
                 this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].thermo[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
                     this.ctx.fillStyle = this[pu + "_col"].thermo[i];
                 } else {
                     this.ctx.fillStyle = Color.GREY_LIGHT;
@@ -812,7 +812,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_circle(this.ctx, this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y, 0.4);
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].thermo[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].thermo[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -833,14 +833,14 @@ class Puzzle_hex extends Puzzle {
             for (var i = 0; i < this[pu].nobulbthermo.length; i++) {
                 if (this[pu].nobulbthermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.fillStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.fillStyle = Color.GREY_LIGHT;
                     }
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -862,7 +862,7 @@ class Puzzle_hex extends Puzzle {
             if (this[pu].arrows[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].arrows[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -884,7 +884,7 @@ class Puzzle_hex extends Puzzle {
                 this.ctx.stroke();
                 this.ctx.setLineDash([]);
                 this.ctx.lineJoin = "miter";
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].arrows[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -902,7 +902,7 @@ class Puzzle_hex extends Puzzle {
             if (this[pu].direction[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].direction[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].direction[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].direction[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -934,7 +934,7 @@ class Puzzle_hex extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 this.ctx.beginPath();
@@ -947,7 +947,7 @@ class Puzzle_hex extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 var i1 = i.split(",")[0];
@@ -995,7 +995,7 @@ class Puzzle_hex extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 this.ctx.beginPath();
@@ -1008,7 +1008,7 @@ class Puzzle_hex extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 var i1 = i.split(",")[0];
@@ -1037,7 +1037,7 @@ class Puzzle_hex extends Puzzle {
         /*freeline*/
         for (var i in this[pu].freeline) {
             set_line_style(this.ctx, this[pu].freeline[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].freeline[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freeline[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
             }
             var i1 = i.split(",")[0];
@@ -1061,7 +1061,7 @@ class Puzzle_hex extends Puzzle {
         }
         for (var i in this[pu].freelineE) {
             set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].freelineE[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freelineE[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
             }
             var i1 = i.split(",")[0];
@@ -1088,7 +1088,7 @@ class Puzzle_hex extends Puzzle {
     draw_wall(pu) {
         for (var i in this[pu].wall) {
             set_line_style(this.ctx, this[pu].wall[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].wall[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].wall[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].wall[i];
             }
             this.ctx.lineCap = "butt";
@@ -1211,7 +1211,7 @@ class Puzzle_hex extends Puzzle {
             }
 
             set_line_style(this.ctx, this[pu].cage[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].cage[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].cage[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].cage[i];
             }
 
@@ -1480,7 +1480,7 @@ class Puzzle_hex extends Puzzle {
 
     draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
         var ccolor = "none";
-        if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+        if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
             this[qamode + "_col"].symbol[i]) {
             ccolor = this[qamode + "_col"].symbol[i];
         }
@@ -1638,7 +1638,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -1670,7 +1670,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {

--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -751,7 +751,7 @@ class Puzzle_hex extends Puzzle {
     draw_surface(pu) {
         for (var i in this[pu].surface) {
             set_surface_style(this.ctx, this[pu].surface[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].surface[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].surface[i]) {
                 this.ctx.fillStyle = this[pu + "_col"].surface[i];
                 this.ctx.strokeStyle = this.ctx.fillStyle;
             }
@@ -784,7 +784,7 @@ class Puzzle_hex extends Puzzle {
             if (this[pu].squareframe[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].squareframe[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].squareframe[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].squareframe[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -804,7 +804,7 @@ class Puzzle_hex extends Puzzle {
         for (var i = 0; i < this[pu].thermo.length; i++) {
             if (this[pu].thermo[i][0]) {
                 this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
                     this.ctx.fillStyle = this[pu + "_col"].thermo[i];
                 } else {
                     this.ctx.fillStyle = Color.GREY_LIGHT;
@@ -812,7 +812,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_circle(this.ctx, this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y, 0.4);
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].thermo[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -833,14 +833,14 @@ class Puzzle_hex extends Puzzle {
             for (var i = 0; i < this[pu].nobulbthermo.length; i++) {
                 if (this[pu].nobulbthermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.fillStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.fillStyle = Color.GREY_LIGHT;
                     }
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -862,7 +862,7 @@ class Puzzle_hex extends Puzzle {
             if (this[pu].arrows[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -884,7 +884,7 @@ class Puzzle_hex extends Puzzle {
                 this.ctx.stroke();
                 this.ctx.setLineDash([]);
                 this.ctx.lineJoin = "miter";
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -902,7 +902,7 @@ class Puzzle_hex extends Puzzle {
             if (this[pu].direction[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].direction[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].direction[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].direction[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -934,7 +934,7 @@ class Puzzle_hex extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 this.ctx.beginPath();
@@ -947,7 +947,7 @@ class Puzzle_hex extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 var i1 = i.split(",")[0];
@@ -995,7 +995,7 @@ class Puzzle_hex extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 this.ctx.beginPath();
@@ -1008,7 +1008,7 @@ class Puzzle_hex extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 var i1 = i.split(",")[0];
@@ -1037,7 +1037,7 @@ class Puzzle_hex extends Puzzle {
         /*freeline*/
         for (var i in this[pu].freeline) {
             set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freeline[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
             }
             var i1 = i.split(",")[0];
@@ -1061,7 +1061,7 @@ class Puzzle_hex extends Puzzle {
         }
         for (var i in this[pu].freelineE) {
             set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freelineE[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
             }
             var i1 = i.split(",")[0];
@@ -1088,7 +1088,7 @@ class Puzzle_hex extends Puzzle {
     draw_wall(pu) {
         for (var i in this[pu].wall) {
             set_line_style(this.ctx, this[pu].wall[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].wall[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].wall[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].wall[i];
             }
             this.ctx.lineCap = "butt";
@@ -1211,7 +1211,7 @@ class Puzzle_hex extends Puzzle {
             }
 
             set_line_style(this.ctx, this[pu].cage[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].cage[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].cage[i];
             }
 
@@ -1480,7 +1480,7 @@ class Puzzle_hex extends Puzzle {
 
     draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
         var ccolor = "none";
-        if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+        if (i !== 'panel' && UserSettings.custom_colors_on &&
             this[qamode + "_col"].symbol[i]) {
             ccolor = this[qamode + "_col"].symbol[i];
         }
@@ -1638,7 +1638,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -1670,7 +1670,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -2285,7 +2285,7 @@ class Puzzle {
         } else if (this.mode[this.mode.qa].edit_mode === "combi") {
             this.subcombimode(this.mode[this.mode.qa].combi[0]);
         }
-        if ((document.getElementById("custom_color_opt").value === "2") && ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex")) &&
+        if ((UserSettings.custom_colors_on === 2) && ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex")) &&
             (mode === "line" || mode === "lineE" || mode === "wall" || mode === "surface" || mode === "cage" || mode === "special" || mode === "symbol")) {
             document.getElementById('style_special').style.display = 'inline';
         } else {
@@ -2309,7 +2309,7 @@ class Puzzle {
             this.redraw(); // Board cursor update
         }
         this.type = this.type_set(); // Coordinate type to select
-        if (document.getElementById("custom_color_opt").value === "2") {
+        if (UserSettings.custom_colors_on === 2) {
             // set the custom color to default
             switch (name) {
                 case "sub_specialthermo":
@@ -2346,7 +2346,7 @@ class Puzzle {
             panel_pu.draw_panel(); // Panel update
         }
 
-        if (document.getElementById("custom_color_opt").value === "2") {
+        if (UserSettings.custom_colors_on === 2) {
             // set the custom color to default
             switch (name) {
                 case "st_surface1":
@@ -2491,7 +2491,7 @@ class Puzzle {
     subsymbolmode(mode) {
         this.mode[this.mode.qa].symbol[0] = mode;
         document.getElementById("symmode_content").innerHTML = mode;
-        if (document.getElementById("custom_color_opt").value === "2") {
+        if (UserSettings.custom_colors_on === 2) {
             // set the custom color to default
             switch ("ms_" + mode) {
                 case "ms_circle_L":
@@ -2561,7 +2561,7 @@ class Puzzle {
     subcombimode(mode) {
         this.mode[this.mode.qa].combi[0] = mode;
         document.getElementById("combimode_content").innerHTML = mode;
-        if (document.getElementById("custom_color_opt").value === "2") {
+        if (UserSettings.custom_colors_on === 2) {
             // set the custom color to default
             switch (mode) {
                 case "linex":
@@ -2626,7 +2626,7 @@ class Puzzle {
         switch (this.mode[this.mode.qa].edit_mode) {
             case "surface":
                 this[this.mode.qa].surface = {};
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"].surface = {};
                 }
                 break;
@@ -2635,20 +2635,20 @@ class Puzzle {
                     for (var i in this[this.mode.qa].line) {
                         if (this[this.mode.qa].line[i] !== 98) {
                             delete this[this.mode.qa].line[i];
-                            if (document.getElementById("custom_color_opt").value === "2") {
+                            if (UserSettings.custom_colors_on === 2) {
                                 delete this[this.mode.qa + "_col"].line[i];
                             }
                         }
                     }
                     this[this.mode.qa].freeline = {};
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this[this.mode.qa + "_col"].freeline = {};
                     }
                 } else {
                     for (var i in this[this.mode.qa].line) {
                         if (this[this.mode.qa].line[i] === 98) {
                             delete this[this.mode.qa].line[i];
-                            if (document.getElementById("custom_color_opt").value === "2") {
+                            if (UserSettings.custom_colors_on === 2) {
                                 delete this[this.mode.qa + "_col"].line[i];
                             }
                         }
@@ -2660,34 +2660,34 @@ class Puzzle {
                     for (var i in this[this.mode.qa].lineE) {
                         if (this[this.mode.qa].lineE[i] === 98) {
                             delete this[this.mode.qa].lineE[i];
-                            if (document.getElementById("custom_color_opt").value === "2") {
+                            if (UserSettings.custom_colors_on === 2) {
                                 delete this[this.mode.qa + "_col"].lineE[i];
                             }
                         }
                     }
                 } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
                     this[this.mode.qa].deletelineE = {};
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this[this.mode.qa + "_col"].deletelineE = {};
                     }
                 } else {
                     for (var i in this[this.mode.qa].lineE) {
                         if (this[this.mode.qa].lineE[i] !== 98) {
                             delete this[this.mode.qa].lineE[i];
-                            if (document.getElementById("custom_color_opt").value === "2") {
+                            if (UserSettings.custom_colors_on === 2) {
                                 delete this[this.mode.qa + "_col"].lineE[i];
                             }
                         }
                     }
                     this[this.mode.qa].freelineE = {};
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this[this.mode.qa + "_col"].freelineE = {};
                     }
                 }
                 break;
             case "wall":
                 this[this.mode.qa].wall = {};
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"].wall = {};
                 }
                 break;
@@ -2701,7 +2701,7 @@ class Puzzle {
                 break;
             case "symbol":
                 this[this.mode.qa].symbol = {};
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"].symbol = {};
                 }
                 break;
@@ -2723,13 +2723,13 @@ class Puzzle {
                 break;
             case "cage":
                 this[this.mode.qa].cage = {};
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"].cage = {};
                 }
                 break;
             case "special":
                 this[this.mode.qa][this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]] = [];
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"][this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]] = [];
                 }
                 break;
@@ -2800,7 +2800,7 @@ class Puzzle {
         text += JSON.stringify("x") + "\n";
 
         // Custom Colors
-        text += (document.getElementById("custom_color_opt").value === "2") ? "1\n" : "0\n";
+        text += (UserSettings.custom_colors_on === 2) ? "1\n" : "0\n";
 
         return text;
     }
@@ -7598,7 +7598,7 @@ class Puzzle {
                     number = parseInt(key, 10);
                 }
                 this[this.mode.qa].symbol[this.cursol] = [number, this.mode[this.mode.qa].symbol[0], this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1]];
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"].symbol[this.cursol] = this.get_customcolor();
                 }
                 this.record_replay("symbol", this.cursol);
@@ -8019,7 +8019,7 @@ class Puzzle {
         } else if (this.mode[this.mode.qa].edit_mode === "symbol") {
             this.record("symbol", this.cursol);
             delete this[this.mode.qa].symbol[this.cursol];
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 delete this[this.mode.qa + "_col"].symbol[this.cursol];
             }
             this.record_replay("symbol", this.cursol);
@@ -8327,19 +8327,19 @@ class Puzzle {
         let rightclick_color = UserSettings.secondcolor;
         if (this[this.mode.qa].surface[num] && this[this.mode.qa].surface[num] === color && allowed_styles.includes(color)) {
             this[this.mode.qa].surface[num] = rightclick_color;
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(rightclick_color);
             }
             this.drawing_mode = rightclick_color;
         } else if (this[this.mode.qa].surface[num] && (this[this.mode.qa].surface[num] === color || (this[this.mode.qa].surface[num] === rightclick_color && allowed_styles.includes(color)))) {
             delete this[this.mode.qa].surface[num];
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 delete this[this.mode.qa + "_col"].surface[num];
             }
             this.drawing_mode = 0;
         } else {
             this[this.mode.qa].surface[num] = color;
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_customcolor();
             }
             this.drawing_mode = color;
@@ -8353,13 +8353,13 @@ class Puzzle {
         this.record("surface", num);
         if (this[this.mode.qa].surface[num] && (this[this.mode.qa].surface[num] === color)) {
             delete this[this.mode.qa].surface[num];
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 delete this[this.mode.qa + "_col"].surface[num];
             }
             this.drawing_mode = 0;
         } else {
             this[this.mode.qa].surface[num] = color;
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_customcolor();
             }
             this.drawing_mode = color;
@@ -8373,13 +8373,13 @@ class Puzzle {
         let rightclick_color = UserSettings.secondcolor;
         if (this[this.mode.qa].surface[num] && this[this.mode.qa].surface[num] === rightclick_color) {
             delete this[this.mode.qa].surface[num];
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 delete this[this.mode.qa + "_col"].surface[num];
             }
             this.drawing_mode = 0;
         } else {
             this[this.mode.qa].surface[num] = rightclick_color;
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(rightclick_color);
             }
             this.drawing_mode = rightclick_color;
@@ -8394,7 +8394,7 @@ class Puzzle {
                 if (this[this.mode.qa].surface[num]) {
                     this.record("surface", num);
                     delete this[this.mode.qa].surface[num];
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         delete this[this.mode.qa + "_col"].surface[num];
                     }
                     this.record_replay("surface", num);
@@ -8404,7 +8404,7 @@ class Puzzle {
                 if (!this[this.mode.qa].surface[num] || this[this.mode.qa].surface[num] != this.drawing_mode) {
                     this.record("surface", num);
                     this[this.mode.qa].surface[num] = this.drawing_mode;
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         // If left click second time (i.e. DG option) and moving or right click and moving
                         if (this.drawing_mode === 2 || this.mouse_click === 2) {
                             this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(this.drawing_mode);
@@ -8496,12 +8496,12 @@ class Puzzle {
                 }
                 if (array === "deletelineE") {
                     delete this["pu_q"][array][num];
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         delete this["pu_q_col"][array][num];
                     }
                 } else {
                     delete this[this.mode.qa][array][num];
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         delete this[this.mode.qa + "_col"][array][num];
                     }
                 }
@@ -8517,12 +8517,12 @@ class Puzzle {
                 this.record(array, num);
                 if (array === "deletelineE") {
                     delete this["pu_q"][array][num];
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         delete this["pu_q_col"][array][num];
                     }
                 } else {
                     delete this[this.mode.qa][array][num];
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         delete this[this.mode.qa + "_col"][array][num];
                     }
                 }
@@ -8537,12 +8537,12 @@ class Puzzle {
                 }
                 if (array === "deletelineE") {
                     this["pu_q"][array][num] = line_style;
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this["pu_q_col"][array][num] = this.get_customcolor();
                     }
                 } else {
                     this[this.mode.qa][array][num] = line_style;
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this[this.mode.qa + "_col"][array][num] = this.get_customcolor();
                     }
                 }
@@ -8558,12 +8558,12 @@ class Puzzle {
                 this.record(array, num);
                 if (array === "deletelineE") {
                     this["pu_q"][array][num] = line_style;
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this["pu_q_col"][array][num] = this.get_customcolor();
                     }
                 } else {
                     this[this.mode.qa][array][num] = line_style;
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this[this.mode.qa + "_col"][array][num] = this.get_customcolor();
                     }
                 }
@@ -8633,12 +8633,12 @@ class Puzzle {
             this.record("freeline", key);
             if (this[this.mode.qa].freeline[key]) {
                 delete this[this.mode.qa].freeline[key];
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     delete this[this.mode.qa + "_col"].freeline[key];
                 }
             } else {
                 this[this.mode.qa].freeline[key] = this.drawing_mode;
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"].freeline[key] = this.get_customcolor();
                 }
             }
@@ -8656,14 +8656,14 @@ class Puzzle {
         if (this[this.mode.qa].line[num] && this[this.mode.qa].line[num] === 98) { // Cross mark (x)
             this.record("line", num);
             delete this[this.mode.qa].line[num];
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 delete this[this.mode.qa + "_col"].line[num];
             }
             this.record_replay("line", num);
         } else {
             this.record("line", num);
             this[this.mode.qa].line[num] = 98;
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"].line[num] = this.get_customcolor();
             }
             this.record_replay("line", num);
@@ -8757,12 +8757,12 @@ class Puzzle {
             this.record("freelineE", key);
             if (this[this.mode.qa].freelineE[key]) {
                 delete this[this.mode.qa].freelineE[key];
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     delete this[this.mode.qa + "_col"].freelineE[key];
                 }
             } else {
                 this[this.mode.qa].freelineE[key] = this.drawing_mode;
-                if (document.getElementById("custom_color_opt").value === "2") {
+                if (UserSettings.custom_colors_on === 2) {
                     this[this.mode.qa + "_col"].freelineE[key] = this.get_customcolor();
                 }
             }
@@ -8780,14 +8780,14 @@ class Puzzle {
         if (this[this.mode.qa].lineE[num] && this[this.mode.qa].lineE[num] === 98) { //×印
             this.record("lineE", num);
             delete this[this.mode.qa].lineE[num];
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 delete this[this.mode.qa + "_col"].lineE[num];
             }
             this.record_replay("lineE", num);
         } else {
             this.record("lineE", num);
             this[this.mode.qa].lineE[num] = 98;
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"].lineE[num] = this.get_customcolor();
             }
             this.record_replay("lineE", num);
@@ -9442,7 +9442,7 @@ class Puzzle {
                             // Save the current killercage and then delete
                             this.record(arraykill, cageexist_loc, this.undoredo_counter);
                             this[this.mode.qa][arraykill][cageexist_loc] = [];
-                            if (document.getElementById("custom_color_opt").value === "2") {
+                            if (UserSettings.custom_colors_on === 2) {
                                 this[this.mode.qa + "_col"][arraykill][cageexist_loc] = [];
                             }
                             this.record_replay(arraykill, cageexist_loc, this.undoredo_counter);
@@ -9552,7 +9552,7 @@ class Puzzle {
             this.last = num;
         }
         if (this[this.mode.qa][arr].slice(-1)[0] && this[this.mode.qa][arr].slice(-1)[0].length > 1) {
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1] = this.get_customcolor();
             }
         }
@@ -9564,7 +9564,7 @@ class Puzzle {
             //*********SPECIAL CASE of EMPTY STARTS HERE***************
             // If the mouse was released back on the starting cell, basically no thermo then remove the custom color entry as well.
             // This accounts for the case when user dragged the thermo but came back to starting point.
-            if (document.getElementById("custom_color_opt").value === "2" && this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1]) {
+            if (UserSettings.custom_colors_on === 2 && this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1]) {
                 this[this.mode.qa + "_col"][arr].pop();
             }
             if (this.mode.qa === "pu_q") {
@@ -9580,7 +9580,7 @@ class Puzzle {
                 if (this[this.mode.qa][arr][i] && this[this.mode.qa][arr][i][0] === num) {
                     this.record(arr, i);
                     this[this.mode.qa][arr][i] = [];
-                    if (document.getElementById("custom_color_opt").value === "2") {
+                    if (UserSettings.custom_colors_on === 2) {
                         this[this.mode.qa + "_col"][arr][i] = [];
                     }
                     this.record_replay(arr, i);
@@ -9595,7 +9595,7 @@ class Puzzle {
         this.freelinecircle_g[1] = num;
         if (this.drawing) {
             this[this.mode.qa][arr].slice(-1)[0][this[this.mode.qa][arr].slice(-1)[0].length - 1] = num;
-            if (document.getElementById("custom_color_opt").value === "2") {
+            if (UserSettings.custom_colors_on === 2) {
                 this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1] = this.get_customcolor();
             }
         }
@@ -11748,7 +11748,7 @@ class Puzzle {
             if (this[pu].polygon[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].polygon[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].polygon[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].polygon[i];
                     this.ctx.fillStyle = this[pu + "_col"].polygon[i];
                 } else {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -2285,7 +2285,7 @@ class Puzzle {
         } else if (this.mode[this.mode.qa].edit_mode === "combi") {
             this.subcombimode(this.mode[this.mode.qa].combi[0]);
         }
-        if ((UserSettings.custom_colors_on === 2) && ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex")) &&
+        if ((UserSettings.custom_colors_on) && ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex")) &&
             (mode === "line" || mode === "lineE" || mode === "wall" || mode === "surface" || mode === "cage" || mode === "special" || mode === "symbol")) {
             document.getElementById('style_special').style.display = 'inline';
         } else {
@@ -2309,7 +2309,7 @@ class Puzzle {
             this.redraw(); // Board cursor update
         }
         this.type = this.type_set(); // Coordinate type to select
-        if (UserSettings.custom_colors_on === 2) {
+        if (UserSettings.custom_colors_on) {
             // set the custom color to default
             switch (name) {
                 case "sub_specialthermo":
@@ -2346,7 +2346,7 @@ class Puzzle {
             panel_pu.draw_panel(); // Panel update
         }
 
-        if (UserSettings.custom_colors_on === 2) {
+        if (UserSettings.custom_colors_on) {
             // set the custom color to default
             switch (name) {
                 case "st_surface1":
@@ -2491,7 +2491,7 @@ class Puzzle {
     subsymbolmode(mode) {
         this.mode[this.mode.qa].symbol[0] = mode;
         document.getElementById("symmode_content").innerHTML = mode;
-        if (UserSettings.custom_colors_on === 2) {
+        if (UserSettings.custom_colors_on) {
             // set the custom color to default
             switch ("ms_" + mode) {
                 case "ms_circle_L":
@@ -2561,7 +2561,7 @@ class Puzzle {
     subcombimode(mode) {
         this.mode[this.mode.qa].combi[0] = mode;
         document.getElementById("combimode_content").innerHTML = mode;
-        if (UserSettings.custom_colors_on === 2) {
+        if (UserSettings.custom_colors_on) {
             // set the custom color to default
             switch (mode) {
                 case "linex":
@@ -2626,7 +2626,7 @@ class Puzzle {
         switch (this.mode[this.mode.qa].edit_mode) {
             case "surface":
                 this[this.mode.qa].surface = {};
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].surface = {};
                 }
                 break;
@@ -2635,20 +2635,20 @@ class Puzzle {
                     for (var i in this[this.mode.qa].line) {
                         if (this[this.mode.qa].line[i] !== 98) {
                             delete this[this.mode.qa].line[i];
-                            if (UserSettings.custom_colors_on === 2) {
+                            if (UserSettings.custom_colors_on) {
                                 delete this[this.mode.qa + "_col"].line[i];
                             }
                         }
                     }
                     this[this.mode.qa].freeline = {};
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this[this.mode.qa + "_col"].freeline = {};
                     }
                 } else {
                     for (var i in this[this.mode.qa].line) {
                         if (this[this.mode.qa].line[i] === 98) {
                             delete this[this.mode.qa].line[i];
-                            if (UserSettings.custom_colors_on === 2) {
+                            if (UserSettings.custom_colors_on) {
                                 delete this[this.mode.qa + "_col"].line[i];
                             }
                         }
@@ -2660,34 +2660,34 @@ class Puzzle {
                     for (var i in this[this.mode.qa].lineE) {
                         if (this[this.mode.qa].lineE[i] === 98) {
                             delete this[this.mode.qa].lineE[i];
-                            if (UserSettings.custom_colors_on === 2) {
+                            if (UserSettings.custom_colors_on) {
                                 delete this[this.mode.qa + "_col"].lineE[i];
                             }
                         }
                     }
                 } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
                     this[this.mode.qa].deletelineE = {};
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this[this.mode.qa + "_col"].deletelineE = {};
                     }
                 } else {
                     for (var i in this[this.mode.qa].lineE) {
                         if (this[this.mode.qa].lineE[i] !== 98) {
                             delete this[this.mode.qa].lineE[i];
-                            if (UserSettings.custom_colors_on === 2) {
+                            if (UserSettings.custom_colors_on) {
                                 delete this[this.mode.qa + "_col"].lineE[i];
                             }
                         }
                     }
                     this[this.mode.qa].freelineE = {};
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this[this.mode.qa + "_col"].freelineE = {};
                     }
                 }
                 break;
             case "wall":
                 this[this.mode.qa].wall = {};
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].wall = {};
                 }
                 break;
@@ -2701,7 +2701,7 @@ class Puzzle {
                 break;
             case "symbol":
                 this[this.mode.qa].symbol = {};
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].symbol = {};
                 }
                 break;
@@ -2723,13 +2723,13 @@ class Puzzle {
                 break;
             case "cage":
                 this[this.mode.qa].cage = {};
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].cage = {};
                 }
                 break;
             case "special":
                 this[this.mode.qa][this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]] = [];
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"][this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]] = [];
                 }
                 break;
@@ -2800,7 +2800,7 @@ class Puzzle {
         text += JSON.stringify("x") + "\n";
 
         // Custom Colors
-        text += (UserSettings.custom_colors_on === 2) ? "1\n" : "0\n";
+        text += (UserSettings.custom_colors_on) ? "1\n" : "0\n";
 
         return text;
     }
@@ -7598,7 +7598,7 @@ class Puzzle {
                     number = parseInt(key, 10);
                 }
                 this[this.mode.qa].symbol[this.cursol] = [number, this.mode[this.mode.qa].symbol[0], this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1]];
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].symbol[this.cursol] = this.get_customcolor();
                 }
                 this.record_replay("symbol", this.cursol);
@@ -8019,7 +8019,7 @@ class Puzzle {
         } else if (this.mode[this.mode.qa].edit_mode === "symbol") {
             this.record("symbol", this.cursol);
             delete this[this.mode.qa].symbol[this.cursol];
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 delete this[this.mode.qa + "_col"].symbol[this.cursol];
             }
             this.record_replay("symbol", this.cursol);
@@ -8327,19 +8327,19 @@ class Puzzle {
         let rightclick_color = UserSettings.secondcolor;
         if (this[this.mode.qa].surface[num] && this[this.mode.qa].surface[num] === color && allowed_styles.includes(color)) {
             this[this.mode.qa].surface[num] = rightclick_color;
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(rightclick_color);
             }
             this.drawing_mode = rightclick_color;
         } else if (this[this.mode.qa].surface[num] && (this[this.mode.qa].surface[num] === color || (this[this.mode.qa].surface[num] === rightclick_color && allowed_styles.includes(color)))) {
             delete this[this.mode.qa].surface[num];
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 delete this[this.mode.qa + "_col"].surface[num];
             }
             this.drawing_mode = 0;
         } else {
             this[this.mode.qa].surface[num] = color;
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_customcolor();
             }
             this.drawing_mode = color;
@@ -8353,13 +8353,13 @@ class Puzzle {
         this.record("surface", num);
         if (this[this.mode.qa].surface[num] && (this[this.mode.qa].surface[num] === color)) {
             delete this[this.mode.qa].surface[num];
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 delete this[this.mode.qa + "_col"].surface[num];
             }
             this.drawing_mode = 0;
         } else {
             this[this.mode.qa].surface[num] = color;
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_customcolor();
             }
             this.drawing_mode = color;
@@ -8373,13 +8373,13 @@ class Puzzle {
         let rightclick_color = UserSettings.secondcolor;
         if (this[this.mode.qa].surface[num] && this[this.mode.qa].surface[num] === rightclick_color) {
             delete this[this.mode.qa].surface[num];
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 delete this[this.mode.qa + "_col"].surface[num];
             }
             this.drawing_mode = 0;
         } else {
             this[this.mode.qa].surface[num] = rightclick_color;
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(rightclick_color);
             }
             this.drawing_mode = rightclick_color;
@@ -8394,7 +8394,7 @@ class Puzzle {
                 if (this[this.mode.qa].surface[num]) {
                     this.record("surface", num);
                     delete this[this.mode.qa].surface[num];
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         delete this[this.mode.qa + "_col"].surface[num];
                     }
                     this.record_replay("surface", num);
@@ -8404,7 +8404,7 @@ class Puzzle {
                 if (!this[this.mode.qa].surface[num] || this[this.mode.qa].surface[num] != this.drawing_mode) {
                     this.record("surface", num);
                     this[this.mode.qa].surface[num] = this.drawing_mode;
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         // If left click second time (i.e. DG option) and moving or right click and moving
                         if (this.drawing_mode === 2 || this.mouse_click === 2) {
                             this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(this.drawing_mode);
@@ -8496,12 +8496,12 @@ class Puzzle {
                 }
                 if (array === "deletelineE") {
                     delete this["pu_q"][array][num];
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         delete this["pu_q_col"][array][num];
                     }
                 } else {
                     delete this[this.mode.qa][array][num];
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         delete this[this.mode.qa + "_col"][array][num];
                     }
                 }
@@ -8517,12 +8517,12 @@ class Puzzle {
                 this.record(array, num);
                 if (array === "deletelineE") {
                     delete this["pu_q"][array][num];
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         delete this["pu_q_col"][array][num];
                     }
                 } else {
                     delete this[this.mode.qa][array][num];
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         delete this[this.mode.qa + "_col"][array][num];
                     }
                 }
@@ -8537,12 +8537,12 @@ class Puzzle {
                 }
                 if (array === "deletelineE") {
                     this["pu_q"][array][num] = line_style;
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this["pu_q_col"][array][num] = this.get_customcolor();
                     }
                 } else {
                     this[this.mode.qa][array][num] = line_style;
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this[this.mode.qa + "_col"][array][num] = this.get_customcolor();
                     }
                 }
@@ -8558,12 +8558,12 @@ class Puzzle {
                 this.record(array, num);
                 if (array === "deletelineE") {
                     this["pu_q"][array][num] = line_style;
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this["pu_q_col"][array][num] = this.get_customcolor();
                     }
                 } else {
                     this[this.mode.qa][array][num] = line_style;
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this[this.mode.qa + "_col"][array][num] = this.get_customcolor();
                     }
                 }
@@ -8633,12 +8633,12 @@ class Puzzle {
             this.record("freeline", key);
             if (this[this.mode.qa].freeline[key]) {
                 delete this[this.mode.qa].freeline[key];
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     delete this[this.mode.qa + "_col"].freeline[key];
                 }
             } else {
                 this[this.mode.qa].freeline[key] = this.drawing_mode;
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].freeline[key] = this.get_customcolor();
                 }
             }
@@ -8656,14 +8656,14 @@ class Puzzle {
         if (this[this.mode.qa].line[num] && this[this.mode.qa].line[num] === 98) { // Cross mark (x)
             this.record("line", num);
             delete this[this.mode.qa].line[num];
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 delete this[this.mode.qa + "_col"].line[num];
             }
             this.record_replay("line", num);
         } else {
             this.record("line", num);
             this[this.mode.qa].line[num] = 98;
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"].line[num] = this.get_customcolor();
             }
             this.record_replay("line", num);
@@ -8757,12 +8757,12 @@ class Puzzle {
             this.record("freelineE", key);
             if (this[this.mode.qa].freelineE[key]) {
                 delete this[this.mode.qa].freelineE[key];
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     delete this[this.mode.qa + "_col"].freelineE[key];
                 }
             } else {
                 this[this.mode.qa].freelineE[key] = this.drawing_mode;
-                if (UserSettings.custom_colors_on === 2) {
+                if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].freelineE[key] = this.get_customcolor();
                 }
             }
@@ -8780,14 +8780,14 @@ class Puzzle {
         if (this[this.mode.qa].lineE[num] && this[this.mode.qa].lineE[num] === 98) { //×印
             this.record("lineE", num);
             delete this[this.mode.qa].lineE[num];
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 delete this[this.mode.qa + "_col"].lineE[num];
             }
             this.record_replay("lineE", num);
         } else {
             this.record("lineE", num);
             this[this.mode.qa].lineE[num] = 98;
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"].lineE[num] = this.get_customcolor();
             }
             this.record_replay("lineE", num);
@@ -9442,7 +9442,7 @@ class Puzzle {
                             // Save the current killercage and then delete
                             this.record(arraykill, cageexist_loc, this.undoredo_counter);
                             this[this.mode.qa][arraykill][cageexist_loc] = [];
-                            if (UserSettings.custom_colors_on === 2) {
+                            if (UserSettings.custom_colors_on) {
                                 this[this.mode.qa + "_col"][arraykill][cageexist_loc] = [];
                             }
                             this.record_replay(arraykill, cageexist_loc, this.undoredo_counter);
@@ -9552,7 +9552,7 @@ class Puzzle {
             this.last = num;
         }
         if (this[this.mode.qa][arr].slice(-1)[0] && this[this.mode.qa][arr].slice(-1)[0].length > 1) {
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1] = this.get_customcolor();
             }
         }
@@ -9564,7 +9564,7 @@ class Puzzle {
             //*********SPECIAL CASE of EMPTY STARTS HERE***************
             // If the mouse was released back on the starting cell, basically no thermo then remove the custom color entry as well.
             // This accounts for the case when user dragged the thermo but came back to starting point.
-            if (UserSettings.custom_colors_on === 2 && this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1]) {
+            if (UserSettings.custom_colors_on && this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1]) {
                 this[this.mode.qa + "_col"][arr].pop();
             }
             if (this.mode.qa === "pu_q") {
@@ -9580,7 +9580,7 @@ class Puzzle {
                 if (this[this.mode.qa][arr][i] && this[this.mode.qa][arr][i][0] === num) {
                     this.record(arr, i);
                     this[this.mode.qa][arr][i] = [];
-                    if (UserSettings.custom_colors_on === 2) {
+                    if (UserSettings.custom_colors_on) {
                         this[this.mode.qa + "_col"][arr][i] = [];
                     }
                     this.record_replay(arr, i);
@@ -9595,7 +9595,7 @@ class Puzzle {
         this.freelinecircle_g[1] = num;
         if (this.drawing) {
             this[this.mode.qa][arr].slice(-1)[0][this[this.mode.qa][arr].slice(-1)[0].length - 1] = num;
-            if (UserSettings.custom_colors_on === 2) {
+            if (UserSettings.custom_colors_on) {
                 this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1] = this.get_customcolor();
             }
         }
@@ -11748,7 +11748,7 @@ class Puzzle {
             if (this[pu].polygon[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].polygon[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].polygon[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].polygon[i];
                     this.ctx.fillStyle = this[pu + "_col"].polygon[i];
                 } else {

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -783,7 +783,7 @@ class Puzzle_square extends Puzzle {
         for (var k = 0; k < keys.length; k++) {
             var i = keys[k];
             set_surface_style(this.ctx, this[pu].surface[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].surface[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].surface[i]) {
                 this.ctx.fillStyle = this[pu + "_col"].surface[i];
                 this.ctx.strokeStyle = this.ctx.fillStyle;
             }
@@ -829,7 +829,7 @@ class Puzzle_square extends Puzzle {
             if (this[pu].squareframe[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].squareframe[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].squareframe[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].squareframe[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -853,7 +853,7 @@ class Puzzle_square extends Puzzle {
             for (var i = 0; i < this[pu].thermo.length; i++) {
                 if (this[pu].thermo[i] && this[pu].thermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
                         this.ctx.fillStyle = this[pu + "_col"].thermo[i];
                     } else {
                         this.ctx.fillStyle = Color.GREY_LIGHT;
@@ -861,7 +861,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(this.ctx, this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y, 0.4);
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].thermo[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -913,14 +913,14 @@ class Puzzle_square extends Puzzle {
             for (var i = 0; i < this[pu].nobulbthermo.length; i++) {
                 if (this[pu].nobulbthermo[i] && this[pu].nobulbthermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.fillStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.fillStyle = Color.GREY_LIGHT;
                     }
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -1030,7 +1030,7 @@ class Puzzle_square extends Puzzle {
                 if (this[pu].arrows[i] && this[pu].arrows[i][0]) {
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -1064,7 +1064,7 @@ class Puzzle_square extends Puzzle {
                         this.ctx.stroke();
                         this.ctx.setLineDash([]);
                         this.ctx.lineJoin = "miter";
-                        if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
+                        if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
                             this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                         } else {
                             this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -1090,7 +1090,7 @@ class Puzzle_square extends Puzzle {
                 if (this[pu].direction[i][0]) {
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].direction[i]) {
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].direction[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].direction[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -1227,7 +1227,7 @@ class Puzzle_square extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 this.ctx.beginPath();
@@ -1240,7 +1240,7 @@ class Puzzle_square extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 var i1 = i.split(",")[0];
@@ -1288,7 +1288,7 @@ class Puzzle_square extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 this.ctx.beginPath();
@@ -1301,7 +1301,7 @@ class Puzzle_square extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
-                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 var i1 = i.split(",")[0];
@@ -1330,7 +1330,7 @@ class Puzzle_square extends Puzzle {
         /*freeline*/
         for (var i in this[pu].freeline) {
             set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freeline[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
             }
             var i1 = i.split(",")[0];
@@ -1354,7 +1354,7 @@ class Puzzle_square extends Puzzle {
         }
         for (var i in this[pu].freelineE) {
             set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freelineE[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
             }
             var i1 = i.split(",")[0];
@@ -1381,7 +1381,7 @@ class Puzzle_square extends Puzzle {
     draw_wall(pu) {
         for (var i in this[pu].wall) {
             set_line_style(this.ctx, this[pu].wall[i]);
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].wall[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].wall[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].wall[i];
             }
             this.ctx.lineCap = "butt";
@@ -1451,7 +1451,7 @@ class Puzzle_square extends Puzzle {
             } else {
                 set_line_style(this.ctx, this[pu].cage[i]);
             }
-            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].cage[i]) {
+            if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].cage[i];
             }
             this.ctx.beginPath();
@@ -1729,7 +1729,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.43);
                     this.draw_circle(ctx, x, y, 0.32);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1744,7 +1744,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.35);
                     this.draw_circle(ctx, x, y, 0.25);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1759,7 +1759,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.22);
                     this.draw_circle(ctx, x, y, 0.14);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1774,7 +1774,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.13);
                     this.draw_circle(ctx, x, y, 0.07);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1784,7 +1784,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "square_LL":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1793,7 +1793,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, 45);
                 break;
             case "square_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1802,7 +1802,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.4 * Math.sqrt(2), 4, 45);
                 break;
             case "square_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1811,7 +1811,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.35 * Math.sqrt(2), 4, 45);
                 break;
             case "square_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1820,7 +1820,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.22 * Math.sqrt(2), 4, 45);
                 break;
             case "square_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1829,7 +1829,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.13 * Math.sqrt(2), 4, 45);
                 break;
             case "triup_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1838,7 +1838,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.5 * 0.25 * this.size, 0.5, 3, 90);
                 break;
             case "triup_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1847,7 +1847,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.4 * 0.25 * this.size, 0.4, 3, 90);
                 break;
             case "triup_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1856,7 +1856,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.25 * 0.25 * this.size, 0.25, 3, 90);
                 break;
             case "triup_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1865,7 +1865,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.16 * 0.25 * this.size, 0.16, 3, 90);
                 break;
             case "tridown_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1874,7 +1874,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.5 * 0.25 * this.size, 0.5, 3, -90);
                 break;
             case "tridown_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1883,7 +1883,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.4 * 0.25 * this.size, 0.4, 3, -90);
                 break;
             case "tridown_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1892,7 +1892,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.25 * 0.25 * this.size, 0.25, 3, -90);
                 break;
             case "tridown_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1901,7 +1901,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.16 * 0.25 * this.size, 0.16, 3, -90);
                 break;
             case "triright_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1910,7 +1910,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.5 * 0.25 * this.size, y, 0.5, 3, 180);
                 break;
             case "triright_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1919,7 +1919,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.4 * 0.25 * this.size, y, 0.4, 3, 180);
                 break;
             case "triright_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1928,7 +1928,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.25 * 0.25 * this.size, y, 0.25, 3, 180);
                 break;
             case "triright_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1937,7 +1937,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.16 * 0.25 * this.size, y, 0.16, 3, 180);
                 break;
             case "trileft_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1946,7 +1946,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.5 * 0.25 * this.size, y, 0.5, 3, 0);
                 break;
             case "trileft_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1955,7 +1955,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.4 * 0.25 * this.size, y, 0.4, 3, 0);
                 break;
             case "trileft_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1964,7 +1964,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.25 * 0.25 * this.size, y, 0.25, 3, 0);
                 break;
             case "trileft_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1973,7 +1973,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.16 * 0.25 * this.size, y, 0.16, 3, 0);
                 break;
             case "diamond_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1982,7 +1982,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.43, 4, 0);
                 break;
             case "diamond_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1991,7 +1991,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.35, 4, 0);
                 break;
             case "diamond_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2000,7 +2000,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.22, 4, 0);
                 break;
             case "diamond_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2009,7 +2009,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
                 break;
             case "hexpoint_LL":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2018,7 +2018,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.48, 6, 30);
                 break;
             case "hexpoint_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2027,7 +2027,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.4, 6, 30);
                 break;
             case "hexpoint_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2036,7 +2036,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.3, 6, 30);
                 break;
             case "hexpoint_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2045,7 +2045,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.2, 6, 30);
                 break;
             case "hexpoint_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2054,7 +2054,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.13, 6, 30);
                 break;
             case "hexflat_LL":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2063,7 +2063,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.48, 6, 0);
                 break;
             case "hexflat_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2072,7 +2072,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.4, 6, 0);
                 break;
             case "hexflat_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2081,7 +2081,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.3, 6, 0);
                 break;
             case "hexflat_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2090,7 +2090,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.2, 6, 0);
                 break;
             case "hexflat_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2102,7 +2102,7 @@ class Puzzle_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -2128,7 +2128,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_ox(ctx, num, x, y);
                 break;
             case "tri":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_tri(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2139,7 +2139,7 @@ class Puzzle_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -2149,7 +2149,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_cross(ctx, num, x, y);
                 break;
             case "line":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_linesym(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2157,7 +2157,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "frameline":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_framelinesym(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2167,7 +2167,7 @@ class Puzzle_square extends Puzzle {
             case "bars_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.fillStyle = this[qamode + "_col"].symbol[i];
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
@@ -2181,7 +2181,7 @@ class Puzzle_square extends Puzzle {
             case "bars_G":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.fillStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -2201,7 +2201,7 @@ class Puzzle_square extends Puzzle {
                 break;
                 //number
             case "inequality":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 10, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2210,7 +2210,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_inequality(ctx, num, x, y);
                 break;
             case "math":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_font_style(ctx, 0.8 * pu.size.toString(10), 1, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2223,7 +2223,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "degital":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2232,7 +2232,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_degital(ctx, num, x, y);
                 break;
             case "degital_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2249,7 +2249,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_degital(ctx, num, x, y);
                 break;
             case "degital_f":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_degital_f(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2257,7 +2257,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "dice":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2267,7 +2267,7 @@ class Puzzle_square extends Puzzle {
                 break;
             case "pills":
                 set_circle_style(ctx, 3);
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_pills(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2277,7 +2277,7 @@ class Puzzle_square extends Puzzle {
 
                 /* arrow */
             case "arrow_B_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2294,7 +2294,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_N_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2311,7 +2311,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2320,7 +2320,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowS(ctx, num, x, y);
                 break;
             case "arrow_GP":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2329,7 +2329,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowGP(ctx, num, x, y);
                 break;
             case "arrow_GP_C":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2338,7 +2338,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowGP_C(ctx, num, x, y);
                 break;
             case "arrow_Short":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2347,7 +2347,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowShort(ctx, num, x, y);
                 break;
             case "arrow_tri_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2364,7 +2364,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_cross":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2373,7 +2373,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowcross(ctx, num, x, y);
                 break;
             case "arrow_eight":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2382,7 +2382,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arroweight(ctx, num, x, y);
                 break;
             case "arrow_fourtip":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2391,7 +2391,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowfourtip(ctx, num, x, y);
                 break;
             case "arrow_fouredge_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2415,7 +2415,7 @@ class Puzzle_square extends Puzzle {
 
                 /* special */
             case "kakuro":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_kakuro(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2423,7 +2423,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "compass":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_compass(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2431,7 +2431,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "star":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_star(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2439,7 +2439,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "tents":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_tents(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2448,7 +2448,7 @@ class Puzzle_square extends Puzzle {
                 break;
             case "battleship_B":
                 var font_style_type = 1;
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                     this.draw_battleship(ctx, num, x, y, font_style_type, this[qamode + "_col"].symbol[i]);
@@ -2472,7 +2472,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_battleship(ctx, num, x, y);
                 break;
             case "battleship_B+":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                     this.draw_battleshipplus(ctx, num, x, y);
@@ -2495,7 +2495,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_battleshipplus(ctx, num, x, y);
                 break;
             case "angleloop":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_angleloop(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2503,7 +2503,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "firefly":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_firefly(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2511,7 +2511,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "sun_moon":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_sun_moon(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2519,7 +2519,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "sudokuetc":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_sudokuetc(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2527,7 +2527,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "sudokumore":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_sudokumore(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2535,7 +2535,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "polyomino":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_polyomino(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2543,7 +2543,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "polyhex":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_polyhex(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2551,7 +2551,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "pencils":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_pencils(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2559,7 +2559,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "slovak":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_slovak(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2567,7 +2567,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "arc":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_arc(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2575,7 +2575,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "darts":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_darts(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2583,7 +2583,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "spans":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_spans(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2591,7 +2591,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "neighbors":
-                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
+                if (i !== 'panel' && UserSettings.custom_colors_on &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_neighbors(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -783,7 +783,7 @@ class Puzzle_square extends Puzzle {
         for (var k = 0; k < keys.length; k++) {
             var i = keys[k];
             set_surface_style(this.ctx, this[pu].surface[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].surface[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].surface[i]) {
                 this.ctx.fillStyle = this[pu + "_col"].surface[i];
                 this.ctx.strokeStyle = this.ctx.fillStyle;
             }
@@ -829,7 +829,7 @@ class Puzzle_square extends Puzzle {
             if (this[pu].squareframe[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].squareframe[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].squareframe[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].squareframe[i];
                 } else {
                     this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -853,7 +853,7 @@ class Puzzle_square extends Puzzle {
             for (var i = 0; i < this[pu].thermo.length; i++) {
                 if (this[pu].thermo[i] && this[pu].thermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].thermo[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
                         this.ctx.fillStyle = this[pu + "_col"].thermo[i];
                     } else {
                         this.ctx.fillStyle = Color.GREY_LIGHT;
@@ -861,7 +861,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(this.ctx, this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y, 0.4);
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].thermo[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].thermo[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].thermo[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -913,14 +913,14 @@ class Puzzle_square extends Puzzle {
             for (var i = 0; i < this[pu].nobulbthermo.length; i++) {
                 if (this[pu].nobulbthermo[i] && this[pu].nobulbthermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.fillStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.fillStyle = Color.GREY_LIGHT;
                     }
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].nobulbthermo[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].nobulbthermo[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].nobulbthermo[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_LIGHT;
@@ -1030,7 +1030,7 @@ class Puzzle_square extends Puzzle {
                 if (this[pu].arrows[i] && this[pu].arrows[i][0]) {
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].arrows[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -1064,7 +1064,7 @@ class Puzzle_square extends Puzzle {
                         this.ctx.stroke();
                         this.ctx.setLineDash([]);
                         this.ctx.lineJoin = "miter";
-                        if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].arrows[i]) {
+                        if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].arrows[i]) {
                             this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
                         } else {
                             this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -1090,7 +1090,7 @@ class Puzzle_square extends Puzzle {
                 if (this[pu].direction[i][0]) {
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].direction[i]) {
+                    if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].direction[i]) {
                         this.ctx.strokeStyle = this[pu + "_col"].direction[i];
                     } else {
                         this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
@@ -1227,7 +1227,7 @@ class Puzzle_square extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 this.ctx.beginPath();
@@ -1240,7 +1240,7 @@ class Puzzle_square extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].line[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].line[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].line[i];
                 }
                 var i1 = i.split(",")[0];
@@ -1288,7 +1288,7 @@ class Puzzle_square extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 this.ctx.beginPath();
@@ -1301,7 +1301,7 @@ class Puzzle_square extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
-                if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].lineE[i]) {
+                if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].lineE[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
                 }
                 var i1 = i.split(",")[0];
@@ -1330,7 +1330,7 @@ class Puzzle_square extends Puzzle {
         /*freeline*/
         for (var i in this[pu].freeline) {
             set_line_style(this.ctx, this[pu].freeline[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].freeline[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freeline[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
             }
             var i1 = i.split(",")[0];
@@ -1354,7 +1354,7 @@ class Puzzle_square extends Puzzle {
         }
         for (var i in this[pu].freelineE) {
             set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].freelineE[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].freelineE[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
             }
             var i1 = i.split(",")[0];
@@ -1381,7 +1381,7 @@ class Puzzle_square extends Puzzle {
     draw_wall(pu) {
         for (var i in this[pu].wall) {
             set_line_style(this.ctx, this[pu].wall[i]);
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].wall[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].wall[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].wall[i];
             }
             this.ctx.lineCap = "butt";
@@ -1451,7 +1451,7 @@ class Puzzle_square extends Puzzle {
             } else {
                 set_line_style(this.ctx, this[pu].cage[i]);
             }
-            if (document.getElementById("custom_color_opt").value === "2" && this[pu + "_col"].cage[i]) {
+            if (UserSettings.custom_colors_on === 2 && this[pu + "_col"].cage[i]) {
                 this.ctx.strokeStyle = this[pu + "_col"].cage[i];
             }
             this.ctx.beginPath();
@@ -1729,7 +1729,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.43);
                     this.draw_circle(ctx, x, y, 0.32);
                 } else {
-                    if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1744,7 +1744,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.35);
                     this.draw_circle(ctx, x, y, 0.25);
                 } else {
-                    if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1759,7 +1759,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.22);
                     this.draw_circle(ctx, x, y, 0.14);
                 } else {
-                    if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1774,7 +1774,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.13);
                     this.draw_circle(ctx, x, y, 0.07);
                 } else {
-                    if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                    if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                         this[qamode + "_col"].symbol[i]) {
                         set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                     } else {
@@ -1784,7 +1784,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "square_LL":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1793,7 +1793,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, 45);
                 break;
             case "square_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1802,7 +1802,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.4 * Math.sqrt(2), 4, 45);
                 break;
             case "square_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1811,7 +1811,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.35 * Math.sqrt(2), 4, 45);
                 break;
             case "square_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1820,7 +1820,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.22 * Math.sqrt(2), 4, 45);
                 break;
             case "square_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1829,7 +1829,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.13 * Math.sqrt(2), 4, 45);
                 break;
             case "triup_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1838,7 +1838,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.5 * 0.25 * this.size, 0.5, 3, 90);
                 break;
             case "triup_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1847,7 +1847,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.4 * 0.25 * this.size, 0.4, 3, 90);
                 break;
             case "triup_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1856,7 +1856,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.25 * 0.25 * this.size, 0.25, 3, 90);
                 break;
             case "triup_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1865,7 +1865,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y + 0.16 * 0.25 * this.size, 0.16, 3, 90);
                 break;
             case "tridown_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1874,7 +1874,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.5 * 0.25 * this.size, 0.5, 3, -90);
                 break;
             case "tridown_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1883,7 +1883,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.4 * 0.25 * this.size, 0.4, 3, -90);
                 break;
             case "tridown_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1892,7 +1892,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.25 * 0.25 * this.size, 0.25, 3, -90);
                 break;
             case "tridown_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1901,7 +1901,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y - 0.16 * 0.25 * this.size, 0.16, 3, -90);
                 break;
             case "triright_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1910,7 +1910,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.5 * 0.25 * this.size, y, 0.5, 3, 180);
                 break;
             case "triright_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1919,7 +1919,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.4 * 0.25 * this.size, y, 0.4, 3, 180);
                 break;
             case "triright_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1928,7 +1928,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.25 * 0.25 * this.size, y, 0.25, 3, 180);
                 break;
             case "triright_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1937,7 +1937,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x - 0.16 * 0.25 * this.size, y, 0.16, 3, 180);
                 break;
             case "trileft_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1946,7 +1946,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.5 * 0.25 * this.size, y, 0.5, 3, 0);
                 break;
             case "trileft_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1955,7 +1955,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.4 * 0.25 * this.size, y, 0.4, 3, 0);
                 break;
             case "trileft_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1964,7 +1964,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.25 * 0.25 * this.size, y, 0.25, 3, 0);
                 break;
             case "trileft_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1973,7 +1973,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x + 0.16 * 0.25 * this.size, y, 0.16, 3, 0);
                 break;
             case "diamond_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1982,7 +1982,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.43, 4, 0);
                 break;
             case "diamond_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -1991,7 +1991,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.35, 4, 0);
                 break;
             case "diamond_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2000,7 +2000,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.22, 4, 0);
                 break;
             case "diamond_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2009,7 +2009,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
                 break;
             case "hexpoint_LL":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2018,7 +2018,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.48, 6, 30);
                 break;
             case "hexpoint_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2027,7 +2027,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.4, 6, 30);
                 break;
             case "hexpoint_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2036,7 +2036,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.3, 6, 30);
                 break;
             case "hexpoint_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2045,7 +2045,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.2, 6, 30);
                 break;
             case "hexpoint_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2054,7 +2054,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.13, 6, 30);
                 break;
             case "hexflat_LL":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2063,7 +2063,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.48, 6, 0);
                 break;
             case "hexflat_L":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2072,7 +2072,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.4, 6, 0);
                 break;
             case "hexflat_M":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2081,7 +2081,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.3, 6, 0);
                 break;
             case "hexflat_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2090,7 +2090,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_polygon(ctx, x, y, 0.2, 6, 0);
                 break;
             case "hexflat_SS":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2102,7 +2102,7 @@ class Puzzle_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -2128,7 +2128,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_ox(ctx, num, x, y);
                 break;
             case "tri":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_tri(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2139,7 +2139,7 @@ class Puzzle_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -2149,7 +2149,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_cross(ctx, num, x, y);
                 break;
             case "line":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_linesym(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2157,7 +2157,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "frameline":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_framelinesym(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2167,7 +2167,7 @@ class Puzzle_square extends Puzzle {
             case "bars_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.fillStyle = this[qamode + "_col"].symbol[i];
                     ctx.strokeStyle = this[qamode + "_col"].symbol[i];
@@ -2181,7 +2181,7 @@ class Puzzle_square extends Puzzle {
             case "bars_G":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     ctx.fillStyle = this[qamode + "_col"].symbol[i];
                 } else {
@@ -2201,7 +2201,7 @@ class Puzzle_square extends Puzzle {
                 break;
                 //number
             case "inequality":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 10, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2210,7 +2210,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_inequality(ctx, num, x, y);
                 break;
             case "math":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_font_style(ctx, 0.8 * pu.size.toString(10), 1, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2223,7 +2223,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "degital":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2232,7 +2232,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_degital(ctx, num, x, y);
                 break;
             case "degital_B":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2249,7 +2249,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_degital(ctx, num, x, y);
                 break;
             case "degital_f":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_degital_f(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2257,7 +2257,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "dice":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2267,7 +2267,7 @@ class Puzzle_square extends Puzzle {
                 break;
             case "pills":
                 set_circle_style(ctx, 3);
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_pills(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2277,7 +2277,7 @@ class Puzzle_square extends Puzzle {
 
                 /* arrow */
             case "arrow_B_B":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2294,7 +2294,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_N_B":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2311,7 +2311,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_S":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2320,7 +2320,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowS(ctx, num, x, y);
                 break;
             case "arrow_GP":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2329,7 +2329,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowGP(ctx, num, x, y);
                 break;
             case "arrow_GP_C":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2338,7 +2338,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowGP_C(ctx, num, x, y);
                 break;
             case "arrow_Short":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2347,7 +2347,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowShort(ctx, num, x, y);
                 break;
             case "arrow_tri_B":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2364,7 +2364,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_cross":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2373,7 +2373,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowcross(ctx, num, x, y);
                 break;
             case "arrow_eight":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2382,7 +2382,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arroweight(ctx, num, x, y);
                 break;
             case "arrow_fourtip":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2391,7 +2391,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowfourtip(ctx, num, x, y);
                 break;
             case "arrow_fouredge_B":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2415,7 +2415,7 @@ class Puzzle_square extends Puzzle {
 
                 /* special */
             case "kakuro":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_kakuro(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2423,7 +2423,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "compass":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_compass(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2431,7 +2431,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "star":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_star(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2439,7 +2439,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "tents":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_tents(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2448,7 +2448,7 @@ class Puzzle_square extends Puzzle {
                 break;
             case "battleship_B":
                 var font_style_type = 1;
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                     this.draw_battleship(ctx, num, x, y, font_style_type, this[qamode + "_col"].symbol[i]);
@@ -2472,7 +2472,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_battleship(ctx, num, x, y);
                 break;
             case "battleship_B+":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
                     this.draw_battleshipplus(ctx, num, x, y);
@@ -2495,7 +2495,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_battleshipplus(ctx, num, x, y);
                 break;
             case "angleloop":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_angleloop(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2503,7 +2503,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "firefly":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_firefly(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2511,7 +2511,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "sun_moon":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_sun_moon(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2519,7 +2519,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "sudokuetc":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_sudokuetc(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2527,7 +2527,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "sudokumore":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_sudokumore(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2535,7 +2535,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "polyomino":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_polyomino(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2543,7 +2543,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "polyhex":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_polyhex(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2551,7 +2551,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "pencils":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_pencils(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2559,7 +2559,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "slovak":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_slovak(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2567,7 +2567,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "arc":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_arc(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2575,7 +2575,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "darts":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_darts(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2583,7 +2583,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "spans":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_spans(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {
@@ -2591,7 +2591,7 @@ class Puzzle_square extends Puzzle {
                 }
                 break;
             case "neighbors":
-                if (i !== 'panel' && document.getElementById("custom_color_opt").value === "2" &&
+                if (i !== 'panel' && UserSettings.custom_colors_on === 2 &&
                     this[qamode + "_col"].symbol[i]) {
                     this.draw_neighbors(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
                 } else {

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -2121,7 +2121,7 @@ function load(urlParam, type = 'url', origurl = null) {
         if (rtext[13]) {
             let parsedValue = JSON.parse(rtext[13]);
             if (parsedValue === "true" || parsedValue === 1) {
-                document.getElementById("custom_color_opt").value = 2;
+                UserSettings.custom_colors_on = 2;
             }
         }
         if (rtext[14]) {
@@ -2255,7 +2255,7 @@ function load(urlParam, type = 'url', origurl = null) {
         if (rtext[13]) {
             let parsedValue = JSON.parse(rtext[13]);
             if (parsedValue === "true" || parsedValue === 1) {
-                document.getElementById("custom_color_opt").value = 2;
+                UserSettings.custom_colors_on = 2;
             }
         }
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2127,7 +2127,7 @@ onload = function() {
     
     // Custom Color Setting
     document.getElementById("custom_color_opt").onchange = function() {
-        UserSettings.custom_colors_on = this.value;
+        UserSettings.custom_colors_on = (parseInt(this.value, 10) === 2);
     }
 
     // Save Setting

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2124,20 +2124,10 @@ onload = function() {
     document.getElementById("responsive_settings_opt").onchange = function() {
         UserSettings.responsive_mode = this.value;
     }
-
+    
     // Custom Color Setting
     document.getElementById("custom_color_opt").onchange = function() {
-        if (document.getElementById("custom_color_opt").value === "1") {
-            document.getElementById('style_special').style.display = 'none';
-            pu.redraw();
-        } else if (document.getElementById("custom_color_opt").value === "2") {
-            let mode = pu.mode[pu.mode.qa].edit_mode;
-            if (((pu.gridtype === "square" || pu.gridtype === "sudoku" || pu.gridtype === "kakuro" || pu.gridtype === "hex")) &&
-                (mode === "line" || mode === "lineE" || mode === "wall" || mode === "surface" || mode === "cage" || mode === "special" || mode === "symbol")) {
-                document.getElementById('style_special').style.display = 'inline';
-            }
-            pu.redraw();
-        }
+        UserSettings.custom_colors_on = this.value;
     }
 
     // Save Setting

--- a/docs/js/settings.js
+++ b/docs/js/settings.js
@@ -147,6 +147,30 @@ const UserSettings = {
         return this._sudoku_centre_size;
     },
 
+    _custom_colors_on: 1,
+    set custom_colors_on(newValue) {
+        const valueInt = newValue ? parseInt(newValue, 10) : 1;
+        this._custom_colors_on = valueInt;
+
+        if (valueInt === 1) {
+            // Off
+            document.getElementById('style_special').style.display = 'none';
+        } else {
+            // On
+            let mode = pu.mode[pu.mode.qa].edit_mode;
+            if (((pu.gridtype === "square" || pu.gridtype === "sudoku" || pu.gridtype === "kakuro" || pu.gridtype === "hex")) &&
+                (mode === "line" || mode === "lineE" || mode === "wall" || mode === "surface" || mode === "cage" || mode === "special" || mode === "symbol")) {
+                document.getElementById('style_special').style.display = 'inline';
+            }
+        }
+        pu.redraw();
+
+        document.getElementById("custom_color_opt").value = valueInt;
+    },
+    get custom_colors_on() {
+        return this._custom_colors_on;
+    },
+
     _local_storage: 1,
     set local_storage(newValue) {
         const valueInt = newValue ? parseInt(newValue, 10) : 1;
@@ -318,6 +342,7 @@ const UserSettings = {
 
     can_save: [
         'color_theme',
+        'custom_colors_on',
         'mousemiddle_button',
         'reload_button',
         'responsive_mode',

--- a/docs/js/settings.js
+++ b/docs/js/settings.js
@@ -147,25 +147,43 @@ const UserSettings = {
         return this._sudoku_centre_size;
     },
 
-    _custom_colors_on: 1,
+    _custom_colors_on: false,
+    _custom_color_supported_grids: {
+        square: 1,
+        sudoku: 1,
+        kakuro: 1,
+        hex: 1
+    },
+    _custom_color_supported_modes: {
+        line: 1,
+        lineE: 1,
+        wall: 1,
+        surface: 1,
+        cage: 1,
+        special: 1,
+        symbol: 1
+    },
     set custom_colors_on(newValue) {
-        const valueInt = newValue ? parseInt(newValue, 10) : 1;
-        this._custom_colors_on = valueInt;
-
-        if (valueInt === 1) {
-            // Off
-            document.getElementById('style_special').style.display = 'none';
+        if (typeof newValue === 'string') {
+            const valueInt = newValue ? parseInt(newValue, 10) : 1;
+            this._custom_colors_on = (valueInt === 2);
         } else {
+            this._custom_colors_on = !!newValue;
+        }
+
+        if (this._custom_colors_on) {
             // On
             let mode = pu.mode[pu.mode.qa].edit_mode;
-            if (((pu.gridtype === "square" || pu.gridtype === "sudoku" || pu.gridtype === "kakuro" || pu.gridtype === "hex")) &&
-                (mode === "line" || mode === "lineE" || mode === "wall" || mode === "surface" || mode === "cage" || mode === "special" || mode === "symbol")) {
+            if (this._custom_color_supported_grids[pu.gridtype] && this._custom_color_supported_modes[mode]) {
                 document.getElementById('style_special').style.display = 'inline';
             }
+        } else {
+            // Off
+            document.getElementById('style_special').style.display = 'none';
         }
+        document.getElementById("custom_color_opt").value = this._custom_colors_on ? '2' : '1';
+        
         pu.redraw();
-
-        document.getElementById("custom_color_opt").value = valueInt;
     },
     get custom_colors_on() {
         return this._custom_colors_on;


### PR DESCRIPTION
This converts all the custom color checks in the code to use UserSettings instead of checking the input value directly. Although not likely a huge issue, the previous way the check was handled would require looking up the select input each time before checking the value. This should be faster/more performant.

I added it to the whitelist of settings saved to cookies but it can be removed from that if needed.