### PR TITLE
Erase killercage cells

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -2739,6 +2739,7 @@ class Puzzle {
                 break;
             case "cage":
                 this[this.mode.qa].cage = {};
+                this[this.mode.qa].killercages = [];
                 if (UserSettings.custom_colors_on) {
                     this[this.mode.qa + "_col"].cage = {};
                 }


### PR DESCRIPTION
When erasing killer cages using 'Erase selected mode' then only the lines are erased, but not the killercage cells.
This bug is very hard to notice in Penpa, but was exposed because of the Penpa to SudokuPad converter.