### PR TITLE
Fix triangle drawing for flipped board

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -3361,7 +3361,7 @@ class Puzzle {
                 checkall) {
 
                 // for newer links, if loop edge is selected, automatically ignore the given border/edge elements
-                if ((this.version[0] > 2) || (this.version[0] == 2 && this.version[1] > 26) || (this.version[0] == 2 && this.version[1] == 26 && this.version[2] > 20)) {
+                if (this.version_gt(2, 26, 20)) {
                     if (!document.getElementById("sol_ignoreborder").checked && !checkall) {
                         document.getElementById("sol_ignoreborder").checked = true;
                     }
@@ -12363,4 +12363,29 @@ class Puzzle {
             }
         }
     }
+
+    version_lt(major, minor, revision) {
+        if (this.version[0] < major) return true;
+        if (this.version[0] > major) return false;        
+        if (this.version[1] < minor) return true;
+        if (this.version[1] > minor) return false;
+        return this.version[2] < revision;
+    }
+
+    version_ge(major, minor, revision) {
+        return !version_lt(major, minor, revision);
+    }
+
+    version_gt(major, minor, revision) {
+        if (this.version[0] > major) return true;        
+        if (this.version[0] < major) return false;
+        if (this.version[1] > minor) return true;
+        if (this.version[1] < minor) return false;
+        return this.version[2] > revision;
+    }
+    
+    version_le(major, minor, revision) {
+        return !version_gt(major, minor, revision);
+    }
+
 }

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12373,7 +12373,7 @@ class Puzzle {
     }
 
     version_ge(major, minor, revision) {
-        return !version_lt(major, minor, revision);
+        return !this.version_lt(major, minor, revision);
     }
 
     version_gt(major, minor, revision) {
@@ -12383,9 +12383,9 @@ class Puzzle {
         if (this.version[1] < minor) return false;
         return this.version[2] > revision;
     }
-    
+
     version_le(major, minor, revision) {
-        return !version_gt(major, minor, revision);
+        return !this.version_gt(major, minor, revision);
     }
 
 }

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -2701,6 +2701,7 @@ class Puzzle_square extends Puzzle {
             case 4:
                 set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
+                // This is to not break old puzzles which were constructed assuming this rendering bug. Check PR 120.
                 if (pu.version_ge(3, 0, 5)) {
                     th1 = this.rotate_theta(-90 * (num - 1) - 135);
                     th2 = this.rotate_theta(-90 * (num - 1) - 45);
@@ -2729,6 +2730,7 @@ class Puzzle_square extends Puzzle {
                 set_circle_style(ctx, 3);
                 ctx.fillStyle = Color.GREY;
                 ctx.beginPath();
+                // This is to not break old puzzles which were constructed assuming this rendering bug. Check PR 120.
                 if (pu.version_ge(3, 0, 5)) {
                     th1 = this.rotate_theta(-90 * (num - 1) - 135);
                     th2 = this.rotate_theta(-90 * (num - 1) - 45);

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -2693,19 +2693,29 @@ class Puzzle_square extends Puzzle {
 
     draw_tri(ctx, num, x, y, ccolor = "none") {
         var r = 0.5,
-            th;
+            th, th1, th2, th3;
         switch (num) {
             case 1:
             case 2:
             case 3:
             case 4:
                 set_circle_style(ctx, 2, ccolor);
-                th = this.rotate_theta(-90 * (num - 1));
                 ctx.beginPath();
-                ctx.moveTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
-                ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.25), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.25));
-                ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th + Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th + Math.PI * 0.75));
-                ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
+                if (pu.version_ge(3, 0, 5)) {
+                    th1 = this.rotate_theta(-90 * (num - 1) - 135);
+                    th2 = this.rotate_theta(-90 * (num - 1) - 45);
+                    th3 = this.rotate_theta(-90 * (num - 1) + 135);
+                    ctx.moveTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th1), y + Math.sqrt(2) * r * pu.size * Math.sin(th1));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th2), y + Math.sqrt(2) * r * pu.size * Math.sin(th2));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th3), y + Math.sqrt(2) * r * pu.size * Math.sin(th3));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th1), y + Math.sqrt(2) * r * pu.size * Math.sin(th1));
+                } else {
+                    th = this.rotate_theta(-90 * (num - 1));
+                    ctx.moveTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.25), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.25));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th + Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th + Math.PI * 0.75));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
+                }
                 ctx.fill();
                 break;
             case 5:
@@ -2718,12 +2728,22 @@ class Puzzle_square extends Puzzle {
             case 9:
                 set_circle_style(ctx, 3);
                 ctx.fillStyle = Color.GREY;
-                th = this.rotate_theta(-90 * (num - 1));
                 ctx.beginPath();
-                ctx.moveTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
-                ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.25), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.25));
-                ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th + Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th + Math.PI * 0.75));
-                ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
+                if (pu.version_ge(3, 0, 5)) {
+                    th1 = this.rotate_theta(-90 * (num - 1) - 135);
+                    th2 = this.rotate_theta(-90 * (num - 1) - 45);
+                    th3 = this.rotate_theta(-90 * (num - 1) + 135);
+                    ctx.moveTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th1), y + Math.sqrt(2) * r * pu.size * Math.sin(th1));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th2), y + Math.sqrt(2) * r * pu.size * Math.sin(th2));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th3), y + Math.sqrt(2) * r * pu.size * Math.sin(th3));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th1), y + Math.sqrt(2) * r * pu.size * Math.sin(th1));
+                } else {
+                    th = this.rotate_theta(-90 * (num - 1));
+                    ctx.moveTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.25), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.25));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th + Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th + Math.PI * 0.75));
+                    ctx.lineTo(x + Math.sqrt(2) * r * pu.size * Math.cos(th - Math.PI * 0.75), y + Math.sqrt(2) * r * pu.size * Math.sin(th - Math.PI * 0.75));
+                }
                 ctx.fill();
                 break;
             case 0:
@@ -3374,7 +3394,7 @@ class Puzzle_square extends Puzzle {
                 th2 = this.rotate_theta(90 * i);
                 ctx.beginPath();
                 // This is to not break old puzzles which were constructed assuming this rendering bug. Check PR 108.
-                if (pu.version[0] >= 3 && pu.version[1] >= 0 && pu.version[2] >= 5) {
+                if (pu.version_ge(3, 0, 5)) {
                     ctx.arrow(
                         x + len1 * pu.size * Math.cos(th1a) + 0.1 * pu.size * Math.cos(th2),
                         y + len1 * pu.size * Math.sin(th1a) + 0.1 * pu.size * Math.sin(th2),
@@ -3400,7 +3420,7 @@ class Puzzle_square extends Puzzle {
                 th2 = this.rotate_theta(90 * i);
                 ctx.beginPath();
                 // This is to not break old puzzles which were constructed assuming this rendering bug. Check PR 108.
-                if (pu.version[0] >= 3 && pu.version[1] >= 0 && pu.version[2] >= 5) {
+                if (pu.version_ge(3, 0, 5)) {
                     ctx.arrow(
                         x + len2 * pu.size * Math.cos(th1b) - 0.1 * pu.size * Math.cos(th2),
                         y + len2 * pu.size * Math.sin(th1b) - 0.1 * pu.size * Math.sin(th2),
@@ -4167,7 +4187,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineCap = "round";
                 ctx.lineWidth = 3;
                 ctx.setLineDash([]);
-                if ((this.version[0] < 2) || (this.version[0] == 2 && this.version[1] < 25) || (this.version[0] == 2 && this.version[1] == 25 && this.version[2] < 9)) {
+                if (this.version_lt(2, 25, 9)) {
                     ctx.fillStyle = Color.TRANSPARENTBLACK;
                 } else {
                     ctx.fillStyle = Color.WHITE;
@@ -4200,7 +4220,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineCap = "round";
                 ctx.lineWidth = 3;
                 ctx.setLineDash([]);
-                if ((this.version[0] < 2) || (this.version[0] == 2 && this.version[1] < 25) || (this.version[0] == 2 && this.version[1] == 25 && this.version[2] < 9)) {
+                if (this.version_lt(2, 25, 9)) {
                     ctx.fillStyle = Color.TRANSPARENTBLACK;
                 } else {
                     ctx.fillStyle = Color.WHITE;
@@ -4233,7 +4253,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineCap = "round";
                 ctx.lineWidth = 3;
                 ctx.setLineDash([]);
-                if ((this.version[0] < 2) || (this.version[0] == 2 && this.version[1] < 25) || (this.version[0] == 2 && this.version[1] == 25 && this.version[2] < 9)) {
+                if (this.version_lt(2, 25, 9)) {
                     ctx.fillStyle = Color.TRANSPARENTBLACK;
                 } else {
                     ctx.fillStyle = Color.WHITE;
@@ -4266,7 +4286,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineCap = "round";
                 ctx.lineWidth = 3;
                 ctx.setLineDash([]);
-                if ((this.version[0] < 2) || (this.version[0] == 2 && this.version[1] < 25) || (this.version[0] == 2 && this.version[1] == 25 && this.version[2] < 9)) {
+                if (this.version_lt(2, 25, 9)) {
                     ctx.fillStyle = Color.TRANSPARENTBLACK;
                 } else {
                     ctx.fillStyle = Color.WHITE;
@@ -4313,7 +4333,7 @@ class Puzzle_square extends Puzzle {
             case 4:
                 ctx.beginPath();
                 // This is to not break old puzzles which were constructed assuming this arc bug. Check PR 109.
-                if (pu.version[0] >= 3 && pu.version[1] >= 0 && pu.version[2] >= 5) {
+                if (pu.version_ge(3, 0, 5)) {
                     th1 = this.rotate_theta(45 + 90 * (num - 1));
                     th2 = this.rotate_theta(225 + 90 * (num - 1));
                     th2a = this.rotate_theta(315 + 90 * (num - 1));
@@ -4330,7 +4350,7 @@ class Puzzle_square extends Puzzle {
             case 6:
                 ctx.beginPath();
                 // This is to not break old puzzles which were constructed assuming this arc bug. Check PR 109.
-                if (pu.version[0] >= 3 && pu.version[1] >= 0 && pu.version[2] >= 5) {
+                if (pu.version_ge(3, 0, 5)) {
                     th1 = this.rotate_theta(45 + 90 * (num - 5));
                     th2 = this.rotate_theta(225 + 90 * (num - 5));
                     ctx.moveTo((x + Math.sqrt(2) * 0.5 * pu.size * Math.cos(th1)), (y + Math.sqrt(2) * 0.5 * pu.size * Math.sin(th1)));


### PR DESCRIPTION
This fixes #119.
- Fix tri rendering for board flip
- Introduce version check helper functions
- Fix version checks for draw_arc and draw_arrowfouredge (this proves the necessity for the version check functions) 