### PR TITLE
Fix runtime error when drawing polygons

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12711,15 +12711,16 @@ class Puzzle {
             this.ctx.fillStyle = Color.TRANSPARENTBLACK;
             this.ctx.strokeStyle = Color.BLUE_LIGHT;
             this.ctx.lineWidth = 4;
-            if (this.freelinecircle_g[0] != -1) {
-                this.draw_circle(this.ctx, this.point[this.freelinecircle_g[0]].x, this.point[this.freelinecircle_g[0]].y, 0.3);
+            let i1 = this.freelinecircle_g[0];
+            let i2 = this.freelinecircle_g[1];
+            if (i1 != -1) {
+                this.draw_circle(this.ctx, this.point[i1].x, this.point[i1].y, 0.3);
             }
-            if (this.freelinecircle_g[1] != -1) {
-                this.draw_circle(this.ctx, this.point[this.freelinecircle_g[1]].x, this.point[this.freelinecircle_g[1]].y, 0.3);
-
-                // Preview the line
-                var i1 = this.freelinecircle_g[0];
-                var i2 = this.freelinecircle_g[1];
+            if (i2 != -1) {
+                this.draw_circle(this.ctx, this.point[i2].x, this.point[i2].y, 0.3);
+            }
+            // Preview the line 
+            if (i1 != -1 && i2 != -1) {
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
                 this.ctx.lineTo(this.point[i2].x, this.point[i2].y);

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -10563,6 +10563,7 @@ class Puzzle {
                 this.drawing = false;
             }
         }
+        this.redraw();
     }
 
     //////////////////////////
@@ -12709,7 +12710,11 @@ class Puzzle {
         if (((this.mode[this.mode.qa].edit_mode === "line" || this.mode[this.mode.qa].edit_mode === "lineE") && this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") || this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
             this.ctx.setLineDash([]);
             this.ctx.fillStyle = Color.TRANSPARENTBLACK;
-            this.ctx.strokeStyle = Color.BLUE_LIGHT;
+            if (this.drawing && this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                this.ctx.strokeStyle = Color.RED;
+            } else {
+                this.ctx.strokeStyle = Color.BLUE_LIGHT;
+            }
             this.ctx.lineWidth = 4;
             let i1 = this.freelinecircle_g[0];
             let i2 = this.freelinecircle_g[1];

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12624,12 +12624,18 @@ class Puzzle {
 
 
     redraw(svgcall = false, check_sol = true) {
-        this.flushcanvas(svgcall);
-        panel_pu.draw_panel();
-        this.draw();
-        this.set_redoundocolor();
-        if (check_sol) {
-            this.check_solution();
+        try {
+            this.flushcanvas(svgcall);
+            panel_pu.draw_panel();
+            this.draw();
+            this.set_redoundocolor();
+            if (check_sol) {
+                this.check_solution();
+            }
+        }
+        // don't crash the UI
+        catch (err) {
+            console.error(err);
         }
     }
 


### PR DESCRIPTION
This PR has the following changes:
- Fix a runtime error (reference to undefined) when moving the polygon cursor
- Fix unresponsive UI when puzzle contains invalid data (can be caused by excessive board resizing)
- Change polygon cursor from blue to red when started drawing a polygon
