### PR TITLE
Draw number circles below symbols

### DIFF
--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -714,14 +714,14 @@ class Puzzle_square extends Puzzle {
             this.draw_line("pu_a");
             this.draw_lattice();
             this.draw_selection();
-            this.draw_symbol("pu_q", 2, false);
-            this.draw_symbol("pu_a", 2, false);
+            this.draw_number_circle("pu_q");
+            this.draw_number_circle("pu_a");
+            this.draw_symbol("pu_q", 2);
+            this.draw_symbol("pu_a", 2);
             this.draw_cage("pu_q");
             this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
-            this.draw_symbol("pu_q", 2, true);
-            this.draw_symbol("pu_a", 2, true);
             this.draw_cursol();
             this.draw_freecircle();
         } else {
@@ -740,10 +740,10 @@ class Puzzle_square extends Puzzle {
             this.draw_direction("pu_q");
             this.draw_lattice();
             this.draw_selection();
-            this.draw_symbol("pu_q", 2, false);
+            this.draw_number_circle("pu_q");
+            this.draw_symbol("pu_q");
             this.draw_cage("pu_q");
             this.draw_number("pu_q");
-            this.draw_symbol("pu_q", 2, true);
             this.draw_cursol();
             this.draw_freecircle();
         }
@@ -1464,7 +1464,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_symbol(pu, layer, abovenumber = false) {
+    draw_symbol(pu, layer) {
         /*symbol_layer*/
         var p_x, p_y;
         for (var i in this[pu].symbol) {
@@ -1476,11 +1476,7 @@ class Puzzle_square extends Puzzle {
                 p_y = this.point[i].y;
             }
             if (this[pu].symbol[i][2] === layer) {
-                // Mutually exclusive condition to draw symbols above or below numbercircles
-                let hasNumberCircle = (this[pu].number[i] && [5, 6, 7, 11].includes(this[pu].number[i][1])) ? true : false;
-                if (layer === 1 || hasNumberCircle === abovenumber) {
-                    this.draw_symbol_select(this.ctx, p_x, p_y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
-                }
+                this.draw_symbol_select(this.ctx, p_x, p_y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
             }
         }
     }
@@ -1505,7 +1501,6 @@ class Puzzle_square extends Puzzle {
             }
             switch (this[pu].number[i][2]) {
                 case "1": //normal
-                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
                     set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
 
                     // if some numbers present in the corner (like Killer sudoku etc) then displace the numbers slightly lower to avoid overlap
@@ -1515,7 +1510,6 @@ class Puzzle_square extends Puzzle {
                     break;
                 case "2": //arrow
                     var arrowlength = 0.7;
-                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
                     set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
                     var direction = {
                         "_0": 90,
@@ -1611,7 +1605,6 @@ class Puzzle_square extends Puzzle {
                     }
                     break;
                 case "4": //tapa
-                    this.draw_numbercircle(pu, i, p_x, p_y, 0.44);
                     let values = [...this[pu].number[i][0]]; // This is to handle unicode symbols.
                     if (values.length === 1) {
                         set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
@@ -1634,22 +1627,18 @@ class Puzzle_square extends Puzzle {
                     }
                     break;
                 case "5": //small
-                    this.draw_numbercircle(pu, i, p_x, p_y, 0.17);
                     set_font_style(this.ctx, 0.25 * this.size.toString(10), this[pu].number[i][1]);
                     this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.02 * factor * this.size, this.size * 0.9);
                     break;
                 case "6": //medium
-                    this.draw_numbercircle(pu, i, p_x, p_y, 0.25);
                     set_font_style(this.ctx, 0.4 * this.size.toString(10), this[pu].number[i][1]);
                     this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.03 * factor * this.size, this.size * 0.9);
                     break;
                 case "10": //big
-                    this.draw_numbercircle(pu, i, p_x, p_y, 0.36);
                     set_font_style(this.ctx, 0.6 * this.size.toString(10), this[pu].number[i][1]);
                     this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.03 * factor * this.size, this.size * 0.8);
                     break;
                 case "7": //sudoku
-                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
                     var sum = 0,
                         pos = 0;
                     for (var j = 0; j < 9; j++) {
@@ -1707,6 +1696,42 @@ class Puzzle_square extends Puzzle {
                 //  set_font_style(this.ctx,0.28*this.size.toString(10),this[pu].numberS[i][1]);
                 //  this.ctx.textAlign = "left";
                 //  this.ctx.text(this[pu].numberS[i][0],this.point[i].x-0.15*this.size,this.point[i].y+0.03*this.size,this.size*0.8);
+            }
+        }
+    }
+
+    draw_number_circle(pu) {
+        var p_x, p_y;
+        for (var i in this[pu].number) {
+            if (i.slice(-1) === "E") { // Overwriting in Edge Mode
+                p_x = this.point[i.slice(0, -1)].x;
+                p_y = this.point[i.slice(0, -1)].y;
+            } else {
+                p_x = this.point[i].x;
+                p_y = this.point[i].y;
+            }
+            switch (this[pu].number[i][2]) {
+                case "1": //normal
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
+                    break;
+                case "2": //arrow
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
+                    break;
+                case "4": //tapa
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.44);
+                    break;
+                case "5": //small
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.17);
+                    break;
+                case "6": //medium
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.25);
+                    break;
+                case "10": //big
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.36);
+                    break;
+                case "7": //sudoku
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
+                    break;
             }
         }
     }

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -714,12 +714,14 @@ class Puzzle_square extends Puzzle {
             this.draw_line("pu_a");
             this.draw_lattice();
             this.draw_selection();
-            this.draw_symbol("pu_q", 2);
-            this.draw_symbol("pu_a", 2);
+            this.draw_symbol("pu_q", 2, false);
+            this.draw_symbol("pu_a", 2, false);
             this.draw_cage("pu_q");
             this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
+            this.draw_symbol("pu_q", 2, true);
+            this.draw_symbol("pu_a", 2, true);
             this.draw_cursol();
             this.draw_freecircle();
         } else {
@@ -738,9 +740,10 @@ class Puzzle_square extends Puzzle {
             this.draw_direction("pu_q");
             this.draw_lattice();
             this.draw_selection();
-            this.draw_symbol("pu_q", 2);
+            this.draw_symbol("pu_q", 2, false);
             this.draw_cage("pu_q");
             this.draw_number("pu_q");
+            this.draw_symbol("pu_q", 2, true);
             this.draw_cursol();
             this.draw_freecircle();
         }
@@ -1461,7 +1464,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_symbol(pu, layer) {
+    draw_symbol(pu, layer, abovenumber = false) {
         /*symbol_layer*/
         var p_x, p_y;
         for (var i in this[pu].symbol) {
@@ -1473,7 +1476,11 @@ class Puzzle_square extends Puzzle {
                 p_y = this.point[i].y;
             }
             if (this[pu].symbol[i][2] === layer) {
-                this.draw_symbol_select(this.ctx, p_x, p_y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
+                // Mutually exclusive condition to draw symbols above or below numbercircles
+                let hasNumberCircle = (this[pu].number[i] && [5, 6, 7, 11].includes(this[pu].number[i][1])) ? true : false;
+                if (layer === 1 || hasNumberCircle === abovenumber) {
+                    this.draw_symbol_select(this.ctx, p_x, p_y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
+                }
             }
         }
     }

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -741,7 +741,7 @@ class Puzzle_square extends Puzzle {
             this.draw_lattice();
             this.draw_selection();
             this.draw_number_circle("pu_q");
-            this.draw_symbol("pu_q");
+            this.draw_symbol("pu_q", 2);
             this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();


### PR DESCRIPTION
This PR will draw symbols which are 'above lines' also above number circles.
This allows for symbols to have a circle around/behind them.
I don't think this change will need a version guard, as there are likely no puzzle with this condition, also because 'above lines' is not the default setting.
And if there are puzzles, the symbol was hidden by the number circle.