### PR TITLE
Add cage diagonal-connection Symbol

### DIFF
--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -2864,18 +2864,26 @@ class Puzzle_square extends Puzzle {
 
     draw_framelinesym(ctx, num, x, y, ccolor = "none") {
         var r = 0.32;
+        var r2 = 0.17;
+        var d = 0.08;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
         ctx.fillStyle = Color.TRANSPARENTBLACK;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 3;
+        let flip = (pu.reflect[0] !== pu.reflect[1]) === ((pu.theta % 180) === 0);
         switch (num) {
             case 1:
                 set_line_style(ctx, 115, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y - r * pu.size);
-                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;
@@ -2883,8 +2891,13 @@ class Puzzle_square extends Puzzle {
                 set_line_style(ctx, 15, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y - r * pu.size);
-                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;
@@ -2892,8 +2905,13 @@ class Puzzle_square extends Puzzle {
                 set_line_style(ctx, 16, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y - r * pu.size);
-                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;
@@ -2901,8 +2919,13 @@ class Puzzle_square extends Puzzle {
                 set_line_style(ctx, 110, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y - r * pu.size);
-                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;
@@ -2910,8 +2933,13 @@ class Puzzle_square extends Puzzle {
                 set_line_style(ctx, 115, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y - r * pu.size);
-                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;
@@ -2919,8 +2947,13 @@ class Puzzle_square extends Puzzle {
                 set_line_style(ctx, 15, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y - r * pu.size);
-                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;
@@ -2928,8 +2961,13 @@ class Puzzle_square extends Puzzle {
                 set_line_style(ctx, 16, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y - r * pu.size);
-                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;
@@ -2937,8 +2975,47 @@ class Puzzle_square extends Puzzle {
                 set_line_style(ctx, 110, ccolor)
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y - r * pu.size);
-                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                if (flip && pu.version_ge(3, 0, 5)) {
+                    ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                } else {
+                    ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                    ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                }
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 9:
+                set_line_style(ctx, 16, ccolor)
+                ctx.beginPath();
+                if (flip) {
+                    ctx.moveTo(x - (r2 + d) * pu.size, y - (r2 - d) * pu.size);
+                    ctx.lineTo(x + (r2 - d) * pu.size, y + (r2 + d) * pu.size);
+                    ctx.moveTo(x - (r2 - d) * pu.size, y - (r2 + d) * pu.size);
+                    ctx.lineTo(x + (r2 + d) * pu.size, y + (r2 - d) * pu.size);
+                } else {
+                    ctx.moveTo(x + (r2 + d) * pu.size, y - (r2 - d) * pu.size);
+                    ctx.lineTo(x - (r2 - d) * pu.size, y + (r2 + d) * pu.size);
+                    ctx.moveTo(x + (r2 - d) * pu.size, y - (r2 + d) * pu.size);
+                    ctx.lineTo(x - (r2 + d) * pu.size, y + (r2 - d) * pu.size);
+                }
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 0:
+                set_line_style(ctx, 16, ccolor)
+                ctx.beginPath();
+                if (flip) {
+                    ctx.moveTo(x + (r2 + d) * pu.size, y - (r2 - d) * pu.size);
+                    ctx.lineTo(x - (r2 - d) * pu.size, y + (r2 + d) * pu.size);
+                    ctx.moveTo(x + (r2 - d) * pu.size, y - (r2 + d) * pu.size);
+                    ctx.lineTo(x - (r2 + d) * pu.size, y + (r2 - d) * pu.size);
+                } else {
+                    ctx.moveTo(x - (r2 + d) * pu.size, y - (r2 - d) * pu.size);
+                    ctx.lineTo(x + (r2 - d) * pu.size, y + (r2 + d) * pu.size);
+                    ctx.moveTo(x - (r2 - d) * pu.size, y - (r2 + d) * pu.size);
+                    ctx.lineTo(x + (r2 + d) * pu.size, y + (r2 - d) * pu.size);
+                }
                 ctx.closePath();
                 ctx.stroke();
                 break;

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -2180,13 +2180,6 @@ function load(urlParam, type = 'url', origurl = null) {
             pu.pu_a.polygon = [];
         }
 
-        // custom color
-        if (rtext[13]) {
-            let parsedValue = JSON.parse(rtext[13]);
-            if (parsedValue === "true" || parsedValue === 1) {
-                UserSettings.custom_colors_on = 2;
-            }
-        }
         if (rtext[14]) {
             pu.pu_q_col = JSON.parse(rtext[14]);
             pu.pu_a_col = JSON.parse(rtext[15]);


### PR DESCRIPTION
This will add a new 'Cage Lines' (frameline) symbol to represent diagonally connected cage cells.
I've also experimented with dashed lines, but they don't render well enough to be clearly visible.
![image](https://user-images.githubusercontent.com/4366965/224553457-d386d512-f57a-4df8-9051-54ddf9d267a3.png)


This PR also fixes the board-rotation issue for this symbol.