### PR TITLE
Fix multi solution check for Math

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -3890,7 +3890,7 @@ class Puzzle {
                         case "math":
                             for (var i in this[pu].symbol) {
                                 if ((this[pu].symbol[i][1] === "math" || this[pu].symbol[i][1] === "math_G") &&
-                                    this[pu].symbol[i][0] === 2 || this[pu].symbol[i][0] === 3) {
+                                    (this[pu].symbol[i][0] === 2 || this[pu].symbol[i][0] === 3)) {
                                     temp_sol.push(i + "," + this[pu].symbol[i][0]);
                                 }
                             }


### PR DESCRIPTION
This PR will fix missing parentheses in `make_solution()`.

This bug caused the check condition to be: `if (this[pu].symbol[i][0] === 3)`
which would match *any* symbol which is option 3.