### PR TITLE
Improve Custom Color UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## History
 * unreleased
+	* Persist custom color selection per edit mode
+	* Preview symbols in Panel with custom color
+	* Implement custom color for Triangle
+	* Implement custom color for Pyramid
+	* Implement custom color for Cube
+	* Implement custom color for Kakuro
+	* Implement custom color for Truncated square
+	* Implement custom color for Snub square
+	* Implement custom color for Cairo pentagonal
+	* Implement custom color for Rhombitrihexagonal
+	* Implement custom color for Deltoidal trihexagonal
+	* Fixed surface painting with custom color
+	* Fixed custom color with transparancy
+	* Fixed selection of unavailable sub mode or symbol. Rare but could cause corruption and unresponsive puzzle.
+* unreleased
 	* Arrow circle without arrow single cell added to arrowsums option
 	* moved gtag code back to html file as Adblock Ultimate was blocking branding.js file for some users
 * 2023/09/24 ver 3.0.9

--- a/docs/index.html
+++ b/docs/index.html
@@ -797,11 +797,11 @@
                 <h4><label class="label_nb" id="nb_gridtype_lb">Board type:</label></h4>
                 <select id="gridtype" onchange="changetype()">
                     <option value="square" id="nb_gridtype1_lb" selected="selected">Square</option>
+                    <option value="sudoku" id="nb_gridtype6_lb">Sudoku</option>
                     <option value="hex" id="nb_gridtype2_lb">Hexagon</option>
                     <option value="tri" id="nb_gridtype3_lb">Triangle</option>
                     <option value="pyramid" id="nb_gridtype4_lb">Pyramid</option>
                     <option value="iso" id="nb_gridtype5_lb">Cube</option>
-                    <option value="sudoku" id="nb_gridtype6_lb">Sudoku</option>
                     <option value="kakuro" id="nb_gridtype7_lb">Kakuro</option>
                     <option value="tetrakis_square" id="nb_gridtype8_lb"> Tetrakis square </option>
                     <option value="truncated_square" id="nb_gridtype9_lb"> Truncated square </option>

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,7 +118,8 @@
             "./js/class_uniform.js",
             "./js/class_panel.js",
             "./js/style.js",
-            "./js/general.js"
+            "./js/general.js",
+            "./js/customcolor.js"
         ];
         for (let i = 0; i < script_sources.length; i++) {
             let script = document.createElement("script");

--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -676,24 +676,6 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_surface(pu) {
-        for (var i in this[pu].surface) {
-            set_surface_style(this.ctx, this[pu].surface[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].surface[i]) {
-                this.ctx.fillStyle = this[pu + "_col"].surface[i];
-                this.ctx.strokeStyle = this.ctx.fillStyle;
-            }
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.point[this.point[i].surround[0]].x, this.point[this.point[i].surround[0]].y);
-            for (var j = 1; j < this.point[i].surround.length; j++) {
-                this.ctx.lineTo(this.point[this.point[i].surround[j]].x, this.point[this.point[i].surround[j]].y);
-            }
-            this.ctx.closePath();
-            this.ctx.fill();
-            this.ctx.stroke();
-        }
-    }
-
     draw_polygon(ctx, x, y, r, n, th) {
         ctx.LineCap = "round";
         ctx.beginPath();

--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -1389,11 +1389,14 @@ class Puzzle_hex extends Puzzle {
     }
 
     draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
-        var ccolor = "none";
-        if (i !== 'panel' && UserSettings.custom_colors_on &&
-            this[qamode + "_col"].symbol[i]) {
+        var ccolor = undefined;
+        if (i !== 'panel' && UserSettings.custom_colors_on && this[qamode + "_col"].symbol[i]) {
             ccolor = this[qamode + "_col"].symbol[i];
         }
+        this.draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor);
+    }
+
+    draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor) {
         switch (sym) {
             /* figure */
             case "circle_L":
@@ -1548,12 +1551,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    ctx.strokeStyle = this[qamode + "_col"].symbol[i];
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 2;
                 this.draw_ox(ctx, num, x, y);
                 break;
@@ -1574,18 +1572,13 @@ class Puzzle_hex extends Puzzle {
                 this.draw_ox(ctx, num, x, y);
                 break;
             case "tri":
-                this.draw_tri(ctx, num, x, y);
+                this.draw_tri(ctx, num, x, y, ccolor);
                 break;
             case "cross":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    ctx.strokeStyle = this[qamode + "_col"].symbol[i];
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 3;
                 this.draw_cross(ctx, num, x, y);
                 break;
@@ -1933,16 +1926,12 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_linesym(ctx, num, x, y, ccolor = "none") {
+    draw_linesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
         ctx.fillStyle = Color.TRANSPARENTBLACK;
-        if (ccolor !== "none") {
-            ctx.strokeStyle = ccolor;
-        } else {
-            ctx.strokeStyle = Color.BLACK;
-        }
+        ctx.strokeStyle = ccolor || Color.BLACK;
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
@@ -2003,7 +1992,7 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_framelinesym(ctx, num, x, y, ccolor = "none") {
+    draw_framelinesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
@@ -2012,7 +2001,7 @@ class Puzzle_hex extends Puzzle {
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
-                set_line_style(ctx, 115, ccolor)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -2021,7 +2010,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.stroke();
                 break;
             case 2:
-                set_line_style(ctx, 15, ccolor)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -2030,7 +2019,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.stroke();
                 break;
             case 3:
-                set_line_style(ctx, 16, ccolor)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -2039,7 +2028,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.stroke();
                 break;
             case 4:
-                set_line_style(ctx, 110, ccolor)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -2048,7 +2037,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.stroke();
                 break;
             case 5:
-                set_line_style(ctx, 115, ccolor)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -2057,7 +2046,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.stroke();
                 break;
             case 6:
-                set_line_style(ctx, 15, ccolor)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -2066,7 +2055,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.stroke();
                 break;
             case 7:
-                set_line_style(ctx, 16, ccolor)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -2075,7 +2064,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.stroke();
                 break;
             case 8:
-                set_line_style(ctx, 110, ccolor)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -2227,7 +2216,7 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_degital_f(ctx, num, x, y, ccolor = "none") {
+    draw_degital_f(ctx, num, x, y, ccolor) {
         set_circle_style(ctx, 3);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.17;
@@ -2297,13 +2286,9 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_pills(ctx, num, x, y, ccolor = "none") {
+    draw_pills(ctx, num, x, y, ccolor) {
         var r = 0.15;
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.GREY;
-        }
+        ctx.fillStyle = ccolor || Color.GREY;
         switch (num) {
             case 1:
                 this.draw_circle(ctx, x, y, r);
@@ -2466,15 +2451,11 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_kakuro(ctx, num, x, y, ccolor = "none") {
+    draw_kakuro(ctx, num, x, y, ccolor) {
         var th = this.rotate_theta(90) * 180 / Math.PI;
         switch (num) {
             case 1:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * 2 / Math.sqrt(3), 6, th);
@@ -2485,11 +2466,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_ast(ctx, x, y, 0.5 * 2 / Math.sqrt(3));
                 break;
             case 2:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * 2 / Math.sqrt(3), 6, th);
@@ -2532,17 +2509,13 @@ class Puzzle_hex extends Puzzle {
     }
 
 
-    draw_compass(ctx, num, x, y, ccolor = "none") {
+    draw_compass(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.5;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * 2 / Math.sqrt(3));
                 break;
@@ -2550,11 +2523,7 @@ class Puzzle_hex extends Puzzle {
                 var r = 0.33;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * 2 / Math.sqrt(3));
                 break;
@@ -2569,7 +2538,7 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_tents(ctx, num, x, y, ccolor = "none") {
+    draw_tents(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r1;
@@ -2595,11 +2564,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY;
-                }
+                ctx.fillStyle = ccolor || Color.GREY;
                 ctx.lineWidth = 1;
                 ctx.beginPath();
                 ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) + 0) * pu.size);
@@ -2617,11 +2582,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY_LIGHT;
-                }
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 1;
                 r1 = 0.3;
                 r2 = 0.4;
@@ -2637,11 +2598,7 @@ class Puzzle_hex extends Puzzle {
             case 3: //anglers
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
                 ctx.lineWidth = 2;
                 ctx.beginPath();
@@ -2661,16 +2618,12 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_star(ctx, num, x, y, ccolor = "none") {
+    draw_star(ctx, num, x, y, ccolor) {
         var r1 = 0.38;
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.WHITE;
-                }
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2678,11 +2631,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 2:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2698,11 +2647,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 4:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.WHITE;
-                }
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2710,11 +2655,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 5:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2730,11 +2671,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 7:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.WHITE;
-                }
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2742,11 +2679,7 @@ class Puzzle_hex extends Puzzle {
                 this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
                 break;
             case 8:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2765,11 +2698,7 @@ class Puzzle_hex extends Puzzle {
                 var r = 0.4;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
@@ -2850,7 +2779,7 @@ class Puzzle_hex extends Puzzle {
         ctx.stroke();
     }
 
-    draw_angleloop(ctx, num, x, y, ccolor = "none") {
+    draw_angleloop(ctx, num, x, y, ccolor) {
         var r;
         switch (num) {
             case 1:
@@ -2861,11 +2790,7 @@ class Puzzle_hex extends Puzzle {
             case 2:
                 r = 0.24;
                 set_circle_style(ctx, 5);
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY;
-                }
+                ctx.fillStyle = ccolor || Color.GREY;
                 this.draw_polygon(ctx, x, y, r, 4, 45);
                 break;
             case 3:
@@ -2883,7 +2808,7 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_firefly(ctx, num, x, y, ccolor = "none") {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.09;
         ctx.setLineDash([]);
@@ -2910,7 +2835,7 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_sun_moon(ctx, num, x, y, ccolor = "none") {
+    draw_sun_moon(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.34;
         switch (num) {
@@ -2937,84 +2862,80 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_pencils(ctx, num, x, y) {
-        var r = 0.2;
-        ctx.setLineDash([]);
-        ctx.lineCap = "butt";
-        ctx.fillStyle = Color.BLACK;
-        ctx.strokeStyle = Color.BLACK;
-        ctx.lineWidth = 2;
-        ctx.lineJoin = "bevel"
-        switch (num) {
-            case 1:
-                ctx.beginPath();
-                ctx.moveTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y - r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + r * pu.size, y + r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-            case 2:
-                ctx.beginPath();
-                ctx.moveTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y + r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - r * pu.size, y + r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-            case 3:
-                ctx.beginPath();
-                ctx.moveTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y + r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - r * pu.size, y - r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-            case 4:
-                ctx.beginPath();
-                ctx.moveTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y - r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + r * pu.size, y - r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-        }
-    }
+    // draw_pencils(ctx, num, x, y) {
+    //     var r = 0.2;
+    //     ctx.setLineDash([]);
+    //     ctx.lineCap = "butt";
+    //     ctx.fillStyle = Color.BLACK;
+    //     ctx.strokeStyle = Color.BLACK;
+    //     ctx.lineWidth = 2;
+    //     ctx.lineJoin = "bevel"
+    //     switch (num) {
+    //         case 1:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + r * pu.size, y - r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + r * pu.size, y + r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //         case 2:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + r * pu.size, y + r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - r * pu.size, y + r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //         case 3:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - r * pu.size, y + r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - r * pu.size, y - r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //         case 4:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - r * pu.size, y - r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + r * pu.size, y - r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //     }
+    // }
 
-    draw_sudokuetc(ctx, num, x, y, ccolor = "none") {
+    draw_sudokuetc(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.14;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY_LIGHT;
-                }
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 this.draw_polygon(ctx, x - r * pu.size, y + r * pu.size, r * Math.sqrt(2), 4, 45);
                 this.draw_polygon(ctx, x + r * pu.size, y - r * pu.size, r * Math.sqrt(2), 4, 45);
                 ctx.fillStyle = Color.GREY_DARK;
@@ -3025,11 +2946,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.GREY_LIGHT;
-                }
+                ctx.strokeStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 4;
                 this.draw_circle(ctx, x, y, 0.71);
                 break;
@@ -3054,11 +2971,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -3082,11 +2995,7 @@ class Puzzle_hex extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -3103,13 +3012,9 @@ class Puzzle_hex extends Puzzle {
         }
     }
 
-    draw_polyomino(ctx, num, x, y, ccolor = "none") {
+    draw_polyomino(ctx, num, x, y, ccolor) {
         ctx.setLineDash([]);
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.GREY_LIGHT;
-        }
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 1.2;
         ctx.lineCap = "butt";
@@ -3120,13 +3025,9 @@ class Puzzle_hex extends Puzzle {
             }
         }
     }
-    draw_polyhex(ctx, num, x, y, ccolor = "none") {
+    draw_polyhex(ctx, num, x, y, ccolor) {
         ctx.setLineDash([]);
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.GREY_LIGHT;
-        }
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 1.2;
         ctx.lineCap = "butt";

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -9139,20 +9139,19 @@ class Puzzle {
             } else {
                 let cc = undefined;
                 if (UserSettings.custom_colors_on) {
-                    // If left click second time (i.e. DG option) and moving or right click and moving
-                    //ML: Why an exception for green (2) ??? 
-                    //if (this.drawing_mode === 2 || this.mouse_click === 2) { 
-                    if (this.mouse_click === 2) {
-                        cc = this.get_rgbcolor(this.drawing_mode);
-                    } else {
+                    // Not right click
+                    if (this.mouse_click !== 2) {
                         cc = this.get_customcolor();
+                        if (!cc || tinycolor.equals(cc, CustomColor.default_surface_style_color(this.drawing_mode))) {
+                            cc = undefined;
+                        }
                     }
                 }
                 if (!this[this.mode.qa].surface[num] || this[this.mode.qa].surface[num] != this.drawing_mode || this[this.mode.qa + "_col"].surface[num] != cc) {
                     this.record("surface", num);
                     this[this.mode.qa].surface[num] = this.drawing_mode;
                     if (UserSettings.custom_colors_on) {
-                        if (!cc || tinycolor.equals(cc, CustomColor.default_surface_style_color(this.drawing_mode))) {
+                        if (!cc) {
                             delete this[this.mode.qa + "_col"].surface[num];
                         } else {
                             this[this.mode.qa + "_col"].surface[num] = cc;

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -163,6 +163,7 @@ class Puzzle {
             ["null", "zO"],
         ];
         this.version = [3, 0, 9]; // Also defined in HTML Script Loading in header tag to avoid Browser Cache Problems
+
         this.undoredo_disable = false;
         this.comp = false;
         this.multisolution = false;
@@ -2300,7 +2301,7 @@ class Puzzle {
             document.getElementById('style_' + mode).style.display = 'inline-block';
         }
         document.getElementById('mo_' + mode).checked = true;
-        this.submode_check('sub_' + mode + this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]);
+        this.submode_check('sub_' + mode + this.mode[this.mode.qa][mode][0]);
         if (mode === "symbol" && !this.panelflag) {
             // Show the panel on the first time landing and then respect user's choice
             if (!UserSettings.panel_shown) {
@@ -2318,19 +2319,19 @@ class Puzzle {
             UserSettings.panel_shown = false;
             document.getElementById('float-key').style.display = "none";
         }
+        const submode = this.mode[this.mode.qa][mode][0];
+        const style = this.mode[this.mode.qa][mode][1];
+        this.stylemode_check('st_' + mode + style);
         if (mode === "symbol") {
-            this.stylemode_check('st_' + mode + this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1] % 10);
-            this.stylemode_check('st_' + mode + parseInt(this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1] / 10) * 10);
-        } else {
-            this.stylemode_check('st_' + mode + this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1]);
+            this.subsymbolmode(submode);
+        } else if (mode === "combi") {
+            this.subcombimode(submode);
         }
-        if (this.mode[this.mode.qa].edit_mode === "symbol") {
-            this.subsymbolmode(this.mode[this.mode.qa].symbol[0]);
-        } else if (this.mode[this.mode.qa].edit_mode === "combi") {
-            this.subcombimode(this.mode[this.mode.qa].combi[0]);
-        }
-        if ((UserSettings.custom_colors_on) && ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex")) &&
-            (mode === "line" || mode === "lineE" || mode === "wall" || mode === "surface" || mode === "cage" || mode === "special" || mode === "symbol")) {
+        if (UserSettings.custom_colors_on && penpa_modes[this.gridtype].customcolor.includes(mode)) {
+            let cc = this.mode[this.mode.qa][mode][2];
+            if (cc) {
+                $("#colorpicker_special").spectrum("set", cc); 
+            }
             document.getElementById('style_special').style.display = 'inline';
         } else {
             document.getElementById('style_special').style.display = 'none';
@@ -2363,31 +2364,14 @@ class Puzzle {
                 let enableLoadButton = (!isNumberS && pu[pu.mode.qa].number[pu.cursol]) || (isNumberS && pu[pu.mode.qa].numberS[pu.cursolS]);
                 document.getElementById("closeBtn_input3").disabled = !enableLoadButton;
             }
-
             this.redraw(); // Board cursor update
         }
         this.type = this.type_set(); // Coordinate type to select
         if (UserSettings.custom_colors_on) {
             // set the custom color to default
-            switch (name) {
-                case "sub_specialthermo":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_LIGHT);
-                    break;
-                case "sub_specialnobulbthermo":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_LIGHT);
-                    break;
-                case "sub_specialarrows":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK_LIGHT);
-                    break;
-                case "sub_specialdirection":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK_LIGHT);
-                    break;
-                case "sub_specialsquareframe":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_LIGHT);
-                    break;
-                case "sub_specialpolygon":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
+            let cc = CustomColor.default_specialmode_color(name);
+            if (cc) {
+                $("#colorpicker_special").spectrum("set", cc);
             }
         }
     }
@@ -2406,142 +2390,9 @@ class Puzzle {
 
         if (UserSettings.custom_colors_on) {
             // set the custom color to default
-            switch (name) {
-                case "st_surface1":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK_VERY);
-                    break;
-                case "st_surface8":
-                    $("#colorpicker_special").spectrum("set", Color.GREY);
-                    break;
-                case "st_surface3":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_LIGHT);
-                    break;
-                case "st_surface4":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_surface2":
-                    $("#colorpicker_special").spectrum("set", Color.GREEN_LIGHT_VERY);
-                    break;
-                case "st_surface5":
-                    $("#colorpicker_special").spectrum("set", Color.BLUE_LIGHT_VERY);
-                    break;
-                case "st_surface6":
-                    $("#colorpicker_special").spectrum("set", Color.RED_LIGHT);
-                    break;
-                case "st_surface7":
-                    $("#colorpicker_special").spectrum("set", Color.YELLOW);
-                    break;
-                case "st_surface9":
-                    $("#colorpicker_special").spectrum("set", Color.PINK_LIGHT);
-                    break;
-                case "st_surface10":
-                    $("#colorpicker_special").spectrum("set", Color.ORANGE_LIGHT);
-                    break;
-                case "st_surface11":
-                    $("#colorpicker_special").spectrum("set", Color.PURPLE_LIGHT);
-                    break;
-                case "st_surface12":
-                    $("#colorpicker_special").spectrum("set", Color.BROWN_LIGHT);
-                    break;
-                case "st_line3":
-                    $("#colorpicker_special").spectrum("set", Color.GREEN);
-                    break;
-                case "st_line2":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_line5":
-                    $("#colorpicker_special").spectrum("set", Color.GREY);
-                    break;
-                case "st_line8":
-                    $("#colorpicker_special").spectrum("set", Color.RED);
-                    break;
-                case "st_line9":
-                    $("#colorpicker_special").spectrum("set", Color.BLUE_LIGHT);
-                    break;
-                case "st_line80":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_line12":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK_VERY);
-                    break;
-                case "st_line13":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_line40":
-                    $("#colorpicker_special").spectrum("set", Color.GREY);
-                    break;
-                case "st_line30":
-                    $("#colorpicker_special").spectrum("set", Color.GREEN);
-                    break;
-                case "st_lineE3":
-                    $("#colorpicker_special").spectrum("set", Color.GREEN);
-                    break;
-                case "st_lineE2":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_lineE5":
-                    $("#colorpicker_special").spectrum("set", Color.GREY);
-                    break;
-                case "st_lineE8":
-                    $("#colorpicker_special").spectrum("set", Color.RED);
-                    break;
-                case "st_lineE9":
-                    $("#colorpicker_special").spectrum("set", Color.BLUE_LIGHT);
-                    break;
-                case "st_lineE21":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_lineE80":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_lineE12":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK_VERY);
-                    break;
-                case "st_lineE13":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_lineE30":
-                    $("#colorpicker_special").spectrum("set", Color.GREEN);
-                    break;
-                case "st_wall3":
-                    $("#colorpicker_special").spectrum("set", Color.GREEN);
-                    break;
-                case "st_wall2":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_wall5":
-                    $("#colorpicker_special").spectrum("set", Color.GREY);
-                    break;
-                case "st_wall8":
-                    $("#colorpicker_special").spectrum("set", Color.RED);
-                    break;
-                case "st_wall9":
-                    $("#colorpicker_special").spectrum("set", Color.BLUE_LIGHT);
-                    break;
-                case "st_wall1":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_wall12":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK_VERY);
-                    break;
-                case "st_wall17":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_wall14":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK);
-                    break;
-                case "st_cage10":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
-                case "st_cage7":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK);
-                    break;
-                case "st_cage15":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK);
-                    break;
-                case "st_cage16":
-                    $("#colorpicker_special").spectrum("set", Color.BLACK);
-                    break;
+            let cc = CustomColor.default_stylemode_color(name);
+            if (cc) {
+                $("#colorpicker_special").spectrum("set", cc);
             }
         }
     }
@@ -2551,66 +2402,8 @@ class Puzzle {
         document.getElementById("symmode_content").innerHTML = mode;
         if (UserSettings.custom_colors_on) {
             // set the custom color to default
-            switch ("ms_" + mode) {
-                case "ms_circle_L":
-                case "ms_circle_M":
-                case "ms_circle_S":
-                case "ms_circle_SS":
-                case "ms_square_LL":
-                case "ms_square_L":
-                case "ms_square_M":
-                case "ms_square_S":
-                case "ms_square_SS":
-                case "ms_triup_L":
-                case "ms_triup_M":
-                case "ms_triup_S":
-                case "ms_triup_SS":
-                case "ms_tridown_L":
-                case "ms_tridown_M":
-                case "ms_tridown_S":
-                case "ms_tridown_SS":
-                case "ms_triright_L":
-                case "ms_triright_M":
-                case "ms_triright_S":
-                case "ms_triright_SS":
-                case "ms_trileft_L":
-                case "ms_trileft_M":
-                case "ms_trileft_S":
-                case "ms_trileft_SS":
-                case "ms_diamond_L":
-                case "ms_diamond_M":
-                case "ms_diamond_S":
-                case "ms_diamond_SS":
-                case "ms_hexpoint_LL":
-                case "ms_hexpoint_L":
-                case "ms_hexpoint_M":
-                case "ms_hexpoint_S":
-                case "ms_hexpoint_SS":
-                case "ms_hexflat_LL":
-                case "ms_hexflat_L":
-                case "ms_hexflat_M":
-                case "ms_hexflat_S":
-                case "ms_hexflat_SS":
-                case "ms_star":
-                case "ms_firefly":
-                case "ms_sun_moon":
-                case "ms_slovak":
-                    $("#colorpicker_special").spectrum("set", Color.WHITE);
-                    break;
-                case "ms_frameline":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_DARK);
-                    break;
-                case "ms_pills":
-                case "ms_tents":
-                    $("#colorpicker_special").spectrum("set", Color.GREY);
-                    break;
-                case "ms_sudokuetc":
-                case "ms_polyomino":
-                case "ms_polyhex":
-                case "ms_neighbors":
-                    $("#colorpicker_special").spectrum("set", Color.GREY_LIGHT);
-                    break;
-            }
+            let cc = CustomColor.default_symbol_color(mode);
+            $("#colorpicker_special").spectrum("set", cc);
         }
         panel_pu.draw_panel();
         this.redraw();
@@ -2621,19 +2414,8 @@ class Puzzle {
         document.getElementById("combimode_content").innerHTML = mode;
         if (UserSettings.custom_colors_on) {
             // set the custom color to default
-            switch (mode) {
-                case "linex":
-                case "lineox":
-                case "edgex":
-                case "edgexoi":
-                case "yajilin":
-                case "hashi":
-                    $("#colorpicker_special").spectrum("set", Color.GREEN);
-                    break;
-                case "edgesub":
-                    $("#colorpicker_special").spectrum("set", Color.GREY);
-                    break;
-            }
+            let cc = CustomColor.default_combimode_color(mode);
+            $("#colorpicker_special").spectrum("set", cc);
         }
         this.type = this.type_set();
         this.redraw();
@@ -8203,18 +7985,14 @@ class Puzzle {
                 if (this.pu_q[arr][num]) {
                     if (groupcounter === 0) {
                         this.pu_q.command_undo.push([arr, num, JSON.stringify(this.pu_q[arr][num]), this.mode.qa]); // Array is also recorded in JSON
-                        if ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex") &&
-                            (arr === "thermo" || arr === "arrows" || arr === "direction" || arr === "squareframe" || arr === "surface" || arr === "wall" || arr === "symbol" ||
-                                arr === "line" || arr === "lineE" || arr === "polygon" || arr === "freeline" || arr === "freelineE" || arr === "cage" || arr === "killercages")) { // Update this as more support for custom colors are added
+                        if (penpa_modes[this.gridtype].customcolor.includes(penpa_modes_map[arr])) {
                             this.pu_q_col.command_undo.push([arr, num, JSON.stringify(this.pu_q_col[arr][num]), this.mode.qa + "_col"]); // Array is also recorded in JSON
                         } else {
                             this.pu_q_col.command_undo.push([arr, num, JSON.stringify(this.pu_q[arr][num]), this.mode.qa + "_col"]); // Array is also recorded in JSON
                         }
                     } else {
                         this.pu_q.command_undo.push([arr, num, JSON.stringify(this.pu_q[arr][num]), this.mode.qa, groupcounter]); // Array is also recorded in JSON
-                        if ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex") &&
-                            (arr === "thermo" || arr === "arrows" || arr === "direction" || arr === "squareframe" || arr === "surface" || arr === "wall" || arr === "symbol" ||
-                                arr === "line" || arr === "lineE" || arr === "polygon" || arr === "freeline" || arr === "freelineE" || arr === "cage" || arr === "killercages")) { // Update this as more support for custom colors are added
+                        if (penpa_modes[this.gridtype].customcolor.includes(penpa_modes_map[arr])) {
                             this.pu_q_col.command_undo.push([arr, num, JSON.stringify(this.pu_q_col[arr][num]), this.mode.qa + "_col", groupcounter]); // Array is also recorded in JSON
                         } else {
                             this.pu_q_col.command_undo.push([arr, num, JSON.stringify(this.pu_q[arr][num]), this.mode.qa + "_col", groupcounter]); // Array is also recorded in JSON
@@ -8252,9 +8030,7 @@ class Puzzle {
             } else {
                 if (this.pu_a[arr][num]) {
                     this.pu_a.command_undo.push([arr, num, JSON.stringify(this.pu_a[arr][num]), this.mode.qa, groupcounter, timestamp]); // Array is also recorded in JSON
-                    if ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex") &&
-                        (arr === "thermo" || arr === "arrows" || arr === "direction" || arr === "squareframe" || arr === "surface" || arr === "wall" || arr === "symbol" ||
-                            arr === "line" || arr === "lineE" || arr === "polygon" || arr === "freeline" || arr === "freelineE" || arr === "cage" || arr === "killercages")) { // Update this as more support for custom colors are added
+                    if (penpa_modes[this.gridtype].customcolor.includes(penpa_modes_map[arr])) {
                         this.pu_a_col.command_undo.push([arr, num, JSON.stringify(this.pu_a_col[arr][num]), this.mode.qa + "_col", groupcounter]); // Array is also recorded in JSON
                     } else {
                         this.pu_a_col.command_undo.push([arr, num, JSON.stringify(this.pu_a[arr][num]), this.mode.qa + "_col", groupcounter]); // Array is also recorded in JSON
@@ -8293,9 +8069,7 @@ class Puzzle {
             } else {
                 if (this.pu_a[arr][num]) {
                     this.pu_a.command_replay.push([arr, num, structuredClone(this.pu_a[arr][num]), this.mode.qa, groupcounter, timestamp]); // Array is also recorded in JSON
-                    if ((this.gridtype === "square" || this.gridtype === "sudoku" || this.gridtype === "kakuro" || this.gridtype === "hex") &&
-                        (arr === "thermo" || arr === "arrows" || arr === "direction" || arr === "squareframe" || arr === "surface" || arr === "wall" || arr === "symbol" ||
-                            arr === "line" || arr === "lineE" || arr === "polygon" || arr === "freeline" || arr === "freelineE" || arr === "cage" || arr === "killercages")) { // Update this as more support for custom colors are added
+                    if (penpa_modes[this.gridtype].customcolor.includes(penpa_modes_map[arr])) {
                         this.pu_a_col.command_replay.push([arr, num, structuredClone(this.pu_a_col[arr][num]), this.mode.qa + "_col", groupcounter]); // Array is also recorded in JSON
                     } else {
                         this.pu_a_col.command_replay.push([arr, num, structuredClone(this.pu_a[arr][num]), this.mode.qa + "_col", groupcounter]); // Array is also recorded in JSON
@@ -8511,8 +8285,9 @@ class Puzzle {
             }
         } else if (this.mode[this.mode.qa].edit_mode === "symbol") {
             if (str_num.indexOf(key) != -1) {
+                const symbolname = this.mode[this.mode.qa].symbol[0];
                 if (this[this.mode.qa].symbol[this.cursol]) {
-                    if (this[this.mode.qa].symbol[this.cursol][0] === parseInt(key, 10) && this[this.mode.qa].symbol[this.cursol][1] === this.mode[this.mode.qa].symbol[0]) {
+                    if (this[this.mode.qa].symbol[this.cursol][0] === parseInt(key, 10) && this[this.mode.qa].symbol[this.cursol][1] === symbolname) {
                         this.key_space(); // Delete if the contents are the same
                         return;
                     } else {
@@ -8523,14 +8298,19 @@ class Puzzle {
                 }
                 this.record("symbol", this.cursol);
 
-                if (this.onoff_symbolmode_list[this.mode[this.mode.qa].symbol[0]]) { // List in ON-OFF mode
-                    number = this.onofftext(this.onoff_symbolmode_list[this.mode[this.mode.qa].symbol[0]], key, con);
+                if (this.onoff_symbolmode_list[symbolname]) { // List in ON-OFF mode
+                    number = this.onofftext(this.onoff_symbolmode_list[symbolname], key, con);
                 } else {
                     number = parseInt(key, 10);
                 }
-                this[this.mode.qa].symbol[this.cursol] = [number, this.mode[this.mode.qa].symbol[0], this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1]];
+                this[this.mode.qa].symbol[this.cursol] = [number, symbolname, this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1]];
                 if (UserSettings.custom_colors_on) {
-                    this[this.mode.qa + "_col"].symbol[this.cursol] = this.get_customcolor();
+                    let cc = this.get_customcolor();
+                    if (!cc || tinycolor.equals(cc, CustomColor.default_symbol_color(symbolname))) {
+                        delete this[this.mode.qa + "_col"].symbol[this.cursol];
+                    } else {
+                        this[this.mode.qa + "_col"].symbol[this.cursol] = cc;
+                    }
                 }
                 this.record_replay("symbol", this.cursol);
             }
@@ -9264,7 +9044,12 @@ class Puzzle {
         if (this[this.mode.qa].surface[num] && this[this.mode.qa].surface[num] === color && allowed_styles.includes(color)) {
             this[this.mode.qa].surface[num] = rightclick_color;
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(rightclick_color);
+                let cc = this.get_rgbcolor(rightclick_color);
+                if (!cc || tinycolor.equals(cc, CustomColor.default_surface_color(rightclick_color))) {
+                    delete this[this.mode.qa + "_col"].surface[num];
+                } else {
+                    this[this.mode.qa + "_col"].surface[num] = cc;
+                }
             }
             this.drawing_mode = rightclick_color;
         } else if (this[this.mode.qa].surface[num] && (this[this.mode.qa].surface[num] === color || (this[this.mode.qa].surface[num] === rightclick_color && allowed_styles.includes(color)))) {
@@ -9276,7 +9061,12 @@ class Puzzle {
         } else {
             this[this.mode.qa].surface[num] = color;
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"].surface[num] = this.get_customcolor();
+                let cc = this.get_customcolor();
+                if (!cc || tinycolor.equals(cc, CustomColor.default_surface_color(color))) {
+                    delete this[this.mode.qa + "_col"].surface[num];
+                } else {
+                    this[this.mode.qa + "_col"].surface[num] = cc;
+                }
             }
             this.drawing_mode = color;
         }
@@ -9296,7 +9086,12 @@ class Puzzle {
         } else {
             this[this.mode.qa].surface[num] = color;
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"].surface[num] = this.get_customcolor();
+                let cc = this.get_customcolor();
+                if (!cc || tinycolor.equals(cc, CustomColor.default_surface_style_color(color))) {
+                    delete this[this.mode.qa + "_col"].surface[num];
+                } else {
+                    this[this.mode.qa + "_col"].surface[num] = cc;
+                }
             }
             this.drawing_mode = color;
         }
@@ -9316,7 +9111,12 @@ class Puzzle {
         } else {
             this[this.mode.qa].surface[num] = rightclick_color;
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(rightclick_color);
+                let cc = this.get_rgbcolor(rightclick_color);
+                if (!cc || tinycolor.equals(cc, CustomColor.default_surface_style_color(rightclick_color))) {
+                    delete this[this.mode.qa + "_col"].surface[num];
+                } else {
+                    this[this.mode.qa + "_col"].surface[num] = cc;
+                }
             }
             this.drawing_mode = rightclick_color;
         }
@@ -9340,7 +9140,9 @@ class Puzzle {
                 let cc = undefined;
                 if (UserSettings.custom_colors_on) {
                     // If left click second time (i.e. DG option) and moving or right click and moving
-                    if (this.drawing_mode === 2 || this.mouse_click === 2) {
+                    //ML: Why an exception for green (2) ??? 
+                    //if (this.drawing_mode === 2 || this.mouse_click === 2) { 
+                    if (this.mouse_click === 2) {
                         cc = this.get_rgbcolor(this.drawing_mode);
                     } else {
                         cc = this.get_customcolor();
@@ -9350,7 +9152,11 @@ class Puzzle {
                     this.record("surface", num);
                     this[this.mode.qa].surface[num] = this.drawing_mode;
                     if (UserSettings.custom_colors_on) {
-                        this[this.mode.qa + "_col"].surface[num] = cc;
+                        if (!cc || tinycolor.equals(cc, CustomColor.default_surface_style_color(this.drawing_mode))) {
+                            delete this[this.mode.qa + "_col"].surface[num];
+                        } else {
+                            this[this.mode.qa + "_col"].surface[num] = cc;
+                        }
                     }
                     this.record_replay("surface", num);
                     this.redraw();
@@ -9436,9 +9242,6 @@ class Puzzle {
                 }
                 if (array === "deletelineE") {
                     delete this["pu_q"][array][num];
-                    if (UserSettings.custom_colors_on) {
-                        delete this["pu_q_col"][array][num];
-                    }
                 } else {
                     delete this[this.mode.qa][array][num];
                     if (UserSettings.custom_colors_on) {
@@ -9457,9 +9260,6 @@ class Puzzle {
                 this.record(array, num);
                 if (array === "deletelineE") {
                     delete this["pu_q"][array][num];
-                    if (UserSettings.custom_colors_on) {
-                        delete this["pu_q_col"][array][num];
-                    }
                 } else {
                     delete this[this.mode.qa][array][num];
                     if (UserSettings.custom_colors_on) {
@@ -9477,13 +9277,15 @@ class Puzzle {
                 }
                 if (array === "deletelineE") {
                     this["pu_q"][array][num] = line_style;
-                    if (UserSettings.custom_colors_on) {
-                        this["pu_q_col"][array][num] = this.get_customcolor();
-                    }
                 } else {
                     this[this.mode.qa][array][num] = line_style;
                     if (UserSettings.custom_colors_on) {
-                        this[this.mode.qa + "_col"][array][num] = this.get_customcolor();
+                        let cc = this.get_customcolor();
+                        if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(line_style))) {
+                            delete this[this.mode.qa + "_col"][array][num];
+                        } else {
+                            this[this.mode.qa + "_col"][array][num] = cc;
+                        }
                     }
                 }
                 if (group_counter > 0) {
@@ -9498,13 +9300,15 @@ class Puzzle {
                 this.record(array, num);
                 if (array === "deletelineE") {
                     this["pu_q"][array][num] = line_style;
-                    if (UserSettings.custom_colors_on) {
-                        this["pu_q_col"][array][num] = this.get_customcolor();
-                    }
                 } else {
                     this[this.mode.qa][array][num] = line_style;
                     if (UserSettings.custom_colors_on) {
-                        this[this.mode.qa + "_col"][array][num] = this.get_customcolor();
+                        let cc = this.get_customcolor();
+                        if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(line_style))) {
+                            delete this[this.mode.qa + "_col"][array][num];
+                        } else {
+                            this[this.mode.qa + "_col"][array][num] = cc;
+                        }
                     }
                 }
                 this.record_replay(array, num);
@@ -9579,7 +9383,12 @@ class Puzzle {
             } else {
                 this[this.mode.qa].freeline[key] = this.drawing_mode;
                 if (UserSettings.custom_colors_on) {
-                    this[this.mode.qa + "_col"].freeline[key] = this.get_customcolor();
+                    let cc = this.get_customcolor();
+                    if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(this.drawing_mode))) {
+                        delete this[this.mode.qa + "_col"].freeline[key];
+                    } else {
+                        this[this.mode.qa + "_col"].freeline[key] = cc;
+                    }
                 }
             }
             this.record_replay("freeline", key);
@@ -9604,7 +9413,12 @@ class Puzzle {
             this.record("line", num);
             this[this.mode.qa].line[num] = 98;
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"].line[num] = this.get_customcolor();
+                let cc = this.get_customcolor();
+                if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(98))) {
+                    delete this[this.mode.qa + "_col"].line[num];
+                } else {
+                    this[this.mode.qa + "_col"].line[num] = cc;
+                }
             }
             this.record_replay("line", num);
         }
@@ -9703,7 +9517,13 @@ class Puzzle {
             } else {
                 this[this.mode.qa].freelineE[key] = this.drawing_mode;
                 if (UserSettings.custom_colors_on) {
-                    this[this.mode.qa + "_col"].freelineE[key] = this.get_customcolor();
+                    let cc = this.get_customcolor();
+                    if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(this.drawing_mode))) {
+                        delete this[this.mode.qa + "_col"].freelineE[key];
+                    } else {
+                        this[this.mode.qa + "_col"].freelineE[key] = cc;
+                    }
+
                 }
             }
             this.record_replay("freelineE", key);
@@ -9728,7 +9548,12 @@ class Puzzle {
             this.record("lineE", num);
             this[this.mode.qa].lineE[num] = 98;
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"].lineE[num] = this.get_customcolor();
+                let cc = this.get_customcolor();
+                if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(98))) {
+                    delete this[this.mode.qa + "_col"].lineE[num];
+                } else {
+                    this[this.mode.qa + "_col"].lineE[num] = cc;
+                }
             }
             this.record_replay("lineE", num);
         }
@@ -10494,7 +10319,13 @@ class Puzzle {
         }
         if (this[this.mode.qa][arr].slice(-1)[0] && this[this.mode.qa][arr].slice(-1)[0].length > 1) {
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1] = this.get_customcolor();
+                let cc = this.get_customcolor();
+                let cc_idx = this[this.mode.qa][arr].length - 1;
+                if (!cc || tinycolor.equals(cc, CustomColor.default_special_style_color(arr))) {
+                    delete this[this.mode.qa + "_col"][arr][cc_idx];
+                } else {
+                    this[this.mode.qa + "_col"][arr][cc_idx] = cc;
+                }
             }
         }
         this.redraw();
@@ -10537,7 +10368,13 @@ class Puzzle {
         if (this.drawing) {
             this[this.mode.qa][arr].slice(-1)[0][this[this.mode.qa][arr].slice(-1)[0].length - 1] = num;
             if (UserSettings.custom_colors_on) {
-                this[this.mode.qa + "_col"][arr][this[this.mode.qa][arr].length - 1] = this.get_customcolor();
+                let cc = this.get_customcolor();
+                let cc_idx = this[this.mode.qa][arr].length - 1;
+                if (!cc || tinycolor.equals(cc, CustomColor.default_special_style_color(arr))) {
+                    delete this[this.mode.qa + "_col"][arr][cc_idx];
+                } else {
+                    this[this.mode.qa + "_col"][arr][cc_idx] = cc;
+                }
             }
         }
         this.redraw();
@@ -13259,6 +13096,7 @@ class Puzzle {
 
     get_customcolor() {
         let customcolor = $("#colorpicker_special").spectrum("get");
+        if (!customcolor) return customcolor;
         return "rgba(" + Math.round(customcolor._r) + "," + Math.round(customcolor._g) + "," + Math.round(customcolor._b) + "," + customcolor._a + ")";
     }
 
@@ -13304,6 +13142,13 @@ class Puzzle {
                 return false;
             }
         }
+    }
+
+    update_customcolor(color) {
+        const mode = this.mode[this.mode.qa].edit_mode;
+        this.mode[this.mode.qa][mode][2] = color;
+
+        panel_pu.draw_panel();
     }
 
     version_lt(major, minor, revision) {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12545,6 +12545,40 @@ class Puzzle {
         }
     }
 
+    draw_surface(pu, num = "") {
+        if (num) {
+            var keys = [],
+                key0 = num + "";
+            if (this[pu].surface[key0]) {
+                keys.push(key0);
+            }
+            for (var i = 0; i < this.point[num].adjacent.length; i++) {
+                key0 = this.point[num].adjacent[i] + "";
+                if (keys.indexOf(key0) === -1 && this[pu].surface[key0]) {
+                    keys.push(key0);
+                }
+            }
+        } else {
+            var keys = Object.keys(this[pu].surface);
+        }
+        for (var k = 0; k < keys.length; k++) {
+            var i = keys[k];
+            set_surface_style(this.ctx, this[pu].surface[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].surface[i]) {
+                this.ctx.fillStyle = this[pu + "_col"].surface[i];
+                this.ctx.strokeStyle = this.ctx.fillStyle;
+            }
+            this.ctx.beginPath();
+            this.ctx.moveTo(this.point[this.point[i].surround[0]].x, this.point[this.point[i].surround[0]].y);
+            for (var j = 1; j < this.point[i].surround.length; j++) {
+                this.ctx.lineTo(this.point[this.point[i].surround[j]].x, this.point[this.point[i].surround[j]].y);
+            }
+            this.ctx.closePath();
+            this.ctx.fill();
+            this.ctx.stroke();
+        }
+    }
+
     draw_freecircle() {
         /*free_circle*/
         if (((this.mode[this.mode.qa].edit_mode === "line" || this.mode[this.mode.qa].edit_mode === "lineE") && this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") || this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -9337,16 +9337,20 @@ class Puzzle {
                     this.redraw();
                 }
             } else {
-                if (!this[this.mode.qa].surface[num] || this[this.mode.qa].surface[num] != this.drawing_mode) {
+                let cc = undefined;
+                if (UserSettings.custom_colors_on) {
+                    // If left click second time (i.e. DG option) and moving or right click and moving
+                    if (this.drawing_mode === 2 || this.mouse_click === 2) {
+                        cc = this.get_rgbcolor(this.drawing_mode);
+                    } else {
+                        cc = this.get_customcolor();
+                    }
+                }
+                if (!this[this.mode.qa].surface[num] || this[this.mode.qa].surface[num] != this.drawing_mode || this[this.mode.qa + "_col"].surface[num] != cc) {
                     this.record("surface", num);
                     this[this.mode.qa].surface[num] = this.drawing_mode;
                     if (UserSettings.custom_colors_on) {
-                        // If left click second time (i.e. DG option) and moving or right click and moving
-                        if (this.drawing_mode === 2 || this.mouse_click === 2) {
-                            this[this.mode.qa + "_col"].surface[num] = this.get_rgbcolor(this.drawing_mode);
-                        } else {
-                            this[this.mode.qa + "_col"].surface[num] = this.get_customcolor();
-                        }
+                        this[this.mode.qa + "_col"].surface[num] = cc;
                     }
                     this.record_replay("surface", num);
                     this.redraw();

--- a/docs/js/class_panel.js
+++ b/docs/js/class_panel.js
@@ -283,19 +283,30 @@ class Panel {
             i = 11;
             this.ctxf.fillRect((i % this.nxf) * (this.sizef + this.spacef), (i / this.nxf | 0) * (this.sizef + this.spacef), this.sizef, this.sizef);
 
-            if (pu.onoff_symbolmode_list[pu.mode[pu.mode.qa].symbol[0]]) {
-                this.cont = this.makecont(pu.onoff_symbolmode_list[pu.mode[pu.mode.qa].symbol[0]]);
+            const symbolname = pu.mode[pu.mode.qa].symbol[0];
+            if (pu.onoff_symbolmode_list[symbolname]) {
+                this.cont = this.makecont(pu.onoff_symbolmode_list[symbolname]);
             } else {
                 this.cont = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, " "];
             }
             var size = pu.size;
             pu.size = this.sizef;
+            pu.panel_col = {symbol: {}};
+            if (UserSettings.custom_colors_on) {
+                let cc = pu.get_customcolor();
+                if (cc && !tinycolor.equals(cc, CustomColor.default_symbol_color(symbolname))) {
+                    pu.panel_col.symbol[0] = cc;
+                }
+            }
             for (var i = 0; i < this.cont.length; i++) {
-                pu.draw_symbol_select(this.ctxf, (i % this.nxf + this.offset) * (this.sizef + this.spacef), ((i / this.nxf | 0) + this.offset) * (this.sizef + this.spacef), this.cont[i], pu.mode[pu.mode.qa].symbol[0]);
+                pu.draw_symbol_select(this.ctxf,
+                     (i % this.nxf + this.offset) * (this.sizef + this.spacef),
+                     ((i / this.nxf | 0) + this.offset) * (this.sizef + this.spacef),
+                     this.cont[i], symbolname, 0, 'panel');
             }
             pu.size = size;
 
-            if (!pu.onoff_symbolmode_list[pu.mode[pu.mode.qa].symbol[0]]) { //onoffモードでなければ赤カーソル
+            if (!pu.onoff_symbolmode_list[symbolname]) { //onoffモードでなければ赤カーソル
                 var i_n
                 if (this.edit_num >= 0 && this.edit_num <= 11 && this.edit_num != 10) {
                     i_n = this.edit_num;

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -525,21 +525,6 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-
-    draw_surface(pu) {
-        for (var i in this[pu].surface) {
-            set_surface_style(this.ctx, this[pu].surface[i]);
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.point[this.point[i].surround[0]].x, this.point[this.point[i].surround[0]].y);
-            for (var j = 1; j < this.point[i].surround.length; j++) {
-                this.ctx.lineTo(this.point[this.point[i].surround[j]].x, this.point[this.point[i].surround[j]].y);
-            }
-            this.ctx.closePath();
-            this.ctx.fill();
-            this.ctx.stroke();
-        }
-    }
-
     draw_polygon(ctx, x, y, r, n, th) {
         ctx.LineCap = "round";
         ctx.beginPath();
@@ -558,7 +543,11 @@ class Puzzle_pyramid extends Puzzle {
             if (this[pu].squareframe[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].squareframe[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].squareframe[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_LIGHT;
+                }
                 this.ctx.lineWidth = this.size * 0.8;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].squareframe[i][0]].x, this.point[this[pu].squareframe[i][0]].y);
@@ -574,11 +563,19 @@ class Puzzle_pyramid extends Puzzle {
         for (var i = 0; i < this[pu].thermo.length; i++) {
             if (this[pu].thermo[i][0]) {
                 this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                this.ctx.fillStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
+                    this.ctx.fillStyle = this[pu + "_col"].thermo[i];
+                } else {
+                    this.ctx.fillStyle = Color.GREY_LIGHT;
+                }
                 this.draw_circle(this.ctx, this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y, 0.4);
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].thermo[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_LIGHT;
+                }
                 this.ctx.lineWidth = this.size * 0.4;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y);
@@ -595,10 +592,18 @@ class Puzzle_pyramid extends Puzzle {
             for (var i = 0; i < this[pu].nobulbthermo.length; i++) {
                 if (this[pu].nobulbthermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    this.ctx.fillStyle = Color.GREY_LIGHT;
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
+                        this.ctx.fillStyle = this[pu + "_col"].nobulbthermo[i];
+                    } else {
+                        this.ctx.fillStyle = Color.GREY_LIGHT;
+                    }
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    this.ctx.strokeStyle = Color.GREY_LIGHT;
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
+                        this.ctx.strokeStyle = this[pu + "_col"].nobulbthermo[i];
+                    } else {
+                        this.ctx.strokeStyle = Color.GREY_LIGHT;
+                    }
                     this.ctx.lineWidth = this.size * 0.4;
                     this.ctx.beginPath();
                     this.ctx.moveTo(this.point[this[pu].nobulbthermo[i][0]].x, this.point[this[pu].nobulbthermo[i][0]].y);
@@ -616,7 +621,11 @@ class Puzzle_pyramid extends Puzzle {
             if (this[pu].arrows[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
                 this.ctx.lineWidth = 3;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].arrows[i][0]].x, this.point[this[pu].arrows[i][0]].y);
@@ -634,7 +643,11 @@ class Puzzle_pyramid extends Puzzle {
                 this.ctx.stroke();
                 this.ctx.setLineDash([]);
                 this.ctx.lineJoin = "miter";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
                 this.ctx.fillStyle = Color.WHITE;
                 this.ctx.lineWidth = 3;
 
@@ -648,7 +661,11 @@ class Puzzle_pyramid extends Puzzle {
             if (this[pu].direction[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].direction[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].direction[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
                 this.ctx.lineWidth = 3;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].direction[i][0]].x, this.point[this[pu].direction[i][0]].y);
@@ -676,6 +693,9 @@ class Puzzle_pyramid extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -686,6 +706,9 @@ class Puzzle_pyramid extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 this.ctx.beginPath();
@@ -720,6 +743,9 @@ class Puzzle_pyramid extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -730,6 +756,9 @@ class Puzzle_pyramid extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 this.ctx.beginPath();
@@ -756,6 +785,9 @@ class Puzzle_pyramid extends Puzzle {
         /*freeline*/
         for (var i in this[pu].freeline) {
             set_line_style(this.ctx, this[pu].freeline[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
+            }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
             this.ctx.beginPath();
@@ -777,6 +809,9 @@ class Puzzle_pyramid extends Puzzle {
         }
         for (var i in this[pu].freelineE) {
             set_line_style(this.ctx, this[pu].freelineE[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
+            }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
             this.ctx.beginPath();
@@ -801,6 +836,9 @@ class Puzzle_pyramid extends Puzzle {
     draw_wall(pu) {
         for (var i in this[pu].wall) {
             set_line_style(this.ctx, this[pu].wall[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].wall[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].wall[i];
+            }
             this.ctx.lineCap = "butt";
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
@@ -816,7 +854,7 @@ class Puzzle_pyramid extends Puzzle {
         /*symbol_layer*/
         for (var i in this[pu].symbol) {
             if (this[pu].symbol[i][2] === layer) {
-                this.draw_symbol_select(this.ctx, this.point[i].x, this.point[i].y, this[pu].symbol[i][0], this[pu].symbol[i][1]);
+                this.draw_symbol_select(this.ctx, this.point[i].x, this.point[i].y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
             }
         }
     }
@@ -1067,7 +1105,15 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_symbol_select(ctx, x, y, num, sym) {
+    draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
+        let ccolor = undefined;
+        if (i !== 'panel' && UserSettings.custom_colors_on && this[qamode + "_col"].symbol[i]) {
+            ccolor = this[qamode + "_col"].symbol[i];
+        }
+        this.draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor);
+    }
+
+    draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor) {
         switch (sym) {
             /* figure */
             case "circle_L":
@@ -1076,7 +1122,7 @@ class Puzzle_pyramid extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.43);
                     this.draw_circle(ctx, x, y, 0.32);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.43);
                 }
                 break;
@@ -1086,7 +1132,7 @@ class Puzzle_pyramid extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.35);
                     this.draw_circle(ctx, x, y, 0.25);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.35);
                 }
                 break;
@@ -1096,7 +1142,7 @@ class Puzzle_pyramid extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.22);
                     this.draw_circle(ctx, x, y, 0.14);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.22);
                 }
                 break;
@@ -1106,115 +1152,115 @@ class Puzzle_pyramid extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.11);
                     this.draw_circle(ctx, x, y, 0.06);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.11);
                 }
                 break;
             case "square_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, 45);
                 break;
             case "square_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4 * Math.sqrt(2), 4, 45);
                 break;
             case "square_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.35 * Math.sqrt(2), 4, 45);
                 break;
             case "square_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.22 * Math.sqrt(2), 4, 45);
                 break;
             case "square_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.11 * Math.sqrt(2), 4, 45);
                 break;
             case "triup_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.5 * 0.25 * this.size, 0.5, 3, 90);
                 break;
             case "triup_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.4 * 0.25 * this.size, 0.4, 3, 90);
                 break;
             case "triup_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.16 * 0.25 * this.size, 0.16, 3, 90);
                 break;
             case "tridown_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.5 * 0.25 * this.size, 0.5, 3, -90);
                 break;
             case "tridown_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.4 * 0.25 * this.size, 0.4, 3, -90);
                 break;
             case "tridown_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.16 * 0.25 * this.size, 0.16, 3, -90);
                 break;
             case "diamond_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.43, 4, 0);
                 break;
             case "diamond_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.35, 4, 0);
                 break;
             case "diamond_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.22, 4, 0);
                 break;
             case "diamond_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
                 break;
             case "hexpoint_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 30);
                 break;
             case "hexpoint_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 30);
                 break;
             case "hexpoint_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 30);
                 break;
             case "hexpoint_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 30);
                 break;
             case "hexpoint_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 30);
                 break;
             case "hexflat_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 0);
                 break;
             case "hexflat_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 0);
                 break;
             case "hexflat_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 0);
                 break;
             case "hexflat_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 0);
                 break;
             case "hexflat_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 0);
                 break;
             case "ox_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 2;
                 this.draw_ox(ctx, num, x, y);
                 break;
@@ -1241,122 +1287,122 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 3;
                 this.draw_cross(ctx, num, x, y);
                 break;
             case "line":
-                this.draw_linesym(ctx, num, x, y);
+                this.draw_linesym(ctx, num, x, y, ccolor);
                 break;
             case "frameline":
-                this.draw_framelinesym(ctx, num, x, y);
+                this.draw_framelinesym(ctx, num, x, y, ccolor);
                 break;
 
                 //number
             case "inequality":
-                set_circle_style(ctx, 10);
+                set_circle_style(ctx, 10, ccolor);
                 this.draw_inequality(ctx, num, x, y);
                 break;
             case "math":
-                set_font_style(ctx, 0.8 * pu.size.toString(10), 1);
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 1, ccolor);
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "math_G":
-                set_font_style(ctx, 0.8 * pu.size.toString(10), 2);
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 2, ccolor);
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "degital":
-                this.draw_degital(ctx, num, x, y);
+                this.draw_degital(ctx, num, x, y, ccolor);
                 break;
             case "degital_f":
-                this.draw_degital_f(ctx, num, x, y);
+                this.draw_degital_f(ctx, num, x, y, ccolor);
                 break;
             case "dice":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_dice(ctx, num, x, y);
                 break;
             case "pills":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_pills(ctx, num, x, y);
                 break;
 
                 /* arrow */
             case "arrow_B_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_B_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_B_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_N_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_N_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_N_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_S":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowS(ctx, num, x, y);
                 break;
             case "arrow_GP":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP(ctx, num, x, y);
                 break;
             case "arrow_GP_C":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP_C(ctx, num, x, y);
                 break;
             case "arrow_Short":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowShort(ctx, num, x, y);
                 break;
             case "arrow_tri_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_tri_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_tri_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_cross":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowcross(ctx, num, x, y);
                 break;
             case "arrow_eight":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arroweight(ctx, num, x, y);
                 break;
 
                 /* special */
             case "kakuro":
-                this.draw_kakuro(ctx, num, x, y);
+                this.draw_kakuro(ctx, num, x, y, ccolor);
                 break;
             case "compass":
-                this.draw_compass(ctx, num, x, y);
+                this.draw_compass(ctx, num, x, y, ccolor);
                 break;
             case "star":
-                this.draw_star(ctx, num, x, y);
+                this.draw_star(ctx, num, x, y, ccolor);
                 break;
             case "tents":
-                this.draw_tents(ctx, num, x, y);
+                this.draw_tents(ctx, num, x, y, ccolor);
                 break;
             case "battleship_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_battleship(ctx, num, x, y);
                 break;
             case "battleship_G":
@@ -1373,22 +1419,22 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_battleship(ctx, num, x, y);
                 break;
             case "angleloop":
-                this.draw_angleloop(ctx, num, x, y);
+                this.draw_angleloop(ctx, num, x, y, ccolor);
                 break;
             case "firefly":
-                this.draw_firefly(ctx, num, x, y);
+                this.draw_firefly(ctx, num, x, y, ccolor);
                 break;
             case "sun_moon":
-                this.draw_sun_moon(ctx, num, x, y);
+                this.draw_sun_moon(ctx, num, x, y, ccolor);
                 break;
             case "sudokuetc":
-                this.draw_sudokuetc(ctx, num, x, y);
+                this.draw_sudokuetc(ctx, num, x, y, ccolor);
                 break;
             case "polyomino":
-                this.draw_polyomino(ctx, num, x, y);
+                this.draw_polyomino(ctx, num, x, y, ccolor);
                 break;
             case "pencils":
-                this.draw_pencils(ctx, num, x, y);
+                this.draw_pencils(ctx, num, x, y, ccolor);
                 break;
         }
     }
@@ -1581,12 +1627,12 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_linesym(ctx, num, x, y) {
+    draw_linesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
         ctx.fillStyle = Color.TRANSPARENTBLACK;
-        ctx.strokeStyle = Color.BLACK;
+        ctx.strokeStyle = ccolor || Color.BLACK;
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
@@ -1647,7 +1693,7 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_framelinesym(ctx, num, x, y) {
+    draw_framelinesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
@@ -1656,7 +1702,7 @@ class Puzzle_pyramid extends Puzzle {
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
-                set_line_style(ctx, 115)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1665,7 +1711,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.stroke();
                 break;
             case 2:
-                set_line_style(ctx, 15)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1674,7 +1720,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.stroke();
                 break;
             case 3:
-                set_line_style(ctx, 16)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1683,7 +1729,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.stroke();
                 break;
             case 4:
-                set_line_style(ctx, 110)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1692,7 +1738,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.stroke();
                 break;
             case 5:
-                set_line_style(ctx, 115)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1701,7 +1747,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.stroke();
                 break;
             case 6:
-                set_line_style(ctx, 15)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1710,7 +1756,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.stroke();
                 break;
             case 7:
-                set_line_style(ctx, 16)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1719,7 +1765,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.stroke();
                 break;
             case 8:
-                set_line_style(ctx, 110)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1817,8 +1863,8 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_degital(ctx, num, x, y) {
-        set_circle_style(ctx, 2);
+    draw_degital(ctx, num, x, y, ccolor) {
+        set_circle_style(ctx, 2, ccolor);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.17;
         z2 = 0.015;
@@ -1884,7 +1930,7 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_degital_f(ctx, num, x, y) {
+    draw_degital_f(ctx, num, x, y, ccolor) {
         set_circle_style(ctx, 3);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.17;
@@ -1943,7 +1989,7 @@ class Puzzle_pyramid extends Puzzle {
         ctx.fill();
 
         //contents
-        this.draw_degital(ctx, num, x, y);
+        this.draw_degital(ctx, num, x, y, ccolor);
     }
 
     draw_dice(ctx, num, x, y) {
@@ -1954,9 +2000,9 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_pills(ctx, num, x, y) {
+    draw_pills(ctx, num, x, y, ccolor) {
         var r = 0.15;
-        ctx.fillStyle = Color.GREY
+        ctx.fillStyle = ccolor || Color.GREY
         switch (num) {
             case 1:
                 this.draw_circle(ctx, x, y, r);
@@ -2119,11 +2165,11 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_kakuro(ctx, num, x, y) {
+    draw_kakuro(ctx, num, x, y, ccolor) {
         var th = this.rotate_theta(45) * 180 / Math.PI;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, th);
@@ -2134,7 +2180,7 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_slash(ctx, x, y, 0.5 * Math.sqrt(2));
                 break;
             case 2:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, th);
@@ -2177,13 +2223,13 @@ class Puzzle_pyramid extends Puzzle {
     }
 
 
-    draw_compass(ctx, num, x, y) {
+    draw_compass(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.5;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * Math.sqrt(2));
                 break;
@@ -2191,7 +2237,7 @@ class Puzzle_pyramid extends Puzzle {
                 var r = 0.33;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * Math.sqrt(2));
                 break;
@@ -2206,7 +2252,7 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_tents(ctx, num, x, y) {
+    draw_tents(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r1;
@@ -2232,7 +2278,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                ctx.fillStyle = Color.GREY;
+                ctx.fillStyle = ccolor || Color.GREY;
                 ctx.lineWidth = 1;
                 ctx.beginPath();
                 ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) + 0) * pu.size);
@@ -2250,7 +2296,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                ctx.fillStyle = Color.GREY_LIGHT;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 1;
                 r1 = 0.3;
                 r2 = 0.4;
@@ -2266,7 +2312,7 @@ class Puzzle_pyramid extends Puzzle {
             case 3: //anglers
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
                 ctx.lineWidth = 2;
                 ctx.beginPath();
@@ -2286,12 +2332,12 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_star(ctx, num, x, y) {
+    draw_star(ctx, num, x, y, ccolor) {
         var r1 = 0.38;
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2299,7 +2345,7 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 2:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2315,7 +2361,7 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 4:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2323,7 +2369,7 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 5:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2339,7 +2385,7 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 7:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2347,7 +2393,7 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
                 break;
             case 8:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2366,7 +2412,7 @@ class Puzzle_pyramid extends Puzzle {
                 var r = 0.4;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
@@ -2446,23 +2492,23 @@ class Puzzle_pyramid extends Puzzle {
         ctx.stroke();
     }
 
-    draw_angleloop(ctx, num, x, y) {
+    draw_angleloop(ctx, num, x, y, ccolor) {
         var r;
         switch (num) {
             case 1:
                 r = 0.24;
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_polygon(ctx, x, y, r, 3, 90);
                 break;
             case 2:
                 r = 0.24;
                 set_circle_style(ctx, 5);
-                ctx.fillStyle = Color.GREY;
+                ctx.fillStyle = ccolor || Color.GREY;
                 this.draw_polygon(ctx, x, y, r, 4, 45);
                 break;
             case 3:
                 r = 0.215;
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, r, 5, 90);
                 break;
@@ -2475,7 +2521,7 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.09;
         ctx.setLineDash([]);
@@ -2488,7 +2534,7 @@ class Puzzle_pyramid extends Puzzle {
             case 5:
             case 6:
                 var th = this.rotate_theta((num - 1) * 60 - 180);
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2496,22 +2542,22 @@ class Puzzle_pyramid extends Puzzle {
                 this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
                 break;
             case 7:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y) {
+    draw_sun_moon(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.34;
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -2529,11 +2575,11 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_pencils(ctx, num, x, y) {
+    draw_pencils(ctx, num, x, y, ccolor) {
         var r = 0.2;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
-        ctx.fillStyle = Color.BLACK;
+        ctx.fillStyle = ccolor || Color.BLACK;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 2;
         ctx.lineJoin = "bevel"
@@ -2597,12 +2643,12 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_sudokuetc(ctx, num, x, y) {
+    draw_sudokuetc(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.14;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.fillStyle = Color.GREY_LIGHT;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 this.draw_polygon(ctx, x - r * pu.size, y + r * pu.size, r * Math.sqrt(2), 4, 45);
                 this.draw_polygon(ctx, x + r * pu.size, y - r * pu.size, r * Math.sqrt(2), 4, 45);
                 ctx.fillStyle = Color.GREY_DARK;
@@ -2612,14 +2658,14 @@ class Puzzle_pyramid extends Puzzle {
             case 2:
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.fillStyle = Color.TRANSPARENTBLACK;
+                ctx.fillStyle = ccolor || Color.TRANSPARENTBLACK;
                 ctx.strokeStyle = Color.GREY_LIGHT;
                 ctx.lineWidth = 4;
                 this.draw_circle(ctx, x, y, 0.71);
                 break;
             case 3:
                 var r = 0.99;
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 ctx.beginPath();
                 ctx.moveTo(x, y + r * pu.size);
                 ctx.lineTo(x + r * pu.size, y);
@@ -2638,7 +2684,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -2662,7 +2708,7 @@ class Puzzle_pyramid extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -2679,9 +2725,9 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_polyomino(ctx, num, x, y) {
+    draw_polyomino(ctx, num, x, y, ccolor) {
         ctx.setLineDash([]);
-        ctx.fillStyle = Color.GREY_LIGHT;
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 1.2;
         ctx.lineCap = "butt";

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -1686,6 +1686,14 @@ class Puzzle_square extends Puzzle {
     }
 
     draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
+        let ccolor = undefined;
+        if (i !== 'panel' && UserSettings.custom_colors_on && this[qamode + "_col"].symbol[i]) {
+            ccolor = this[qamode + "_col"].symbol[i];
+        }
+        this.draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor);
+    }
+    
+    draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor) {   
         switch (sym) {
             /* figure */
             case "circle_L":
@@ -1694,12 +1702,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.43);
                     this.draw_circle(ctx, x, y, 0.32);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on &&
-                        this[qamode + "_col"].symbol[i]) {
-                        set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                    } else {
-                        set_circle_style(ctx, num);
-                    }
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.43);
                 }
                 break;
@@ -1709,12 +1712,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.35);
                     this.draw_circle(ctx, x, y, 0.25);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on &&
-                        this[qamode + "_col"].symbol[i]) {
-                        set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                    } else {
-                        set_circle_style(ctx, num);
-                    }
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.35);
                 }
                 break;
@@ -1724,12 +1722,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.22);
                     this.draw_circle(ctx, x, y, 0.14);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on &&
-                        this[qamode + "_col"].symbol[i]) {
-                        set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                    } else {
-                        set_circle_style(ctx, num);
-                    }
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.22);
                 }
                 break;
@@ -1739,340 +1732,155 @@ class Puzzle_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.13);
                     this.draw_circle(ctx, x, y, 0.07);
                 } else {
-                    if (i !== 'panel' && UserSettings.custom_colors_on &&
-                        this[qamode + "_col"].symbol[i]) {
-                        set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                    } else {
-                        set_circle_style(ctx, num);
-                    }
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.13);
                 }
                 break;
             case "square_LL":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, 45);
                 break;
             case "square_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4 * Math.sqrt(2), 4, 45);
                 break;
             case "square_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.35 * Math.sqrt(2), 4, 45);
                 break;
             case "square_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.22 * Math.sqrt(2), 4, 45);
                 break;
             case "square_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13 * Math.sqrt(2), 4, 45);
                 break;
             case "triup_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.5 * 0.25 * this.size, 0.5, 3, 90);
                 break;
             case "triup_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.4 * 0.25 * this.size, 0.4, 3, 90);
                 break;
             case "triup_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.25 * 0.25 * this.size, 0.25, 3, 90);
                 break;
             case "triup_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.16 * 0.25 * this.size, 0.16, 3, 90);
                 break;
             case "tridown_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.5 * 0.25 * this.size, 0.5, 3, -90);
                 break;
             case "tridown_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.4 * 0.25 * this.size, 0.4, 3, -90);
                 break;
             case "tridown_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.25 * 0.25 * this.size, 0.25, 3, -90);
                 break;
             case "tridown_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.16 * 0.25 * this.size, 0.16, 3, -90);
                 break;
             case "triright_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x - 0.5 * 0.25 * this.size, y, 0.5, 3, 180);
                 break;
             case "triright_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x - 0.4 * 0.25 * this.size, y, 0.4, 3, 180);
                 break;
             case "triright_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x - 0.25 * 0.25 * this.size, y, 0.25, 3, 180);
                 break;
             case "triright_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x - 0.16 * 0.25 * this.size, y, 0.16, 3, 180);
                 break;
             case "trileft_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x + 0.5 * 0.25 * this.size, y, 0.5, 3, 0);
                 break;
             case "trileft_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x + 0.4 * 0.25 * this.size, y, 0.4, 3, 0);
                 break;
             case "trileft_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x + 0.25 * 0.25 * this.size, y, 0.25, 3, 0);
                 break;
             case "trileft_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x + 0.16 * 0.25 * this.size, y, 0.16, 3, 0);
                 break;
             case "diamond_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.43, 4, 0);
                 break;
             case "diamond_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.35, 4, 0);
                 break;
             case "diamond_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.22, 4, 0);
                 break;
             case "diamond_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
                 break;
             case "hexpoint_LL":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 30);
                 break;
             case "hexpoint_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 30);
                 break;
             case "hexpoint_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 30);
                 break;
             case "hexpoint_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 30);
                 break;
             case "hexpoint_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 30);
                 break;
             case "hexflat_LL":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 0);
                 break;
             case "hexflat_L":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 0);
                 break;
             case "hexflat_M":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 0);
                 break;
             case "hexflat_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 0);
                 break;
             case "hexflat_SS":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, num, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, num);
-                }
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 0);
                 break;
             case "ox_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    ctx.strokeStyle = this[qamode + "_col"].symbol[i];
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 2;
                 this.draw_ox(ctx, num, x, y);
                 break;
@@ -2093,65 +1901,34 @@ class Puzzle_square extends Puzzle {
                 this.draw_ox(ctx, num, x, y);
                 break;
             case "tri":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_tri(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_tri(ctx, num, x, y);
-                }
+                this.draw_tri(ctx, num, x, y, ccolor);
                 break;
             case "cross":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    ctx.strokeStyle = this[qamode + "_col"].symbol[i];
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 3;
                 this.draw_cross(ctx, num, x, y);
                 break;
             case "line":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_linesym(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_linesym(ctx, num, x, y);
-                }
+                this.draw_linesym(ctx, num, x, y, ccolor);
                 break;
             case "frameline":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_framelinesym(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_framelinesym(ctx, num, x, y);
-                }
+                this.draw_framelinesym(ctx, num, x, y, ccolor);
                 break;
             case "bars_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    ctx.fillStyle = this[qamode + "_col"].symbol[i];
-                    ctx.strokeStyle = this[qamode + "_col"].symbol[i];
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_bars(ctx, num, x, y);
                 break;
             case "bars_G":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    ctx.fillStyle = this[qamode + "_col"].symbol[i];
-                } else {
-                    ctx.fillStyle = Color.GREY_LIGHT;
-                }
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 ctx.strokeStyle = Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_bars(ctx, num, x, y);
@@ -2166,21 +1943,11 @@ class Puzzle_square extends Puzzle {
                 break;
                 //number
             case "inequality":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 10, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 10);
-                }
+                set_circle_style(ctx, 10, ccolor);
                 this.draw_inequality(ctx, num, x, y);
                 break;
             case "math":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_font_style(ctx, 0.8 * pu.size.toString(10), 1, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_font_style(ctx, 0.8 * pu.size.toString(10), 1);
-                }
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 1, ccolor);
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "math_G":
@@ -2188,21 +1955,11 @@ class Puzzle_square extends Puzzle {
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "degital":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_degital(ctx, num, x, y);
                 break;
             case "degital_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_degital(ctx, num, x, y);
                 break;
             case "degital_E":
@@ -2214,40 +1971,20 @@ class Puzzle_square extends Puzzle {
                 this.draw_degital(ctx, num, x, y);
                 break;
             case "degital_f":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_degital_f(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_degital_f(ctx, num, x, y);
-                }
+                this.draw_degital_f(ctx, num, x, y, ccolor);
                 break;
             case "dice":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_dice(ctx, num, x, y);
                 break;
             case "pills":
                 set_circle_style(ctx, 3);
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_pills(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_pills(ctx, num, x, y);
-                }
+                this.draw_pills(ctx, num, x, y, ccolor);
                 break;
 
                 /* arrow */
             case "arrow_B_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_B_G":
@@ -2259,12 +1996,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_N_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_N_G":
@@ -2276,48 +2008,23 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_S":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowS(ctx, num, x, y);
                 break;
             case "arrow_GP":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP(ctx, num, x, y);
                 break;
             case "arrow_GP_C":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP_C(ctx, num, x, y);
                 break;
             case "arrow_Short":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowShort(ctx, num, x, y);
                 break;
             case "arrow_tri_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_tri_G":
@@ -2329,39 +2036,19 @@ class Puzzle_square extends Puzzle {
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_cross":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowcross(ctx, num, x, y);
                 break;
             case "arrow_eight":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arroweight(ctx, num, x, y);
                 break;
             case "arrow_fourtip":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowfourtip(ctx, num, x, y);
                 break;
             case "arrow_fouredge_B":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                }
+                set_circle_style(ctx, 2, ccolor);
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
                 this.draw_arrowfouredge(ctx, num, x, y);
                 break;
@@ -2380,47 +2067,21 @@ class Puzzle_square extends Puzzle {
 
                 /* special */
             case "kakuro":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_kakuro(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_kakuro(ctx, num, x, y);
-                }
+                this.draw_kakuro(ctx, num, x, y, ccolor);
                 break;
             case "compass":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_compass(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_compass(ctx, num, x, y);
-                }
+                this.draw_compass(ctx, num, x, y, ccolor);
                 break;
             case "star":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_star(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_star(ctx, num, x, y);
-                }
+                this.draw_star(ctx, num, x, y, ccolor);
                 break;
             case "tents":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_tents(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_tents(ctx, num, x, y);
-                }
+                this.draw_tents(ctx, num, x, y, ccolor);
                 break;
             case "battleship_B":
                 var font_style_type = 1;
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                    this.draw_battleship(ctx, num, x, y, font_style_type, this[qamode + "_col"].symbol[i]);
-                } else {
-                    set_circle_style(ctx, 2);
-                    this.draw_battleship(ctx, num, x, y, font_style_type);
-                }
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_battleship(ctx, num, x, y, font_style_type, ccolor);
                 break;
             case "battleship_G":
                 set_circle_style(ctx, 3);
@@ -2437,14 +2098,8 @@ class Puzzle_square extends Puzzle {
                 this.draw_battleship(ctx, num, x, y);
                 break;
             case "battleship_B+":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    set_circle_style(ctx, 2, this[qamode + "_col"].symbol[i]);
-                    this.draw_battleshipplus(ctx, num, x, y);
-                } else {
-                    set_circle_style(ctx, 2);
-                    this.draw_battleshipplus(ctx, num, x, y);
-                }
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_battleshipplus(ctx, num, x, y);
                 break;
             case "battleship_G+":
                 set_circle_style(ctx, 3);
@@ -2460,108 +2115,43 @@ class Puzzle_square extends Puzzle {
                 this.draw_battleshipplus(ctx, num, x, y);
                 break;
             case "angleloop":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_angleloop(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_angleloop(ctx, num, x, y);
-                }
+                this.draw_angleloop(ctx, num, x, y, ccolor);
                 break;
             case "firefly":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_firefly(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_firefly(ctx, num, x, y);
-                }
+                this.draw_firefly(ctx, num, x, y, ccolor);
                 break;
             case "sun_moon":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_sun_moon(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_sun_moon(ctx, num, x, y);
-                }
+                this.draw_sun_moon(ctx, num, x, y, ccolor);
                 break;
             case "sudokuetc":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_sudokuetc(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_sudokuetc(ctx, num, x, y);
-                }
+                this.draw_sudokuetc(ctx, num, x, y, ccolor);
                 break;
             case "sudokumore":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_sudokumore(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_sudokumore(ctx, num, x, y);
-                }
+                this.draw_sudokumore(ctx, num, x, y, ccolor);
                 break;
             case "polyomino":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_polyomino(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_polyomino(ctx, num, x, y);
-                }
+                this.draw_polyomino(ctx, num, x, y, ccolor);
                 break;
             case "polyhex":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_polyhex(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_polyhex(ctx, num, x, y);
-                }
+                this.draw_polyhex(ctx, num, x, y, ccolor);
                 break;
             case "pencils":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_pencils(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_pencils(ctx, num, x, y);
-                }
+                this.draw_pencils(ctx, num, x, y, ccolor);
                 break;
             case "slovak":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_slovak(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_slovak(ctx, num, x, y);
-                }
+                this.draw_slovak(ctx, num, x, y, ccolor);
                 break;
             case "arc":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_arc(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_arc(ctx, num, x, y);
-                }
+                this.draw_arc(ctx, num, x, y, ccolor);
                 break;
             case "darts":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_darts(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_darts(ctx, num, x, y);
-                }
+                this.draw_darts(ctx, num, x, y, ccolor);
                 break;
             case "spans":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_spans(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_spans(ctx, num, x, y);
-                }
+                this.draw_spans(ctx, num, x, y, ccolor);
                 break;
             case "neighbors":
-                if (i !== 'panel' && UserSettings.custom_colors_on &&
-                    this[qamode + "_col"].symbol[i]) {
-                    this.draw_neighbors(ctx, num, x, y, this[qamode + "_col"].symbol[i]);
-                } else {
-                    this.draw_neighbors(ctx, num, x, y);
-                }
+                this.draw_neighbors(ctx, num, x, y, ccolor);
                 break;
         }
     }
@@ -2656,7 +2246,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_tri(ctx, num, x, y, ccolor = "none") {
+    draw_tri(ctx, num, x, y, ccolor) {
         var r = 0.5,
             th, th1, th2, th3;
         switch (num) {
@@ -2733,16 +2323,12 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_linesym(ctx, num, x, y, ccolor = "none") {
+    draw_linesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
         ctx.fillStyle = Color.TRANSPARENTBLACK;
-        if (ccolor !== "none") {
-            ctx.strokeStyle = ccolor;
-        } else {
-            ctx.strokeStyle = Color.BLACK;
-        }
+        ctx.strokeStyle = ccolor || Color.BLACK;
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
@@ -2827,7 +2413,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_framelinesym(ctx, num, x, y, ccolor = "none") {
+    draw_framelinesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         var r2 = 0.17;
         var d = 0.08;
@@ -3147,7 +2733,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_degital_f(ctx, num, x, y, ccolor = "none") {
+    draw_degital_f(ctx, num, x, y, ccolor) {
         set_circle_style(ctx, 3);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.17;
@@ -3218,13 +2804,9 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_pills(ctx, num, x, y, ccolor = "none") {
+    draw_pills(ctx, num, x, y, ccolor) {
         var r = 0.15;
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.GREY;
-        }
+        ctx.fillStyle = ccolor || Color.GREY;
         switch (num) {
             case 1:
                 this.draw_circle(ctx, x, y, r);
@@ -3485,15 +3067,11 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_kakuro(ctx, num, x, y, ccolor = "none") {
+    draw_kakuro(ctx, num, x, y, ccolor) {
         var th = this.rotate_theta(45) * 180 / Math.PI;
         switch (num) {
             case 1:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, th);
@@ -3504,11 +3082,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_slash(ctx, x, y, 0.5 * Math.sqrt(2));
                 break;
             case 2:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, th);
@@ -3551,17 +3125,13 @@ class Puzzle_square extends Puzzle {
     }
 
 
-    draw_compass(ctx, num, x, y, ccolor = "none") {
+    draw_compass(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.5;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * Math.sqrt(2));
                 break;
@@ -3569,11 +3139,7 @@ class Puzzle_square extends Puzzle {
                 var r = 0.33;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * Math.sqrt(2));
                 break;
@@ -3588,7 +3154,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_tents(ctx, num, x, y, ccolor = "none") {
+    draw_tents(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r1;
@@ -3613,11 +3179,7 @@ class Puzzle_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY;
-                }
+                ctx.fillStyle = ccolor || Color.GREY;
                 ctx.lineWidth = 1;
                 ctx.beginPath();
                 ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) + 0) * pu.size);
@@ -3635,11 +3197,7 @@ class Puzzle_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY_LIGHT;
-                }
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 1;
                 r1 = 0.3;
                 r2 = 0.4;
@@ -3655,11 +3213,7 @@ class Puzzle_square extends Puzzle {
             case 3: //anglers
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
                 ctx.lineWidth = 2;
                 ctx.beginPath();
@@ -3679,16 +3233,12 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_star(ctx, num, x, y, ccolor = "none") {
+    draw_star(ctx, num, x, y, ccolor) {
         var r1 = 0.38;
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.WHITE;
-                }
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -3696,11 +3246,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 2:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -3716,11 +3262,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 4:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.WHITE;
-                }
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -3728,11 +3270,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 5:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -3748,11 +3286,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 7:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.WHITE;
-                }
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -3760,11 +3294,7 @@ class Puzzle_square extends Puzzle {
                 this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
                 break;
             case 8:
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.BLACK;
-                }
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -3783,11 +3313,7 @@ class Puzzle_square extends Puzzle {
                 var r = 0.4;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
@@ -3811,7 +3337,7 @@ class Puzzle_square extends Puzzle {
         ctx.stroke();
     }
 
-    draw_battleship(ctx, num, x, y, color_type = 1, ccolor = "none") {
+    draw_battleship(ctx, num, x, y, color_type = 1, ccolor) {
         var r = 0.4;
         var th;
         switch (num) {
@@ -3847,15 +3373,7 @@ class Puzzle_square extends Puzzle {
                 r = 0.05;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    if (color_type === 3) {
-                        ctx.fillStyle = Color.GREY;
-                    } else {
-                        ctx.fillStyle = Color.BLACK;
-                    }
-                }
+                ctx.fillStyle = ccolor || (color_type === 3 ? Color.GREY : Color.BLACK);
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
                 ctx.lineWidth = 2;
                 this.draw_circle(ctx, x, y, r);
@@ -3909,7 +3427,7 @@ class Puzzle_square extends Puzzle {
         ctx.stroke();
     }
 
-    draw_angleloop(ctx, num, x, y, ccolor = "none") {
+    draw_angleloop(ctx, num, x, y, ccolor) {
         var r;
         switch (num) {
             case 1:
@@ -3920,11 +3438,7 @@ class Puzzle_square extends Puzzle {
             case 2:
                 r = 0.24;
                 set_circle_style(ctx, 5);
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY;
-                }
+                ctx.fillStyle = ccolor || Color.GREY;
                 this.draw_polygon(ctx, x, y, r, 4, 45);
                 break;
             case 3:
@@ -3942,7 +3456,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_firefly(ctx, num, x, y, ccolor = "none") {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.09;
         ctx.setLineDash([]);
@@ -3967,7 +3481,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_sun_moon(ctx, num, x, y, ccolor = "none") {
+    draw_sun_moon(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.34;
         switch (num) {
@@ -3998,18 +3512,13 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_pencils(ctx, num, x, y, ccolor = "none") {
+    draw_pencils(ctx, num, x, y, ccolor) {
         var r = 0.2,
             th;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-            ctx.strokeStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.BLACK;
-            ctx.strokeStyle = Color.BLACK;
-        }
+        ctx.fillStyle = ccolor || Color.BLACK;
+        ctx.strokeStyle = ccolor || Color.BLACK;
         ctx.lineWidth = 2;
         ctx.lineJoin = "bevel"
         switch (num) {
@@ -4033,7 +3542,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_slovak(ctx, num, x, y, ccolor = "none") {
+    draw_slovak(ctx, num, x, y, ccolor) {
         var r = 0.09,
             h = 0.37;
         switch (num) {
@@ -4066,16 +3575,12 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_sudokuetc(ctx, num, x, y, ccolor = "none") {
+    draw_sudokuetc(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.14;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY_LIGHT;
-                }
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 this.draw_polygon(ctx, x - r * pu.size, y + r * pu.size, r * Math.sqrt(2), 4, 45);
                 this.draw_polygon(ctx, x + r * pu.size, y - r * pu.size, r * Math.sqrt(2), 4, 45);
                 ctx.fillStyle = Color.GREY_DARK;
@@ -4086,11 +3591,7 @@ class Puzzle_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.GREY_LIGHT;
-                }
+                ctx.strokeStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 4;
                 this.draw_circle(ctx, x, y, 0.71);
                 break;
@@ -4115,11 +3616,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4143,11 +3640,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4171,11 +3664,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4199,11 +3688,7 @@ class Puzzle_square extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.BLACK;
-                }
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4220,7 +3705,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_sudokumore(ctx, num, x, y, ccolor = "none") {
+    draw_sudokumore(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.4 * pu.size;
@@ -4236,11 +3721,7 @@ class Puzzle_square extends Puzzle {
                 } else {
                     ctx.fillStyle = Color.WHITE;
                 }
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.GREY_DARK_LIGHT;
-                }
+                ctx.strokeStyle = ccolor || Color.GREY_DARK_LIGHT;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4269,11 +3750,7 @@ class Puzzle_square extends Puzzle {
                 } else {
                     ctx.fillStyle = Color.WHITE;
                 }
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.GREY_DARK_LIGHT;
-                }
+                ctx.strokeStyle = ccolor || Color.GREY_DARK_LIGHT;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4302,11 +3779,7 @@ class Puzzle_square extends Puzzle {
                 } else {
                     ctx.fillStyle = Color.WHITE;
                 }
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.GREY_DARK_LIGHT;
-                }
+                ctx.strokeStyle = ccolor || Color.GREY_DARK_LIGHT;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4335,11 +3808,7 @@ class Puzzle_square extends Puzzle {
                 } else {
                     ctx.fillStyle = Color.WHITE;
                 }
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.GREY_DARK_LIGHT;
-                }
+                ctx.strokeStyle = ccolor || Color.GREY_DARK_LIGHT;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -4358,27 +3827,18 @@ class Puzzle_square extends Puzzle {
                 ctx.lineWidth = 3;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.WHITE;
-                if (ccolor !== "none") {
-                    ctx.strokeStyle = ccolor;
-                } else {
-                    ctx.strokeStyle = Color.GREY_DARK_LIGHT;
-                }
+                ctx.strokeStyle = ccolor || Color.GREY_DARK_LIGHT;
                 this.draw_circle(ctx, x, y, 0.4);
                 break;
         }
     }
 
-    draw_arc(ctx, num, x, y, ccolor = "none") {
+    draw_arc(ctx, num, x, y, ccolor) {
         var th, th1, th2, th2a;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-            ctx.strokeStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.BLACK;
-            ctx.strokeStyle = Color.BLACK;
-        }
+        ctx.fillStyle = ccolor || Color.BLACK;
+        ctx.strokeStyle = ccolor || Color.BLACK;
         ctx.lineWidth = 3;
         ctx.lineJoin = "bevel"
         switch (num) {
@@ -4419,7 +3879,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_darts(ctx, num, x, y, ccolor = "none") {
+    draw_darts(ctx, num, x, y, ccolor) {
         set_circle_style(ctx, 13, ccolor);
         if (1 <= num, num <= 4) {
             for (var i = 1; i <= num; i++) {
@@ -4434,7 +3894,7 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_spans(ctx, num, x, y, ccolor = "none") {
+    draw_spans(ctx, num, x, y, ccolor) {
         var h = 0.15;
         switch (num) {
             case 1:
@@ -4456,30 +3916,22 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_neighbors(ctx, num, x, y, ccolor = "none") {
+    draw_neighbors(ctx, num, x, y, ccolor) {
         var r = 0.85;
         switch (num) {
             case 1:
                 set_circle_style(ctx, 1);
                 ctx.fillStyle = Color.GREY;
                 this.draw_polygon(ctx, x, y, 1 / Math.sqrt(2), 4, 45);
-                if (ccolor !== "none") {
-                    ctx.fillStyle = ccolor;
-                } else {
-                    ctx.fillStyle = Color.GREY_LIGHT;
-                }
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 this.draw_polygon(ctx, x, y, r / Math.sqrt(2), 4, 45);
                 break;
         }
     }
 
-    draw_polyomino(ctx, num, x, y, ccolor = "none") {
+    draw_polyomino(ctx, num, x, y, ccolor) {
         ctx.setLineDash([]);
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.GREY_LIGHT;
-        }
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 1.2;
         ctx.lineCap = "butt";
@@ -4491,13 +3943,9 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_polyhex(ctx, num, x, y, ccolor = "none") {
+    draw_polyhex(ctx, num, x, y, ccolor) {
         ctx.setLineDash([]);
-        if (ccolor !== "none") {
-            ctx.fillStyle = ccolor;
-        } else {
-            ctx.fillStyle = Color.GREY_LIGHT;
-        }
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 1.2;
         ctx.lineCap = "butt";

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -728,40 +728,6 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_surface(pu, num = "") {
-        if (num) {
-            var keys = [],
-                key0 = num + "";
-            if (this[pu].surface[key0]) {
-                keys.push(key0);
-            }
-            for (var i = 0; i < this.point[num].adjacent.length; i++) {
-                key0 = this.point[num].adjacent[i] + "";
-                if (keys.indexOf(key0) === -1 && this[pu].surface[key0]) {
-                    keys.push(key0);
-                }
-            }
-        } else {
-            var keys = Object.keys(this[pu].surface);
-        }
-        for (var k = 0; k < keys.length; k++) {
-            var i = keys[k];
-            set_surface_style(this.ctx, this[pu].surface[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].surface[i]) {
-                this.ctx.fillStyle = this[pu + "_col"].surface[i];
-                this.ctx.strokeStyle = this.ctx.fillStyle;
-            }
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.point[this.point[i].surround[0]].x, this.point[this.point[i].surround[0]].y);
-            for (var j = 1; j < this.point[i].surround.length; j++) {
-                this.ctx.lineTo(this.point[this.point[i].surround[j]].x, this.point[this.point[i].surround[j]].y);
-            }
-            this.ctx.closePath();
-            this.ctx.fill();
-            this.ctx.stroke();
-        }
-    }
-
     draw_polygon(ctx, x, y, r, n, th) {
         ctx.LineCap = "round";
         ctx.beginPath();

--- a/docs/js/class_tri.js
+++ b/docs/js/class_tri.js
@@ -511,20 +511,6 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_surface(pu) {
-        for (var i in this[pu].surface) {
-            set_surface_style(this.ctx, this[pu].surface[i]);
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.point[this.point[i].surround[0]].x, this.point[this.point[i].surround[0]].y);
-            for (var j = 1; j < this.point[i].surround.length; j++) {
-                this.ctx.lineTo(this.point[this.point[i].surround[j]].x, this.point[this.point[i].surround[j]].y);
-            }
-            this.ctx.closePath();
-            this.ctx.fill();
-            this.ctx.stroke();
-        }
-    }
-
     draw_polygon(ctx, x, y, r, n, th) {
         ctx.LineCap = "round";
         ctx.beginPath();
@@ -543,7 +529,11 @@ class Puzzle_tri extends Puzzle {
             if (this[pu].squareframe[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].squareframe[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].squareframe[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_LIGHT;
+                }
                 this.ctx.lineWidth = this.size * 0.4;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].squareframe[i][0]].x, this.point[this[pu].squareframe[i][0]].y);
@@ -559,11 +549,19 @@ class Puzzle_tri extends Puzzle {
         for (var i = 0; i < this[pu].thermo.length; i++) {
             if (this[pu].thermo[i][0]) {
                 this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                this.ctx.fillStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
+                    this.ctx.fillStyle = this[pu + "_col"].thermo[i];
+                } else {
+                    this.ctx.fillStyle = Color.GREY_LIGHT;
+                }
                 this.draw_circle(this.ctx, this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y, 0.25);
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].thermo[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].thermo[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_LIGHT;
+                }
                 this.ctx.lineWidth = this.size * 0.27;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].thermo[i][0]].x, this.point[this[pu].thermo[i][0]].y);
@@ -580,10 +578,18 @@ class Puzzle_tri extends Puzzle {
             for (var i = 0; i < this[pu].nobulbthermo.length; i++) {
                 if (this[pu].nobulbthermo[i][0]) {
                     this.ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                    this.ctx.fillStyle = Color.GREY_LIGHT;
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
+                        this.ctx.fillStyle = this[pu + "_col"].nobulbthermo[i];
+                    } else {
+                        this.ctx.fillStyle = Color.GREY_LIGHT;
+                    }
                     this.ctx.setLineDash([]);
                     this.ctx.lineCap = "square";
-                    this.ctx.strokeStyle = Color.GREY_LIGHT;
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].nobulbthermo[i]) {
+                        this.ctx.strokeStyle = this[pu + "_col"].nobulbthermo[i];
+                    } else {
+                        this.ctx.strokeStyle = Color.GREY_LIGHT;
+                    }
                     this.ctx.lineWidth = this.size * 0.27;
                     this.ctx.beginPath();
                     this.ctx.moveTo(this.point[this[pu].nobulbthermo[i][0]].x, this.point[this[pu].nobulbthermo[i][0]].y);
@@ -601,7 +607,11 @@ class Puzzle_tri extends Puzzle {
             if (this[pu].arrows[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
                 this.ctx.lineWidth = 3;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].arrows[i][0]].x, this.point[this[pu].arrows[i][0]].y);
@@ -619,7 +629,11 @@ class Puzzle_tri extends Puzzle {
                 this.ctx.stroke();
                 this.ctx.setLineDash([]);
                 this.ctx.lineJoin = "miter";
-                this.ctx.strokeStyle = Color.GREY_LIGHT;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].arrows[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].arrows[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
                 this.ctx.fillStyle = Color.WHITE;
                 this.ctx.lineWidth = 3;
 
@@ -633,7 +647,11 @@ class Puzzle_tri extends Puzzle {
             if (this[pu].direction[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].direction[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].direction[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
                 this.ctx.lineWidth = 3;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].direction[i][0]].x, this.point[this[pu].direction[i][0]].y);
@@ -661,6 +679,9 @@ class Puzzle_tri extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -671,6 +692,9 @@ class Puzzle_tri extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 this.ctx.beginPath();
@@ -716,6 +740,9 @@ class Puzzle_tri extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -726,6 +753,9 @@ class Puzzle_tri extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 this.ctx.beginPath();
@@ -752,6 +782,9 @@ class Puzzle_tri extends Puzzle {
         /*freeline*/
         for (var i in this[pu].freeline) {
             set_line_style(this.ctx, this[pu].freeline[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
+            }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
             this.ctx.beginPath();
@@ -773,6 +806,9 @@ class Puzzle_tri extends Puzzle {
         }
         for (var i in this[pu].freelineE) {
             set_line_style(this.ctx, this[pu].freelineE[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
+            }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
             this.ctx.beginPath();
@@ -794,24 +830,11 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_wall(pu) {
-        for (var i in this[pu].wall) {
-            set_line_style(this.ctx, this[pu].wall[i]);
-            this.ctx.lineCap = "butt";
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-            this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            this.ctx.stroke();
-        }
-    }
-
     draw_symbol(pu, layer) {
         /*symbol_layer*/
         for (var i in this[pu].symbol) {
             if (this[pu].symbol[i][2] === layer) {
-                this.draw_symbol_select(this.ctx, this.point[i].x, this.point[i].y, this[pu].symbol[i][0], this[pu].symbol[i][1]);
+                this.draw_symbol_select(this.ctx, this.point[i].x, this.point[i].y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
             }
         }
     }
@@ -1083,7 +1106,15 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_symbol_select(ctx, x, y, num, sym) {
+    draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
+        let ccolor = undefined;
+        if (i !== 'panel' && UserSettings.custom_colors_on && this[qamode + "_col"].symbol[i]) {
+            ccolor = this[qamode + "_col"].symbol[i];
+        }
+        this.draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor);
+    }
+    
+    draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor) {    
         switch (sym) {
             /* figure */
             case "circle_L":
@@ -1092,7 +1123,7 @@ class Puzzle_tri extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.25);
                     this.draw_circle(ctx, x, y, 0.2);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.25);
                 }
                 break;
@@ -1102,7 +1133,7 @@ class Puzzle_tri extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.2);
                     this.draw_circle(ctx, x, y, 0.15);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.2);
                 }
                 break;
@@ -1112,7 +1143,7 @@ class Puzzle_tri extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.13);
                     this.draw_circle(ctx, x, y, 0.09);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.13);
                 }
                 break;
@@ -1122,115 +1153,115 @@ class Puzzle_tri extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.1);
                     this.draw_circle(ctx, x, y, 0.06);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.1);
                 }
                 break;
             case "square_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.5, 4, 45);
                 break;
             case "square_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 4, 45);
                 break;
             case "square_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 4, 45);
                 break;
             case "square_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.22, 4, 45);
                 break;
             case "square_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 4, 45);
                 break;
             case "triup_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.5, 3, 90);
                 break;
             case "triup_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 3, 90);
                 break;
             case "triup_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.16, 3, 90);
                 break;
             case "tridown_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.5, 3, -90);
                 break;
             case "tridown_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 3, -90);
                 break;
             case "tridown_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.16, 3, -90);
                 break;
             case "diamond_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.43, 4, 0);
                 break;
             case "diamond_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.25, 4, 0);
                 break;
             case "diamond_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.17, 4, 0);
                 break;
             case "diamond_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.11, 4, 0);
                 break;
             case "hexpoint_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 30);
                 break;
             case "hexpoint_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 30);
                 break;
             case "hexpoint_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 30);
                 break;
             case "hexpoint_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 30);
                 break;
             case "hexpoint_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 30);
                 break;
             case "hexflat_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 0);
                 break;
             case "hexflat_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 0);
                 break;
             case "hexflat_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 0);
                 break;
             case "hexflat_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 0);
                 break;
             case "hexflat_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 0);
                 break;
             case "ox_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 2;
                 this.draw_ox(ctx, num, x, y);
                 break;
@@ -1251,129 +1282,129 @@ class Puzzle_tri extends Puzzle {
                 this.draw_ox(ctx, num, x, y);
                 break;
             case "tri":
-                this.draw_tri(ctx, num, x, y);
+                this.draw_tri(ctx, num, x, y, ccolor);
                 break;
             case "cross":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 3;
                 this.draw_cross(ctx, num, x, y);
                 break;
             case "line":
-                this.draw_linesym(ctx, num, x, y);
+                this.draw_linesym(ctx, num, x, y, ccolor);
                 break;
             case "frameline":
-                this.draw_framelinesym(ctx, num, x, y);
+                this.draw_framelinesym(ctx, num, x, y, ccolor);
                 break;
 
                 //number
             case "inequality":
-                set_circle_style(ctx, 10);
+                set_circle_style(ctx, 10, ccolor);
                 this.draw_inequality(ctx, num, x, y);
                 break;
             case "math":
-                set_font_style(ctx, 0.4 * pu.size.toString(10), 1);
+                set_font_style(ctx, 0.4 * pu.size.toString(10), 1, ccolor);
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "math_G":
-                set_font_style(ctx, 0.4 * pu.size.toString(10), 2);
+                set_font_style(ctx, 0.4 * pu.size.toString(10), 2, ccolor);
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "degital":
-                this.draw_degital(ctx, num, x, y);
+                this.draw_degital(ctx, num, x, y, ccolor);
                 break;
             case "degital_f":
-                this.draw_degital_f(ctx, num, x, y);
+                this.draw_degital_f(ctx, num, x, y, ccolor);
                 break;
             case "dice":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_dice(ctx, num, x, y);
                 break;
                 /*
       case "pills":
-        set_circle_style(ctx,3);
+        set_circle_style(ctx, 3, ccolor);
         this.draw_pills(ctx,num,x,y);
         break;
 */
                 /* arrow */
             case "arrow_B_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_B_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_B_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_N_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_N_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_N_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_S":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowS(ctx, num, x, y);
                 break;
             case "arrow_GP":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP(ctx, num, x, y);
                 break;
             case "arrow_GP_C":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP_C(ctx, num, x, y);
                 break;
             case "arrow_Short":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowShort(ctx, num, x, y);
                 break;
             case "arrow_tri_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_tri_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_tri_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_cross":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowcross(ctx, num, x, y);
                 break;
             case "arrow_eight":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arroweight(ctx, num, x, y);
                 break;
 
                 /* special */
             case "kakuro":
-                this.draw_kakuro(ctx, num, x, y);
+                this.draw_kakuro(ctx, num, x, y, ccolor);
                 break;
             case "compass":
-                this.draw_compass(ctx, num, x, y);
+                this.draw_compass(ctx, num, x, y, ccolor);
                 break;
             case "star":
-                this.draw_star(ctx, num, x, y);
+                this.draw_star(ctx, num, x, y, ccolor);
                 break;
             case "tents":
-                this.draw_tents(ctx, num, x, y);
+                this.draw_tents(ctx, num, x, y, ccolor);
                 break;
             case "battleship_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_battleship(ctx, num, x, y);
                 break;
             case "battleship_G":
@@ -1390,19 +1421,19 @@ class Puzzle_tri extends Puzzle {
                 this.draw_battleship(ctx, num, x, y);
                 break;
             case "angleloop":
-                this.draw_angleloop(ctx, num, x, y);
+                this.draw_angleloop(ctx, num, x, y, ccolor);
                 break;
             case "firefly":
-                this.draw_firefly(ctx, num, x, y);
+                this.draw_firefly(ctx, num, x, y, ccolor);
                 break;
             case "sun_moon":
-                this.draw_sun_moon(ctx, num, x, y);
+                this.draw_sun_moon(ctx, num, x, y, ccolor);
                 break;
             case "sudokuetc":
-                this.draw_sudokuetc(ctx, num, x, y);
+                this.draw_sudokuetc(ctx, num, x, y, ccolor);
                 break;
             case "polyomino":
-                this.draw_polyomino(ctx, num, x, y);
+                this.draw_polyomino(ctx, num, x, y, ccolor);
                 break;
                 //case "pencils":
                 //  this.draw_pencils(ctx,num,x,y);
@@ -1594,12 +1625,12 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_linesym(ctx, num, x, y) {
+    draw_linesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
         ctx.fillStyle = Color.TRANSPARENTBLACK;
-        ctx.strokeStyle = Color.BLACK;
+        ctx.strokeStyle = ccolor || Color.BLACK;
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
@@ -1660,7 +1691,7 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_framelinesym(ctx, num, x, y) {
+    draw_framelinesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
@@ -1669,7 +1700,7 @@ class Puzzle_tri extends Puzzle {
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
-                set_line_style(ctx, 115)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1678,7 +1709,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.stroke();
                 break;
             case 2:
-                set_line_style(ctx, 15)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1687,7 +1718,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.stroke();
                 break;
             case 3:
-                set_line_style(ctx, 16)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1696,7 +1727,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.stroke();
                 break;
             case 4:
-                set_line_style(ctx, 110)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1705,7 +1736,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.stroke();
                 break;
             case 5:
-                set_line_style(ctx, 115)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1714,7 +1745,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.stroke();
                 break;
             case 6:
-                set_line_style(ctx, 15)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1723,7 +1754,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.stroke();
                 break;
             case 7:
-                set_line_style(ctx, 16)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1732,7 +1763,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.stroke();
                 break;
             case 8:
-                set_line_style(ctx, 110)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1813,8 +1844,8 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_degital(ctx, num, x, y) {
-        set_circle_style(ctx, 2);
+    draw_degital(ctx, num, x, y, ccolor) {
+        set_circle_style(ctx, 2, ccolor);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.1;
         z2 = 0.01;
@@ -1880,7 +1911,7 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_degital_f(ctx, num, x, y) {
+    draw_degital_f(ctx, num, x, y, ccolor) {
         set_circle_style(ctx, 3);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.1;
@@ -1939,7 +1970,7 @@ class Puzzle_tri extends Puzzle {
         ctx.fill();
 
         //contents
-        this.draw_degital(ctx, num, x, y);
+        this.draw_degital(ctx, num, x, y, ccolor);
     }
 
     draw_dice(ctx, num, x, y) {
@@ -1950,37 +1981,37 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_pills(ctx, num, x, y) {
-        var r = 0.1;
-        ctx.fillStyle = Color.GREY
-        switch (num) {
-            case 1:
-                this.draw_circle(ctx, x, y, r);
-                break;
-            case 2:
-                this.draw_circle(ctx, x - 0.12 * pu.size, y - 0.12 * pu.size, r);
-                this.draw_circle(ctx, x + 0.12 * pu.size, y + 0.12 * pu.size, r);
-                break;
-            case 3:
-                this.draw_circle(ctx, x - 0 * pu.size, y - 0.12 * pu.size, r);
-                this.draw_circle(ctx, x + 0.12 * pu.size, y + 0.1 * pu.size, r);
-                this.draw_circle(ctx, x - 0.12 * pu.size, y + 0.1 * pu.size, r);
-                break;
-            case 4:
-                this.draw_circle(ctx, x - 0.12 * pu.size, y - 0.12 * pu.size, r);
-                this.draw_circle(ctx, x + 0.12 * pu.size, y + 0.12 * pu.size, r);
-                this.draw_circle(ctx, x - 0.12 * pu.size, y + 0.12 * pu.size, r);
-                this.draw_circle(ctx, x + 0.12 * pu.size, y - 0.12 * pu.size, r);
-                break;
-            case 5:
-                this.draw_circle(ctx, x, y, r);
-                this.draw_circle(ctx, x - 0.24 * pu.size, y - 0.24 * pu.size, r);
-                this.draw_circle(ctx, x + 0.24 * pu.size, y + 0.24 * pu.size, r);
-                this.draw_circle(ctx, x - 0.24 * pu.size, y + 0.24 * pu.size, r);
-                this.draw_circle(ctx, x + 0.24 * pu.size, y - 0.24 * pu.size, r);
-                break;
-        }
-    }
+    // draw_pills(ctx, num, x, y, ccolor) {
+    //     var r = 0.1;
+    //     ctx.fillStyle = ccolor || Color.GREY
+    //     switch (num) {
+    //         case 1:
+    //             this.draw_circle(ctx, x, y, r);
+    //             break;
+    //         case 2:
+    //             this.draw_circle(ctx, x - 0.12 * pu.size, y - 0.12 * pu.size, r);
+    //             this.draw_circle(ctx, x + 0.12 * pu.size, y + 0.12 * pu.size, r);
+    //             break;
+    //         case 3:
+    //             this.draw_circle(ctx, x - 0 * pu.size, y - 0.12 * pu.size, r);
+    //             this.draw_circle(ctx, x + 0.12 * pu.size, y + 0.1 * pu.size, r);
+    //             this.draw_circle(ctx, x - 0.12 * pu.size, y + 0.1 * pu.size, r);
+    //             break;
+    //         case 4:
+    //             this.draw_circle(ctx, x - 0.12 * pu.size, y - 0.12 * pu.size, r);
+    //             this.draw_circle(ctx, x + 0.12 * pu.size, y + 0.12 * pu.size, r);
+    //             this.draw_circle(ctx, x - 0.12 * pu.size, y + 0.12 * pu.size, r);
+    //             this.draw_circle(ctx, x + 0.12 * pu.size, y - 0.12 * pu.size, r);
+    //             break;
+    //         case 5:
+    //             this.draw_circle(ctx, x, y, r);
+    //             this.draw_circle(ctx, x - 0.24 * pu.size, y - 0.24 * pu.size, r);
+    //             this.draw_circle(ctx, x + 0.24 * pu.size, y + 0.24 * pu.size, r);
+    //             this.draw_circle(ctx, x - 0.24 * pu.size, y + 0.24 * pu.size, r);
+    //             this.draw_circle(ctx, x + 0.24 * pu.size, y - 0.24 * pu.size, r);
+    //             break;
+    //     }
+    // }
 
 
     draw_arrowB(ctx, num, x, y) {
@@ -2116,11 +2147,11 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_kakuro(ctx, num, x, y) {
+    draw_kakuro(ctx, num, x, y, ccolor) {
         var th = this.rotate_theta(90) * 180 / Math.PI;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * 2 / Math.sqrt(3), 6, th);
@@ -2131,7 +2162,7 @@ class Puzzle_tri extends Puzzle {
                 this.draw_ast(ctx, x, y, 0.5 * 2 / Math.sqrt(3));
                 break;
             case 2:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTWHITE;
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, 0.5 * 2 / Math.sqrt(3), 6, th);
@@ -2174,13 +2205,13 @@ class Puzzle_tri extends Puzzle {
     }
 
 
-    draw_compass(ctx, num, x, y) {
+    draw_compass(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.5;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * 2 / Math.sqrt(3));
                 break;
@@ -2188,7 +2219,7 @@ class Puzzle_tri extends Puzzle {
                 var r = 0.33;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_ast(ctx, x, y, r * 2 / Math.sqrt(3));
                 break;
@@ -2203,7 +2234,7 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_tents(ctx, num, x, y) {
+    draw_tents(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r1;
@@ -2229,7 +2260,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                ctx.fillStyle = Color.GREY;
+                ctx.fillStyle = ccolor || Color.GREY;
                 ctx.lineWidth = 1;
                 ctx.beginPath();
                 ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) + 0) * pu.size);
@@ -2247,7 +2278,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                ctx.fillStyle = Color.GREY_LIGHT;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 1;
                 r1 = 0.3;
                 r2 = 0.4;
@@ -2263,7 +2294,7 @@ class Puzzle_tri extends Puzzle {
             case 3: //anglers
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
                 ctx.lineWidth = 2;
                 ctx.beginPath();
@@ -2283,12 +2314,12 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_star(ctx, num, x, y) {
+    draw_star(ctx, num, x, y, ccolor) {
         var r1 = 0.25;
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2296,7 +2327,7 @@ class Puzzle_tri extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 2:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2312,7 +2343,7 @@ class Puzzle_tri extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 4:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2320,7 +2351,7 @@ class Puzzle_tri extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 5:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2336,7 +2367,7 @@ class Puzzle_tri extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 7:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2344,7 +2375,7 @@ class Puzzle_tri extends Puzzle {
                 this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
                 break;
             case 8:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2363,7 +2394,7 @@ class Puzzle_tri extends Puzzle {
                 var r = 0.3;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
@@ -2444,23 +2475,23 @@ class Puzzle_tri extends Puzzle {
         ctx.stroke();
     }
 
-    draw_angleloop(ctx, num, x, y) {
+    draw_angleloop(ctx, num, x, y, ccolor) {
         var r;
         switch (num) {
             case 1:
                 r = 0.24;
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_polygon(ctx, x, y, r, 3, 90);
                 break;
             case 2:
                 r = 0.24;
                 set_circle_style(ctx, 5);
-                ctx.fillStyle = Color.GREY;
+                ctx.fillStyle = ccolor || Color.GREY;
                 this.draw_polygon(ctx, x, y, r, 4, 45);
                 break;
             case 3:
                 r = 0.215;
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, r, 5, 90);
                 break;
@@ -2473,7 +2504,7 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.09;
         ctx.setLineDash([]);
@@ -2486,7 +2517,7 @@ class Puzzle_tri extends Puzzle {
             case 5:
             case 6:
                 var th = this.rotate_theta((num - 1) * 60 - 180);
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2494,22 +2525,22 @@ class Puzzle_tri extends Puzzle {
                 this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
                 break;
             case 7:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y) {
+    draw_sun_moon(ctx, num, x, y, ccolor) {
         var r1 = 0.22,
             r2 = 0.20;
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -2527,80 +2558,80 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_pencils(ctx, num, x, y) {
-        var r = 0.2;
-        ctx.setLineDash([]);
-        ctx.lineCap = "butt";
-        ctx.fillStyle = Color.BLACK;
-        ctx.strokeStyle = Color.BLACK;
-        ctx.lineWidth = 2;
-        ctx.lineJoin = "bevel"
-        switch (num) {
-            case 1:
-                ctx.beginPath();
-                ctx.moveTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y - r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + r * pu.size, y + r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-            case 2:
-                ctx.beginPath();
-                ctx.moveTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x + r * pu.size, y + r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - r * pu.size, y + r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-            case 3:
-                ctx.beginPath();
-                ctx.moveTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y + r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x - r * pu.size, y - r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-            case 4:
-                ctx.beginPath();
-                ctx.moveTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
-                ctx.closePath();
-                ctx.stroke();
-                ctx.beginPath();
-                ctx.moveTo(x - r * pu.size, y - r * pu.size);
-                ctx.lineTo(x, y);
-                ctx.lineTo(x + r * pu.size, y - r * pu.size);
-                ctx.closePath();
-                ctx.fill();
-                break;
-        }
-    }
+    // draw_pencils(ctx, num, x, y) {
+    //     var r = 0.2;
+    //     ctx.setLineDash([]);
+    //     ctx.lineCap = "butt";
+    //     ctx.fillStyle = Color.BLACK;
+    //     ctx.strokeStyle = Color.BLACK;
+    //     ctx.lineWidth = 2;
+    //     ctx.lineJoin = "bevel"
+    //     switch (num) {
+    //         case 1:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + r * pu.size, y - r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + r * pu.size, y + r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //         case 2:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x + r * pu.size, y + r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - r * pu.size, y + r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //         case 3:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - 0.5 * pu.size, y + 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - r * pu.size, y + r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x - r * pu.size, y - r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //         case 4:
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + 0.5 * pu.size, y - 0.5 * pu.size);
+    //             ctx.closePath();
+    //             ctx.stroke();
+    //             ctx.beginPath();
+    //             ctx.moveTo(x - r * pu.size, y - r * pu.size);
+    //             ctx.lineTo(x, y);
+    //             ctx.lineTo(x + r * pu.size, y - r * pu.size);
+    //             ctx.closePath();
+    //             ctx.fill();
+    //             break;
+    //     }
+    // }
 
-    draw_sudokuetc(ctx, num, x, y) {
+    draw_sudokuetc(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.14;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.fillStyle = Color.GREY_LIGHT;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 this.draw_polygon(ctx, x - r * pu.size, y + r * pu.size, r * Math.sqrt(2), 4, 45);
                 this.draw_polygon(ctx, x + r * pu.size, y - r * pu.size, r * Math.sqrt(2), 4, 45);
                 ctx.fillStyle = Color.GREY_DARK;
@@ -2610,14 +2641,14 @@ class Puzzle_tri extends Puzzle {
             case 2:
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.fillStyle = Color.TRANSPARENTBLACK;
+                ctx.fillStyle = ccolor || Color.TRANSPARENTBLACK;
                 ctx.strokeStyle = Color.GREY_LIGHT;
                 ctx.lineWidth = 4;
                 this.draw_circle(ctx, x, y, 0.71);
                 break;
             case 3:
                 var r = 0.99;
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 ctx.beginPath();
                 ctx.moveTo(x, y + r * pu.size);
                 ctx.lineTo(x + r * pu.size, y);
@@ -2636,7 +2667,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -2660,7 +2691,7 @@ class Puzzle_tri extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENT;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -2677,9 +2708,9 @@ class Puzzle_tri extends Puzzle {
         }
     }
 
-    draw_polyomino(ctx, num, x, y) {
+    draw_polyomino(ctx, num, x, y, ccolor) {
         ctx.setLineDash([]);
-        ctx.fillStyle = Color.GREY_LIGHT;
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 1.2;
         ctx.lineCap = "butt";

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -731,36 +731,6 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_surface(pu, num = "") {
-        if (num) {
-            var keys = [],
-                key0 = num + "";
-            if (this[pu].surface[key0]) {
-                keys.push(key0);
-            }
-            for (var i = 0; i < this.point[num].adjacent.length; i++) {
-                key0 = this.point[num].adjacent[i] + "";
-                if (keys.indexOf(key0) === -1 && this[pu].surface[key0]) {
-                    keys.push(key0);
-                }
-            }
-        } else {
-            var keys = Object.keys(this[pu].surface);
-        }
-        for (var k = 0; k < keys.length; k++) {
-            var i = keys[k];
-            set_surface_style(this.ctx, this[pu].surface[i]);
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.point[this.point[i].surround[0]].x, this.point[this.point[i].surround[0]].y);
-            for (var j = 1; j < this.point[i].surround.length; j++) {
-                this.ctx.lineTo(this.point[this.point[i].surround[j]].x, this.point[this.point[i].surround[j]].y);
-            }
-            this.ctx.closePath();
-            this.ctx.fill();
-            this.ctx.stroke();
-        }
-    }
-
     draw_polygon(ctx, x, y, r, n, th) {
         ctx.LineCap = "round";
         ctx.beginPath();

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -1186,7 +1186,7 @@ class Puzzle_truncated_square extends Puzzle {
     }
 
     draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
-        var ccolor = "none";
+        let ccolor = undefined;
         if (i !== 'panel' && UserSettings.custom_colors_on && this[qamode + "_col"].symbol[i]) {
             ccolor = this[qamode + "_col"].symbol[i];
         }

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -749,7 +749,11 @@ class Puzzle_truncated_square extends Puzzle {
             if (this[pu].direction[i][0]) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
-                this.ctx.strokeStyle = Color.GREY;
+                if (UserSettings.custom_colors_on && this[pu + "_col"].direction[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].direction[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
                 this.ctx.lineWidth = 3;
                 this.ctx.beginPath();
                 this.ctx.moveTo(this.point[this[pu].direction[i][0]].x, this.point[this[pu].direction[i][0]].y);
@@ -776,6 +780,9 @@ class Puzzle_truncated_square extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -786,6 +793,9 @@ class Puzzle_truncated_square extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 this.ctx.beginPath();
@@ -831,6 +841,9 @@ class Puzzle_truncated_square extends Puzzle {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -841,6 +854,9 @@ class Puzzle_truncated_square extends Puzzle {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 this.ctx.beginPath();
@@ -867,6 +883,9 @@ class Puzzle_truncated_square extends Puzzle {
         /*freeline*/
         for (var i in this[pu].freeline) {
             set_line_style(this.ctx, this[pu].freeline[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
+            }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
             this.ctx.beginPath();
@@ -888,6 +907,9 @@ class Puzzle_truncated_square extends Puzzle {
         }
         for (var i in this[pu].freelineE) {
             set_line_style(this.ctx, this[pu].freelineE[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
+            }
             var i1 = i.split(",")[0];
             var i2 = i.split(",")[1];
             this.ctx.beginPath();
@@ -909,19 +931,6 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_wall(pu) {
-        for (var i in this[pu].wall) {
-            set_line_style(this.ctx, this[pu].wall[i]);
-            this.ctx.lineCap = "butt";
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-            this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            this.ctx.stroke();
-        }
-    }
-
     draw_symbol(pu, layer) {
         /*symbol_layer*/
         var p_x, p_y;
@@ -934,7 +943,11 @@ class Puzzle_truncated_square extends Puzzle {
                 p_y = this.point[i].y;
             }
             if (this[pu].symbol[i][2] === layer) {
-                this.draw_symbol_select(this.ctx, p_x, p_y, this[pu].symbol[i][0], this[pu].symbol[i][1], i);
+                try {
+                    this.draw_symbol_select(this.ctx, p_x, p_y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
+                } catch (err) {
+                    console.error(err);
+                }
             }
         }
     }
@@ -1172,7 +1185,15 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_symbol_select(ctx, x, y, num, sym, loc = 0) {
+    draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
+        var ccolor = "none";
+        if (i !== 'panel' && UserSettings.custom_colors_on && this[qamode + "_col"].symbol[i]) {
+            ccolor = this[qamode + "_col"].symbol[i];
+        }
+        this.draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor);
+    }
+
+    draw_symbol_select_ccolor(ctx, x, y, num, sym, loc, ccolor) {
         switch (sym) {
             /* figure */
             case "circle_L":
@@ -1181,7 +1202,7 @@ class Puzzle_truncated_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.43);
                     this.draw_circle(ctx, x, y, 0.32);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.43);
                 }
                 break;
@@ -1191,7 +1212,7 @@ class Puzzle_truncated_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.35);
                     this.draw_circle(ctx, x, y, 0.25);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.35);
                 }
                 break;
@@ -1201,7 +1222,7 @@ class Puzzle_truncated_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.22);
                     this.draw_circle(ctx, x, y, 0.14);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.22);
                 }
                 break;
@@ -1211,115 +1232,115 @@ class Puzzle_truncated_square extends Puzzle {
                     this.draw_circle(ctx, x, y, 0.13);
                     this.draw_circle(ctx, x, y, 0.07);
                 } else {
-                    set_circle_style(ctx, num);
+                    set_circle_style(ctx, num, ccolor);
                     this.draw_circle(ctx, x, y, 0.13);
                 }
                 break;
             case "square_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, 45);
                 break;
             case "square_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4 * Math.sqrt(2), 4, 45);
                 break;
             case "square_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.35 * Math.sqrt(2), 4, 45);
                 break;
             case "square_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.22 * Math.sqrt(2), 4, 45);
                 break;
             case "square_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13 * Math.sqrt(2), 4, 45);
                 break;
             case "triup_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.5 * 0.25 * this.size, 0.5, 3, 90);
                 break;
             case "triup_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.4 * 0.25 * this.size, 0.4, 3, 90);
                 break;
             case "triup_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y + 0.16 * 0.25 * this.size, 0.16, 3, 90);
                 break;
             case "tridown_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.5 * 0.25 * this.size, 0.5, 3, -90);
                 break;
             case "tridown_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.4 * 0.25 * this.size, 0.4, 3, -90);
                 break;
             case "tridown_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y - 0.16 * 0.25 * this.size, 0.16, 3, -90);
                 break;
             case "diamond_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.43, 4, 0);
                 break;
             case "diamond_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.35, 4, 0);
                 break;
             case "diamond_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.22, 4, 0);
                 break;
             case "diamond_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 4, 0);
                 break;
             case "hexpoint_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 30);
                 break;
             case "hexpoint_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 30);
                 break;
             case "hexpoint_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 30);
                 break;
             case "hexpoint_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 30);
                 break;
             case "hexpoint_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 30);
                 break;
             case "hexflat_LL":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.48, 6, 0);
                 break;
             case "hexflat_L":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.4, 6, 0);
                 break;
             case "hexflat_M":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.3, 6, 0);
                 break;
             case "hexflat_S":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.2, 6, 0);
                 break;
             case "hexflat_SS":
-                set_circle_style(ctx, num);
+                set_circle_style(ctx, num, ccolor);
                 this.draw_polygon(ctx, x, y, 0.13, 6, 0);
                 break;
             case "ox_B":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTWHITE;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 2;
                 this.draw_ox(ctx, num, x, y);
                 break;
@@ -1340,118 +1361,118 @@ class Puzzle_truncated_square extends Puzzle {
                 this.draw_ox(ctx, num, x, y);
                 break;
             case "tri":
-                this.draw_tri(ctx, num, x, y);
+                this.draw_tri(ctx, num, x, y, ccolor);
                 break;
             case "cross":
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 3;
                 this.draw_cross(ctx, num, x, y);
                 break;
             case "line":
-                this.draw_linesym(ctx, num, x, y);
+                this.draw_linesym(ctx, num, x, y, ccolor);
                 break;
             case "frameline":
-                this.draw_framelinesym(ctx, num, x, y);
+                this.draw_framelinesym(ctx, num, x, y, ccolor);
                 break;
 
                 //number
             case "inequality":
-                set_circle_style(ctx, 10);
+                set_circle_style(ctx, 10, ccolor);
                 this.draw_inequality(ctx, num, x, y);
                 break;
             case "math":
-                set_font_style(ctx, 0.8 * pu.size.toString(10), 1);
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 1, ccolor);
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "math_G":
-                set_font_style(ctx, 0.8 * pu.size.toString(10), 2);
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 2, ccolor);
                 this.draw_math(ctx, num, x, y + 0.05 * pu.size);
                 break;
             case "degital":
-                this.draw_degital(ctx, num, x, y);
+                this.draw_degital(ctx, num, x, y, ccolor);
                 break;
             case "degital_f":
-                this.draw_degital_f(ctx, num, x, y);
+                this.draw_degital_f(ctx, num, x, y, ccolor);
                 break;
             case "dice":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_dice(ctx, num, x, y);
                 break;
             case "pills":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_pills(ctx, num, x, y);
                 break;
 
                 /* arrow */
             case "arrow_B_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_B_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_B_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowB(ctx, num, x, y);
                 break;
             case "arrow_N_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_N_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_N_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowN(ctx, num, x, y);
                 break;
             case "arrow_S":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowS(ctx, num, x, y);
                 break;
             case "arrow_GP":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP(ctx, num, x, y);
                 break;
             case "arrow_GP_C":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowGP_C(ctx, num, x, y);
                 break;
             case "arrow_Short":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowShort(ctx, num, x, y);
                 break;
             case "arrow_tri_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_tri_G":
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_tri_W":
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_arrowtri(ctx, num, x, y);
                 break;
             case "arrow_cross":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowcross(ctx, num, x, y);
                 break;
             case "arrow_eight":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arroweight(ctx, num, x, y);
                 break;
             case "arrow_fourtip":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_arrowfourtip(ctx, num, x, y);
                 break;
             case "arrow_fouredge_B":
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
                 this.draw_arrowfouredge(ctx, num, x, y);
                 break;
@@ -1469,53 +1490,53 @@ class Puzzle_truncated_square extends Puzzle {
                 break;
 
                 /* special */
-            case "kakuro":
-                this.draw_kakuro(ctx, num, x, y);
-                break;
-            case "compass":
-                this.draw_compass(ctx, num, x, y);
-                break;
+            // case "kakuro":
+            //     this.draw_kakuro(ctx, num, x, y, ccolor);
+            //     break;
+            // case "compass":
+            //     this.draw_compass(ctx, num, x, y, ccolor);
+            //     break;
             case "star":
-                this.draw_star(ctx, num, x, y, loc);
+                this.draw_star(ctx, num, x, y, loc, ccolor);
                 break;
             case "tents":
-                this.draw_tents(ctx, num, x, y);
+                this.draw_tents(ctx, num, x, y, ccolor);
                 break;
-            case "battleship_B":
-                set_circle_style(ctx, 2);
-                this.draw_battleship(ctx, num, x, y);
-                break;
-            case "battleship_G":
-                set_circle_style(ctx, 3);
-                ctx.fillStyle = Color.GREY;
-                this.draw_battleship(ctx, num, x, y);
-                break;
-            case "battleship_W":
-                ctx.setLineDash([]);
-                ctx.lineCap = "butt";
-                ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
-                ctx.lineWidth = 2;
-                this.draw_battleship(ctx, num, x, y);
-                break;
+            // case "battleship_B":
+            //     set_circle_style(ctx, 2);
+            //     this.draw_battleship(ctx, num, x, y, ccolor);
+            //     break;
+            // case "battleship_G":
+            //     set_circle_style(ctx, 3);
+            //     ctx.fillStyle = Color.GREY;
+            //     this.draw_battleship(ctx, num, x, y);
+            //     break;
+            // case "battleship_W":
+            //     ctx.setLineDash([]);
+            //     ctx.lineCap = "butt";
+            //     ctx.fillStyle = Color.TRANSPARENTBLACK;
+            //     ctx.strokeStyle = Color.BLACK;
+            //     ctx.lineWidth = 2;
+            //     this.draw_battleship(ctx, num, x, y);
+            //     break;
             case "angleloop":
-                this.draw_angleloop(ctx, num, x, y);
+                this.draw_angleloop(ctx, num, x, y, ccolor);
                 break;
             case "firefly":
-                this.draw_firefly(ctx, num, x, y);
+                this.draw_firefly(ctx, num, x, y, ccolor);
                 break;
             case "sun_moon":
-                this.draw_sun_moon(ctx, num, x, y, loc);
+                this.draw_sun_moon(ctx, num, x, y, loc, ccolor);
                 break;
             case "sudokuetc":
-                this.draw_sudokuetc(ctx, num, x, y);
+                this.draw_sudokuetc(ctx, num, x, y, ccolor);
                 break;
             case "polyomino":
-                this.draw_polyomino(ctx, num, x, y);
+                this.draw_polyomino(ctx, num, x, y, ccolor);
                 break;
-            case "pencils":
-                this.draw_pencils(ctx, num, x, y);
-                break;
+            // case "pencils":
+            //     this.draw_pencils(ctx, num, x, y);
+            //     break;
         }
     }
 
@@ -1621,12 +1642,12 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_linesym(ctx, num, x, y) {
+    draw_linesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
         ctx.fillStyle = Color.TRANSPARENTBLACK;
-        ctx.strokeStyle = Color.BLACK;
+        ctx.strokeStyle = ccolor || Color.BLACK;
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
@@ -1687,7 +1708,7 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_framelinesym(ctx, num, x, y) {
+    draw_framelinesym(ctx, num, x, y, ccolor) {
         var r = 0.32;
         ctx.setLineDash([]);
         ctx.lineCap = "round";
@@ -1696,7 +1717,7 @@ class Puzzle_truncated_square extends Puzzle {
         ctx.lineWidth = 3;
         switch (num) {
             case 1:
-                set_line_style(ctx, 115)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1705,7 +1726,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 2:
-                set_line_style(ctx, 15)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1714,7 +1735,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 3:
-                set_line_style(ctx, 16)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1723,7 +1744,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 4:
-                set_line_style(ctx, 110)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x + r * pu.size, y - r * pu.size);
@@ -1732,7 +1753,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 5:
-                set_line_style(ctx, 115)
+                set_line_style(ctx, 115, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1741,7 +1762,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 6:
-                set_line_style(ctx, 15)
+                set_line_style(ctx, 15, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1750,7 +1771,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 7:
-                set_line_style(ctx, 16)
+                set_line_style(ctx, 16, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1759,7 +1780,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 8:
-                set_line_style(ctx, 110)
+                set_line_style(ctx, 110, ccolor);
                 r = r / Math.sqrt(2);
                 ctx.beginPath();
                 ctx.moveTo(x - r * pu.size, y - r * pu.size);
@@ -1849,8 +1870,8 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_degital(ctx, num, x, y) {
-        set_circle_style(ctx, 2);
+    draw_degital(ctx, num, x, y, ccolor) {
+        set_circle_style(ctx, 2, ccolor);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.17;
         z2 = 0.015;
@@ -1909,7 +1930,7 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_degital_f(ctx, num, x, y) {
+    draw_degital_f(ctx, num, x, y, ccolor) {
         set_circle_style(ctx, 3);
         var w1, w2, w3, w4, z1, z2;
         z1 = 0.17;
@@ -1961,7 +1982,7 @@ class Puzzle_truncated_square extends Puzzle {
         ctx.fill();
 
         //contents
-        this.draw_degital(ctx, num, x, y);
+        this.draw_degital(ctx, num, x, y, ccolor);
     }
 
     draw_dice(ctx, num, x, y) {
@@ -2188,7 +2209,7 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_tents(ctx, num, x, y) {
+    draw_tents(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r1;
@@ -2214,7 +2235,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                ctx.fillStyle = Color.GREY;
+                ctx.fillStyle = ccolor || Color.GREY;
                 ctx.lineWidth = 1;
                 ctx.beginPath();
                 ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) + 0) * pu.size);
@@ -2232,7 +2253,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
-                ctx.fillStyle = Color.GREY_LIGHT;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 1;
                 r1 = 0.3;
                 r2 = 0.4;
@@ -2248,7 +2269,7 @@ class Puzzle_truncated_square extends Puzzle {
             case 3: //anglers
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
                 ctx.lineWidth = 2;
                 ctx.beginPath();
@@ -2260,7 +2281,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.stroke();
                 break;
             case 4:
-                set_font_style(ctx, 0.8 * pu.size.toString(10), 1);
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 1, ccolor);
                 ctx.text("～", x, y - 0.11 * pu.size);
                 ctx.text("～", x, y + 0.09 * pu.size);
                 ctx.text("～", x, y + 0.29 * pu.size);
@@ -2268,7 +2289,7 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_star(ctx, num, x, y, loc) {
+    draw_star(ctx, num, x, y, loc, ccolor) {
         if (parseInt(loc % 2) === 0) { // Even numbers are octa shape, odd numbers are square shape
             var r1 = 0.5;
             var r = 0.5;
@@ -2279,7 +2300,7 @@ class Puzzle_truncated_square extends Puzzle {
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2287,7 +2308,7 @@ class Puzzle_truncated_square extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 2:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2303,7 +2324,7 @@ class Puzzle_truncated_square extends Puzzle {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 4:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2311,7 +2332,7 @@ class Puzzle_truncated_square extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 5:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2327,7 +2348,7 @@ class Puzzle_truncated_square extends Puzzle {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 7:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -2335,7 +2356,7 @@ class Puzzle_truncated_square extends Puzzle {
                 this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
                 break;
             case 8:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2353,7 +2374,7 @@ class Puzzle_truncated_square extends Puzzle {
             case 0:
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
@@ -2377,23 +2398,23 @@ class Puzzle_truncated_square extends Puzzle {
         ctx.stroke();
     }
 
-    draw_angleloop(ctx, num, x, y) {
+    draw_angleloop(ctx, num, x, y, ccolor) {
         var r;
         switch (num) {
             case 1:
                 r = 0.24;
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 this.draw_polygon(ctx, x, y, r, 3, 90);
                 break;
             case 2:
                 r = 0.24;
                 set_circle_style(ctx, 5);
-                ctx.fillStyle = Color.GREY;
+                ctx.fillStyle = ccolor || Color.GREY;
                 this.draw_polygon(ctx, x, y, r, 4, 45);
                 break;
             case 3:
                 r = 0.215;
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 ctx.lineWidth = 1;
                 this.draw_polygon(ctx, x, y, r, 5, 90);
                 break;
@@ -2406,87 +2427,24 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.25,
             r2 = 0.09;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
+        const thMap = {1: -90, 2: 90, 3: -45, 4: 45, 5: -225, 6: 225, 7: 135, 8: 180, 9: 0};
         switch (num) {
             case 1:
-                var th = this.rotate_theta(-90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 2:
-                var th = this.rotate_theta(90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 3:
-                var th = this.rotate_theta(-45);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 4:
-                var th = this.rotate_theta(45);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 5:
-                var th = this.rotate_theta(-225);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 6:
-                var th = this.rotate_theta(225);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 7:
-                var th = this.rotate_theta(135);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 8:
-                var th = this.rotate_theta(180);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 9:
-                var th = this.rotate_theta(0);
-                set_circle_style(ctx, 1);
+                var th = this.rotate_theta(thMap[num]);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -2494,13 +2452,13 @@ class Puzzle_truncated_square extends Puzzle {
                 this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
                 break;
             case 0:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y, loc) {
+    draw_sun_moon(ctx, num, x, y, loc, ccolor) {
         if (this.point[loc].surround.length === 4) {
             var r1 = 0.24,
                 r2 = 0.22,
@@ -2516,11 +2474,11 @@ class Puzzle_truncated_square extends Puzzle {
         }
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -2538,12 +2496,12 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_sudokuetc(ctx, num, x, y) {
+    draw_sudokuetc(ctx, num, x, y, ccolor) {
         switch (num) {
             case 1:
                 var r = 0.14;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.fillStyle = Color.GREY_LIGHT;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
                 this.draw_polygon(ctx, x - r * pu.size, y + r * pu.size, r * Math.sqrt(2), 4, 45);
                 this.draw_polygon(ctx, x + r * pu.size, y - r * pu.size, r * Math.sqrt(2), 4, 45);
                 ctx.fillStyle = Color.GREY_DARK;
@@ -2554,13 +2512,13 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.GREY_LIGHT;
+                ctx.strokeStyle = ccolor || Color.GREY_LIGHT;
                 ctx.lineWidth = 4;
                 this.draw_circle(ctx, x, y, 0.71);
                 break;
             case 3:
                 var r = 0.99;
-                set_circle_style(ctx, 3);
+                set_circle_style(ctx, 3, ccolor);
                 ctx.beginPath();
                 ctx.moveTo(x, y + r * pu.size);
                 ctx.lineTo(x + r * pu.size, y);
@@ -2579,7 +2537,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -2603,7 +2561,7 @@ class Puzzle_truncated_square extends Puzzle {
                 ctx.lineWidth = 2;
                 ctx.setLineDash([]);
                 ctx.fillStyle = Color.TRANSPARENTBLACK;
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.beginPath()
                 ctx.moveTo(x + r, y);
                 ctx.lineTo(x + w - r, y);
@@ -2620,9 +2578,9 @@ class Puzzle_truncated_square extends Puzzle {
         }
     }
 
-    draw_polyomino(ctx, num, x, y) {
+    draw_polyomino(ctx, num, x, y, ccolor) {
         ctx.setLineDash([]);
-        ctx.fillStyle = Color.GREY_LIGHT;
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
         ctx.strokeStyle = Color.BLACK;
         ctx.lineWidth = 1.2;
         ctx.lineCap = "butt";
@@ -3138,7 +3096,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
         this.redraw();
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.09;
         ctx.setLineDash([]);
@@ -3153,7 +3111,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
             case 7:
             case 8:
                 var th = this.rotate_theta((num - 1) * 45 - 180);
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -3161,22 +3119,22 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                 this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
                 break;
             case 9:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y) {
+    draw_sun_moon(ctx, num, x, y, loc, ccolor) {
         var r1 = 0.22,
             r2 = 0.20;
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -3194,12 +3152,12 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
         }
     }
 
-    draw_star(ctx, num, x, y) {
+    draw_star(ctx, num, x, y, loc, ccolor) {
         var r1 = 0.25;
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -3210,7 +3168,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                 var r = 0.25;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
@@ -3733,7 +3691,7 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
         return th;
     }
 
-    draw_star(ctx, num, x, y, loc) {
+    draw_star(ctx, num, x, y, loc, ccolor) {
         if (this.point[loc].surround.length === 3) {
             var r1 = 0.2;
             var r = 0.2;
@@ -3744,7 +3702,7 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -3754,14 +3712,14 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
             case 0:
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y, loc) {
+    draw_sun_moon(ctx, num, x, y, loc, ccolor) {
         if (this.point[loc].surround.length === 3) {
             var r1 = 0.26,
                 r2 = 0.24,
@@ -3777,11 +3735,11 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
         }
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -3799,96 +3757,25 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.25,
             r2 = 0.09;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
+        const thMap = {1: -90, 2: 90, 3: -30, 4: 60, 5: 150, 6: 240, 7: 210, 8: 180, 9: 0, 0: 30};
         switch (num) {
             case 1:
-                var th = this.rotate_theta(-90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 2:
-                var th = this.rotate_theta(90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 3:
-                var th = this.rotate_theta(-30);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 4:
-                var th = this.rotate_theta(60);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 5:
-                var th = this.rotate_theta(150);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 6:
-                var th = this.rotate_theta(240);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 7:
-                var th = this.rotate_theta(210);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 8:
-                var th = this.rotate_theta(180);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 9:
-                var th = this.rotate_theta(0);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 0:
-                var th = this.rotate_theta(30);
-                set_circle_style(ctx, 1);
+                var th = this.rotate_theta(thMap[num]);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -4431,13 +4318,13 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
         return th;
     }
 
-    draw_star(ctx, num, x, y) {
+    draw_star(ctx, num, x, y, loc, ccolor) {
         var r1 = 0.4
         var r2 = 0.382 * r1;
         var r = 0.4;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -4447,109 +4334,38 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
             case 0:
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.25,
             r2 = 0.09;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
-        switch (num) {
+        const thMap = {1: -90, 2: 90, 3: -30, 4: 60, 5: 150, 6: 240, 7: 210, 8: 180, 9: 0, 0: 30};
+        switch (num) {            
             case 1:
-                var th = this.rotate_theta(-90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 2:
-                var th = this.rotate_theta(90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 3:
-                var th = this.rotate_theta(-30);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 4:
-                var th = this.rotate_theta(60);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 5:
-                var th = this.rotate_theta(150);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 6:
-                var th = this.rotate_theta(240);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 7:
-                var th = this.rotate_theta(210);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 8:
-                var th = this.rotate_theta(180);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 9:
-                var th = this.rotate_theta(0);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 0:
-                var th = this.rotate_theta(30);
-                set_circle_style(ctx, 1);
+                var th = this.rotate_theta(thMap[num]);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
                 ctx.lineWidth = 2;
                 this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
+                break;        
         }
     }
 }
@@ -4591,78 +4407,6 @@ class Puzzle_iso extends Puzzle_truncated_square {
         this.reset();
         PenpaUI.set_visible_modes_by_gridtype(this.gridtype);
         document.getElementById("sub_lineE2_lb").style.display = "inline-block";
-    }
-
-    erase_buttons() {
-        // One time operation when the grid is created
-        // Remove all modes, square grid is the reference as it has all the modes
-        for (var i of penpa_modes["square"]['mode']) {
-            document.getElementById("mo_" + i + "_lb").style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['sub']) {
-            document.getElementById("sub_" + i + "_lb").style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['customcolor']) {
-            document.getElementById(i).style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['ms']) {
-            document.getElementById("ms_" + i).parentElement.style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['ms1']) {
-            document.getElementById("ms1_" + i).parentElement.style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['ms3']) {
-            document.getElementById("ms3_" + i).parentElement.style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['shapemodes']) {
-            document.getElementById(i).style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['combisub']) {
-            document.getElementById("combisub_" + i).parentElement.style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['subcombi']) {
-            document.getElementById(i).style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['top_buttons']) {
-            document.getElementById(i).style.display = "none";
-        }
-        for (var i of penpa_modes["square"]['exceptions']) {
-            document.getElementById(i).style.display = "none";
-        }
-        // Add all modes only applicable to this grid type
-        for (var i of penpa_modes[this.gridtype]['mode']) {
-            document.getElementById("mo_" + i + "_lb").style.display = "inline-block";
-        }
-        for (var i of penpa_modes[this.gridtype]['sub']) {
-            document.getElementById("sub_" + i + "_lb").style.display = "inline-block";
-        }
-        for (var i of penpa_modes[this.gridtype]['customcolor']) {
-            document.getElementById(i).style.display = "table-row";
-        }
-        for (var i of penpa_modes[this.gridtype]['ms']) {
-            document.getElementById("ms_" + i).parentElement.style.display = "list-item";
-        }
-        for (var i of penpa_modes[this.gridtype]['ms1']) {
-            document.getElementById("ms1_" + i).parentElement.style.display = "list-item";
-        }
-        for (var i of penpa_modes[this.gridtype]['ms3']) {
-            document.getElementById("ms3_" + i).parentElement.style.display = "list-item";
-        }
-        for (var i of penpa_modes[this.gridtype]['shapemodes']) {
-            document.getElementById(i).style.display = "inline-block";
-        }
-        for (var i of penpa_modes[this.gridtype]['combisub']) {
-            document.getElementById("combisub_" + i).parentElement.style.display = "list-item";
-        }
-        for (var i of penpa_modes[this.gridtype]['subcombi']) {
-            document.getElementById(i).style.display = "inline-block";
-        }
-        for (var i of penpa_modes[this.gridtype]['top_buttons']) {
-            document.getElementById(i).style.display = "inline-block";
-        }
-        for (var i of penpa_modes[this.gridtype]['exceptions']) {
-            document.getElementById(i).style.display = "inline-block";
-        }
     }
 
     create_point() {
@@ -5158,6 +4902,9 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -5168,6 +4915,9 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].line[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 var i3;
@@ -5222,6 +4972,9 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 var x = this.point[i].x;
                 var y = this.point[i].y;
                 set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 this.ctx.beginPath();
                 this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
                 this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
@@ -5232,6 +4985,9 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.ctx.stroke();
             } else {
                 set_line_style(this.ctx, this[pu].lineE[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
                 this.ctx.beginPath();
@@ -5613,12 +5369,12 @@ class Puzzle_iso extends Puzzle_truncated_square {
         return th;
     }
 
-    draw_star(ctx, num, x, y) {
+    draw_star(ctx, num, x, y, loc, ccolor) {
         var r1 = 0.38;
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -5626,7 +5382,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 2:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -5642,7 +5398,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
                 break;
             case 4:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -5650,7 +5406,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 5:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -5666,7 +5422,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
                 break;
             case 7:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -5674,7 +5430,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
                 break;
             case 8:
-                ctx.fillStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.BLACK;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -5693,23 +5449,23 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 var r = 0.4;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y) {
+    draw_sun_moon(ctx, num, x, y, loc, ccolor) {
         var r1 = 0.36,
             r2 = 0.34;
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -5727,69 +5483,22 @@ class Puzzle_iso extends Puzzle_truncated_square {
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.36,
             r2 = 0.09;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
+        const thMap = {1: -90, 2: 90, 3: -30, 4: 30, 5: -210, 6: 210, 7: 150};
         switch (num) {
             case 1:
-                var th = this.rotate_theta(-90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 2:
-                var th = this.rotate_theta(90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 3:
-                var th = this.rotate_theta(-30);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 4:
-                var th = this.rotate_theta(30);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 5:
-                var th = this.rotate_theta(-210);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 6:
-                var th = this.rotate_theta(210);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
-            case 7:
-                var th = this.rotate_theta(150);
-                set_circle_style(ctx, 1);
+            case 7:                
+                var th = this.rotate_theta(thMap[num]);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -5797,7 +5506,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
                 break;
             case 8:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
         }
@@ -6336,7 +6045,7 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
         return th;
     }
 
-    draw_star(ctx, num, x, y, loc) {
+    draw_star(ctx, num, x, y, loc, ccolor) {
         if (this.point[loc].surround.length === 3) {
             var r1 = 0.2;
             var r = 0.2;
@@ -6347,7 +6056,7 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -6357,14 +6066,14 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
             case 0:
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y, loc) {
+    draw_sun_moon(ctx, num, x, y, loc, ccolor) {
         if (this.point[loc].surround.length === 3) {
             var r1 = 0.26,
                 r2 = 0.24,
@@ -6380,11 +6089,11 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
         }
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -6402,96 +6111,25 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.25,
             r2 = 0.09;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
+        const thMap = {1: -90, 2: 90, 3: -30, 4: 60, 5: 150, 6: 240, 7: 210, 8: 180, 9: 0, 0: 30};
         switch (num) {
             case 1:
-                var th = this.rotate_theta(-90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 2:
-                var th = this.rotate_theta(90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 3:
-                var th = this.rotate_theta(-30);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 4:
-                var th = this.rotate_theta(60);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 5:
-                var th = this.rotate_theta(150);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 6:
-                var th = this.rotate_theta(240);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 7:
-                var th = this.rotate_theta(210);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 8:
-                var th = this.rotate_theta(180);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 9:
-                var th = this.rotate_theta(0);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 0:
-                var th = this.rotate_theta(30);
-                set_circle_style(ctx, 1);
+                var th = this.rotate_theta(thMap[num]);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;
@@ -7047,7 +6685,7 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
         return th;
     }
 
-    draw_star(ctx, num, x, y, loc) {
+    draw_star(ctx, num, x, y, loc, ccolor) {
         if (this.point[loc].surround.length === 3) {
             var r1 = 0.2;
             var r = 0.2;
@@ -7058,7 +6696,7 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
         var r2 = 0.382 * r1;
         switch (num) {
             case 1:
-                ctx.fillStyle = Color.WHITE;
+                ctx.fillStyle = ccolor || Color.WHITE;
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
                 ctx.strokeStyle = Color.BLACK;
@@ -7068,14 +6706,14 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
             case 0:
                 ctx.setLineDash([]);
                 ctx.lineCap = "butt";
-                ctx.strokeStyle = Color.BLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
                 ctx.lineWidth = 1;
                 this.draw_x(ctx, x, y, r)
                 break;
         }
     }
 
-    draw_sun_moon(ctx, num, x, y, loc) {
+    draw_sun_moon(ctx, num, x, y, loc, ccolor) {
         if (this.point[loc].surround.length === 3) {
             var r1 = 0.26,
                 r2 = 0.24,
@@ -7091,11 +6729,11 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
         }
         switch (num) {
             case 1:
-                set_circle_style(ctx, 1);
+                set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 break;
             case 2:
-                set_circle_style(ctx, 2);
+                set_circle_style(ctx, 2, ccolor);
                 ctx.beginPath();
                 ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
                 ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
@@ -7113,96 +6751,25 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
         }
     }
 
-    draw_firefly(ctx, num, x, y) {
+    draw_firefly(ctx, num, x, y, ccolor) {
         var r1 = 0.25,
             r2 = 0.09;
         ctx.setLineDash([]);
         ctx.lineCap = "butt";
+        const thMap = {1: -90, 2: 90, 3: -30, 4: 60, 5: 150, 6: 240, 7: 210, 8: 180, 9: 0, 0: 30};
         switch (num) {
             case 1:
-                var th = this.rotate_theta(-90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 2:
-                var th = this.rotate_theta(90);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 3:
-                var th = this.rotate_theta(-30);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 4:
-                var th = this.rotate_theta(60);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 5:
-                var th = this.rotate_theta(150);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 6:
-                var th = this.rotate_theta(240);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 7:
-                var th = this.rotate_theta(210);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 8:
-                var th = this.rotate_theta(180);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 9:
-                var th = this.rotate_theta(0);
-                set_circle_style(ctx, 1);
-                this.draw_circle(ctx, x, y, r1);
-                ctx.fillStyle = Color.BLACK;
-                ctx.strokeStyle = Color.TRANSPARENTBLACK;
-                ctx.lineWidth = 2;
-                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
-                break;
             case 0:
-                var th = this.rotate_theta(30);
-                set_circle_style(ctx, 1);
+                var th = this.rotate_theta(thMap[num]);
+                this.set_circle_style(ctx, 1, ccolor);
                 this.draw_circle(ctx, x, y, r1);
                 ctx.fillStyle = Color.BLACK;
                 ctx.strokeStyle = Color.TRANSPARENTBLACK;

--- a/docs/js/customcolor.js
+++ b/docs/js/customcolor.js
@@ -1,0 +1,164 @@
+const CustomColor = (() => {
+    "use strict";
+
+    function default_symbol_color(name) {
+        switch (name) {
+            case "circle_L":
+            case "circle_M":
+            case "circle_S":
+            case "circle_SS":
+            case "square_LL":
+            case "square_L":
+            case "square_M":
+            case "square_S":
+            case "square_SS":
+            case "triup_L":
+            case "triup_M":
+            case "triup_S":
+            case "triup_SS":
+            case "tridown_L":
+            case "tridown_M":
+            case "tridown_S":
+            case "tridown_SS":
+            case "triright_L":
+            case "triright_M":
+            case "triright_S":
+            case "triright_SS":
+            case "trileft_L":
+            case "trileft_M":
+            case "trileft_S":
+            case "trileft_SS":
+            case "diamond_L":
+            case "diamond_M":
+            case "diamond_S":
+            case "diamond_SS":
+            case "hexpoint_LL":
+            case "hexpoint_L":
+            case "hexpoint_M":
+            case "hexpoint_S":
+            case "hexpoint_SS":
+            case "hexflat_LL":
+            case "hexflat_L":
+            case "hexflat_M":
+            case "hexflat_S":
+            case "hexflat_SS":
+            case "star":
+            case "firefly":
+            case "sun_moon":
+            case "slovak":
+                return Color.WHITE;
+            case "frameline":
+                return Color.GREY_DARK;
+            case "pills":
+            case "tents":
+                return Color.GREY;
+            case "sudokuetc":
+            case "polyomino":
+            case "polyhex":
+            case "neighbors":
+                return Color.GREY_LIGHT;
+        }
+        return Color.BLACK;
+    }
+
+    function default_combimode_color(mode) {
+        // switch (mode) {
+        //     case "linex":
+        //     case "lineox":
+        //     case "edgex":
+        //     case "edgexoi":
+        //     case "yajilin":
+        //     case "hashi":
+        //         return Color.GREEN;
+        //     case "edgesub":
+        //         return Color.GREY;
+        // }
+        return null; // Don't use custom color
+    }
+
+    function default_specialmode_color(name) {
+        if (name.substring(0, 11) === "sub_special") {
+            return this.default_special_style_color(name.substring(11));
+        }
+        return undefined;
+    }
+
+    function default_special_style_color(name) {
+        switch (name) {
+            case "thermo": return Color.GREY_LIGHT;
+            case "nobulbthermo": return Color.GREY_LIGHT;
+            case "arrows": return Color.GREY_DARK_LIGHT;
+            case "direction": return Color.GREY_DARK_LIGHT;
+            case "squareframe": return Color.GREY_LIGHT;
+            case "polygon": return Color.BLACK;
+        }
+        return undefined;
+    }
+
+    function default_stylemode_color(name) {
+        // name = "st_" + mode + stylenumber
+        const [_, mode, style] = name.match(/^st_([^\d]+)(.*)/) || [];
+        switch (mode) {
+            case "surface": return this.default_surface_style_color(style);
+            case "lineE":
+            case "line":
+            case "wall":
+            case "cage": return this.default_line_style_color(style);
+        }
+        return undefined;
+    }
+
+    function default_surface_style_color(style) {
+        switch (String(style)) {
+            case "1": return Color.GREY_DARK_VERY;
+            case "8": return Color.GREY;
+            case "3": return Color.GREY_LIGHT;
+            case "4": return Color.BLACK;
+            case "2": return Color.GREEN_LIGHT_VERY;
+            case "5": return Color.BLUE_LIGHT_VERY;
+            case "6": return Color.RED_LIGHT;
+            case "7": return Color.YELLOW;
+            case "9": return Color.PINK_LIGHT;
+            case "10": return Color.ORANGE_LIGHT;
+            case "11": return Color.PURPLE_LIGHT;
+            case "12": return Color.BROWN_LIGHT;
+        }        
+        return undefined;
+    }
+
+    function default_line_style_color(style) {
+        switch (String(style)) {
+            case "1": return Color.BLACK;
+            case "2": return Color.BLACK;
+            case "3": return Color.GREEN;
+            case "5": return Color.GREY;
+            case "7": return Color.GREY_DARK;
+            case "8": return Color.RED;
+            case "9": return Color.BLUE_LIGHT;
+            case "10": return Color.BLACK;
+            case "12": return Color.GREY_DARK_VERY;
+            case "13": return Color.BLACK;
+            case "14": return Color.GREY_DARK;
+            case "15": return Color.GREY_DARK;
+            case "16": return Color.BLACK;
+            case "17": return Color.BLACK;
+            case "21": return Color.BLACK;
+            case "30": return Color.GREEN;
+            case "40": return Color.GREY;
+            case "80": return Color.BLACK;
+            case "98": return Color.GREEN;
+        }
+        return undefined;
+    }
+
+    return {
+        default_symbol_color,
+        default_combimode_color,
+        default_specialmode_color,
+        default_special_style_color,
+        default_stylemode_color,
+        default_surface_style_color,
+        default_line_style_color,
+    };
+
+})();

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -4910,3 +4910,13 @@ function hide_element_by_id(s) {
     let element = document.getElementById(s);
     element.parentElement.style.contentVisibility = 'hidden';
 }
+
+// Polyfills
+if (!String.prototype.startsWith) {
+    Object.defineProperty(String.prototype, 'startsWith', {
+        value: function(search, rawPos) {
+            var pos = rawPos > 0 ? rawPos|0 : 0;
+            return this.substring(pos, pos + search.length) === search;
+        }
+    });
+}

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -192,10 +192,27 @@ function create_newboard() {
         pu = make_class(gridtype);
         pu.mode = mode;
 
-        // update default composite mode for special grids
+        // update mode defaults for special grids
         if (!(gridtype === "square" || gridtype === "sudoku" || gridtype === "kakuro")) {
             pu.mode["pu_q"]["combi"] = ["linex", ""];
             pu.mode["pu_a"]["combi"] = ["linex", ""];
+            pu.mode["pu_q"]["symbol"] = ["circle_L", 1];
+            pu.mode["pu_a"]["symbol"] = ["circle_L", 1];
+        }
+
+        // Update mode states for grid type having unavailable sub modes
+        for (let q of ["pu_q", "pu_a"]) {
+            for (let mode in pu.mode[q]) {
+                const submode = `${mode}${pu.mode[q][mode][0]}`;
+                // A valid but unavailable sub mode
+                if (penpa_modes["square"].sub.includes(submode) && !penpa_modes[pu.gridtype].sub.includes(submode)) {
+                    // Replace state with first sub mode which is available for this grid type
+                    let newsub = penpa_modes[pu.gridtype].sub.find(s => s.startsWith(mode));
+                    if (newsub) {
+                        pu.mode[q][mode][0] = newsub.substring(mode.length);
+                    }
+                }
+            }
         }
 
         pu.reset_frame(); // Draw the board
@@ -298,7 +315,7 @@ function make_class(gridtype, loadtype = 'new') {
             if (n0 <= gridmax['cube'] && n0 > 0) {
                 pu = new Puzzle_iso(n0, n0, size);
             } else {
-                errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['iso'] + '</h2>');
+                errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['cube'] + '</h2>');
             }
             break;
         case "sudoku":
@@ -475,7 +492,7 @@ function make_class(gridtype, loadtype = 'new') {
             break;
         case "truncated_square":
             var n0 = parseInt(document.getElementById("nb_size1").value, 10);
-            if (n0 <= 20 && n0 > 0) {
+            if (n0 <= gridmax['truncated'] && n0 > 0) {
                 pu = new Puzzle_truncated_square(n0, n0, size);
             } else {
                 errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['truncated'] + '</h2>');
@@ -483,7 +500,7 @@ function make_class(gridtype, loadtype = 'new') {
             break;
         case "tetrakis_square":
             var n0 = parseInt(document.getElementById("nb_size1").value, 10);
-            if (n0 <= 20 && n0 > 0) {
+            if (n0 <= gridmax['tetrakis'] && n0 > 0) {
                 pu = new Puzzle_tetrakis_square(n0, n0, size);
             } else {
                 errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['tetrakis'] + '</h2>');
@@ -491,7 +508,7 @@ function make_class(gridtype, loadtype = 'new') {
             break;
         case "snub_square":
             var n0 = parseInt(document.getElementById("nb_size1").value, 10);
-            if (n0 <= 20 && n0 > 0) {
+            if (n0 <= gridmax['snub'] && n0 > 0) {
                 pu = new Puzzle_snub_square(n0, n0, size);
             } else {
                 errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['snub'] + '</h2>');
@@ -499,7 +516,7 @@ function make_class(gridtype, loadtype = 'new') {
             break;
         case "cairo_pentagonal":
             var n0 = parseInt(document.getElementById("nb_size1").value, 10);
-            if (n0 <= 20 && n0 > 0) {
+            if (n0 <= gridmax['cairo'] && n0 > 0) {
                 pu = new Puzzle_cairo_pentagonal(n0, n0, size);
             } else {
                 errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['cairo'] + '</h2>');
@@ -507,7 +524,7 @@ function make_class(gridtype, loadtype = 'new') {
             break;
         case "rhombitrihexagonal":
             var n0 = parseInt(document.getElementById("nb_size1").value, 10);
-            if (n0 <= 20 && n0 > 0) {
+            if (n0 <= gridmax['rhombitrihex'] && n0 > 0) {
                 pu = new Puzzle_rhombitrihexagonal(n0, n0, size);
             } else {
                 errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['rhombitrihex'] + '</h2>');
@@ -515,7 +532,7 @@ function make_class(gridtype, loadtype = 'new') {
             break;
         case "deltoidal_trihexagonal":
             var n0 = parseInt(document.getElementById("nb_size1").value, 10);
-            if (n0 <= 20 && n0 > 0) {
+            if (n0 <= gridmax['deltoidal'] && n0 > 0) {
                 pu = new Puzzle_deltoidal_trihexagonal(n0, n0, size);
             } else {
                 errorMsg('Side Size must be in the range <h2 class="warn">1-' + gridmax['deltoidal'] + '</h2>');

--- a/docs/js/interface.js
+++ b/docs/js/interface.js
@@ -7,9 +7,6 @@ const PenpaUI = {
         for (var i of allModes.sub) {
             document.getElementById("sub_" + i + "_lb").classList.toggle('is_hidden', hidden);
         }
-        for (var i of allModes.customcolor) {
-            document.getElementById(i).classList.toggle('is_hidden', hidden);
-        }
         for (var i of allModes.ms) {
             document.getElementById("ms_" + i).parentElement.classList.toggle('is_hidden', hidden);
         }
@@ -50,9 +47,6 @@ const PenpaUI = {
         }
         for (var i of allPossible.sub) {
             document.getElementById("sub_" + i + "_lb").classList.toggle('is_hidden', selectedGrid.sub.indexOf(i) < 0);
-        }
-        for (var i of allPossible.customcolor) {
-            document.getElementById(i).classList.toggle('is_hidden', selectedGrid.customcolor.indexOf(i) < 0);
         }
         for (var i of allPossible.ms) {
             document.getElementById("ms_" + i).parentElement.classList.toggle('is_hidden', selectedGrid.ms.indexOf(i) < 0);

--- a/docs/js/libs/spectrum.js
+++ b/docs/js/libs/spectrum.js
@@ -1227,1108 +1227,1187 @@
         }
     };
 
-    // TinyColor v1.1.2
+    // TinyColor v1.5.2
     // https://github.com/bgrins/TinyColor
     // Brian Grinstead, MIT License
 
     (function() {
 
-    var trimLeft = /^[\s,#]+/,
-        trimRight = /\s+$/,
-        tinyCounter = 0,
-        math = Math,
-        mathRound = math.round,
-        mathMin = math.min,
-        mathMax = math.max,
-        mathRandom = math.random;
-
-    var tinycolor = function(color, opts) {
-
-        color = (color) ? color : '';
-        opts = opts || { };
-
-        // If input is already a tinycolor, return itself
-        if (color instanceof tinycolor) {
-           return color;
-        }
-        // If we are called as a function, call using new instead
-        if (!(this instanceof tinycolor)) {
-            return new tinycolor(color, opts);
-        }
-
-        var rgb = inputToRGB(color);
-        this._originalInput = color;
-        this._r = rgb.r;
-        this._g = rgb.g;
-        this._b = rgb.b;
-        this._a = rgb.a;
-        this._roundA = mathRound(1000 * this._a) / 1000;
-        this._format = opts.format || rgb.format;
-        this._gradientType = opts.gradientType;
-
-        // Don't let the range of [0,255] come back in [0,1].
-        // Potentially lose a little bit of precision here, but will fix issues where
-        // .5 gets interpreted as half of the total, instead of half of 1
-        // If it was supposed to be 128, this was already taken care of by `inputToRgb`
-        if (this._r < 1) { this._r = mathRound(this._r); }
-        if (this._g < 1) { this._g = mathRound(this._g); }
-        if (this._b < 1) { this._b = mathRound(this._b); }
-
-        this._ok = rgb.ok;
-        this._tc_id = tinyCounter++;
-    };
-
-    tinycolor.prototype = {
-        isDark: function() {
-            return this.getBrightness() < 128;
-        },
-        isLight: function() {
-            return !this.isDark();
-        },
-        isValid: function() {
-            return this._ok;
-        },
-        getOriginalInput: function() {
-          return this._originalInput;
-        },
-        getFormat: function() {
-            return this._format;
-        },
-        getAlpha: function() {
-            return this._a;
-        },
-        getBrightness: function() {
-            var rgb = this.toRgb();
-            return (rgb.r * 299 + rgb.g * 587 + rgb.b * 114) / 1000;
-        },
-        setAlpha: function(value) {
-            this._a = boundAlpha(value);
-            this._roundA = mathRound(1000 * this._a) / 1000;
-            return this;
-        },
-        toHsv: function() {
-            var hsv = rgbToHsv(this._r, this._g, this._b);
-            return { h: hsv.h * 360, s: hsv.s, v: hsv.v, a: this._a };
-        },
-        toHsvString: function() {
-            var hsv = rgbToHsv(this._r, this._g, this._b);
-            var h = mathRound(hsv.h * 360), s = mathRound(hsv.s * 100), v = mathRound(hsv.v * 100);
-            return (this._a == 1) ?
-              "hsv("  + h + ", " + s + "%, " + v + "%)" :
-              "hsva(" + h + ", " + s + "%, " + v + "%, "+ this._roundA + ")";
-        },
-        toHsl: function() {
-            var hsl = rgbToHsl(this._r, this._g, this._b);
-            return { h: hsl.h * 360, s: hsl.s, l: hsl.l, a: this._a };
-        },
-        toHslString: function() {
-            var hsl = rgbToHsl(this._r, this._g, this._b);
-            var h = mathRound(hsl.h * 360), s = mathRound(hsl.s * 100), l = mathRound(hsl.l * 100);
-            return (this._a == 1) ?
-              "hsl("  + h + ", " + s + "%, " + l + "%)" :
-              "hsla(" + h + ", " + s + "%, " + l + "%, "+ this._roundA + ")";
-        },
-        toHex: function(allow3Char) {
-            return rgbToHex(this._r, this._g, this._b, allow3Char);
-        },
-        toHexString: function(allow3Char) {
-            return '#' + this.toHex(allow3Char);
-        },
-        toHex8: function() {
-            return rgbaToHex(this._r, this._g, this._b, this._a);
-        },
-        toHex8String: function() {
-            return '#' + this.toHex8();
-        },
-        toRgb: function() {
-            return { r: mathRound(this._r), g: mathRound(this._g), b: mathRound(this._b), a: this._a };
-        },
-        toRgbString: function() {
-            return (this._a == 1) ?
-              "rgb("  + mathRound(this._r) + ", " + mathRound(this._g) + ", " + mathRound(this._b) + ")" :
-              "rgba(" + mathRound(this._r) + ", " + mathRound(this._g) + ", " + mathRound(this._b) + ", " + this._roundA + ")";
-        },
-        toPercentageRgb: function() {
-            return { r: mathRound(bound01(this._r, 255) * 100) + "%", g: mathRound(bound01(this._g, 255) * 100) + "%", b: mathRound(bound01(this._b, 255) * 100) + "%", a: this._a };
-        },
-        toPercentageRgbString: function() {
-            return (this._a == 1) ?
-              "rgb("  + mathRound(bound01(this._r, 255) * 100) + "%, " + mathRound(bound01(this._g, 255) * 100) + "%, " + mathRound(bound01(this._b, 255) * 100) + "%)" :
-              "rgba(" + mathRound(bound01(this._r, 255) * 100) + "%, " + mathRound(bound01(this._g, 255) * 100) + "%, " + mathRound(bound01(this._b, 255) * 100) + "%, " + this._roundA + ")";
-        },
-        toName: function() {
-            if (this._a === 0) {
+        function _typeof(obj) {
+            "@babel/helpers - typeof";
+        
+            return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
+              return typeof obj;
+            } : function (obj) {
+              return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+            }, _typeof(obj);
+          }
+        
+          var trimLeft = /^\s+/;
+          var trimRight = /\s+$/;
+          function tinycolor(color, opts) {
+            color = color ? color : "";
+            opts = opts || {};
+        
+            // If input is already a tinycolor, return itself
+            if (color instanceof tinycolor) {
+              return color;
+            }
+            // If we are called as a function, call using new instead
+            if (!(this instanceof tinycolor)) {
+              return new tinycolor(color, opts);
+            }
+            var rgb = inputToRGB(color);
+            this._originalInput = color, this._r = rgb.r, this._g = rgb.g, this._b = rgb.b, this._a = rgb.a, this._roundA = Math.round(100 * this._a) / 100, this._format = opts.format || rgb.format;
+            this._gradientType = opts.gradientType;
+        
+            // Don't let the range of [0,255] come back in [0,1].
+            // Potentially lose a little bit of precision here, but will fix issues where
+            // .5 gets interpreted as half of the total, instead of half of 1
+            // If it was supposed to be 128, this was already taken care of by `inputToRgb`
+            if (this._r < 1) this._r = Math.round(this._r);
+            if (this._g < 1) this._g = Math.round(this._g);
+            if (this._b < 1) this._b = Math.round(this._b);
+            this._ok = rgb.ok;
+          }
+          tinycolor.prototype = {
+            isDark: function isDark() {
+              return this.getBrightness() < 128;
+            },
+            isLight: function isLight() {
+              return !this.isDark();
+            },
+            isValid: function isValid() {
+              return this._ok;
+            },
+            getOriginalInput: function getOriginalInput() {
+              return this._originalInput;
+            },
+            getFormat: function getFormat() {
+              return this._format;
+            },
+            getAlpha: function getAlpha() {
+              return this._a;
+            },
+            getBrightness: function getBrightness() {
+              //http://www.w3.org/TR/AERT#color-contrast
+              var rgb = this.toRgb();
+              return (rgb.r * 299 + rgb.g * 587 + rgb.b * 114) / 1000;
+            },
+            getLuminance: function getLuminance() {
+              //http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+              var rgb = this.toRgb();
+              var RsRGB, GsRGB, BsRGB, R, G, B;
+              RsRGB = rgb.r / 255;
+              GsRGB = rgb.g / 255;
+              BsRGB = rgb.b / 255;
+              if (RsRGB <= 0.03928) R = RsRGB / 12.92;else R = Math.pow((RsRGB + 0.055) / 1.055, 2.4);
+              if (GsRGB <= 0.03928) G = GsRGB / 12.92;else G = Math.pow((GsRGB + 0.055) / 1.055, 2.4);
+              if (BsRGB <= 0.03928) B = BsRGB / 12.92;else B = Math.pow((BsRGB + 0.055) / 1.055, 2.4);
+              return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+            },
+            setAlpha: function setAlpha(value) {
+              this._a = boundAlpha(value);
+              this._roundA = Math.round(100 * this._a) / 100;
+              return this;
+            },
+            toHsv: function toHsv() {
+              var hsv = rgbToHsv(this._r, this._g, this._b);
+              return {
+                h: hsv.h * 360,
+                s: hsv.s,
+                v: hsv.v,
+                a: this._a
+              };
+            },
+            toHsvString: function toHsvString() {
+              var hsv = rgbToHsv(this._r, this._g, this._b);
+              var h = Math.round(hsv.h * 360),
+                s = Math.round(hsv.s * 100),
+                v = Math.round(hsv.v * 100);
+              return this._a == 1 ? "hsv(" + h + ", " + s + "%, " + v + "%)" : "hsva(" + h + ", " + s + "%, " + v + "%, " + this._roundA + ")";
+            },
+            toHsl: function toHsl() {
+              var hsl = rgbToHsl(this._r, this._g, this._b);
+              return {
+                h: hsl.h * 360,
+                s: hsl.s,
+                l: hsl.l,
+                a: this._a
+              };
+            },
+            toHslString: function toHslString() {
+              var hsl = rgbToHsl(this._r, this._g, this._b);
+              var h = Math.round(hsl.h * 360),
+                s = Math.round(hsl.s * 100),
+                l = Math.round(hsl.l * 100);
+              return this._a == 1 ? "hsl(" + h + ", " + s + "%, " + l + "%)" : "hsla(" + h + ", " + s + "%, " + l + "%, " + this._roundA + ")";
+            },
+            toHex: function toHex(allow3Char) {
+              return rgbToHex(this._r, this._g, this._b, allow3Char);
+            },
+            toHexString: function toHexString(allow3Char) {
+              return "#" + this.toHex(allow3Char);
+            },
+            toHex8: function toHex8(allow4Char) {
+              return rgbaToHex(this._r, this._g, this._b, this._a, allow4Char);
+            },
+            toHex8String: function toHex8String(allow4Char) {
+              return "#" + this.toHex8(allow4Char);
+            },
+            toRgb: function toRgb() {
+              return {
+                r: Math.round(this._r),
+                g: Math.round(this._g),
+                b: Math.round(this._b),
+                a: this._a
+              };
+            },
+            toRgbString: function toRgbString() {
+              return this._a == 1 ? "rgb(" + Math.round(this._r) + ", " + Math.round(this._g) + ", " + Math.round(this._b) + ")" : "rgba(" + Math.round(this._r) + ", " + Math.round(this._g) + ", " + Math.round(this._b) + ", " + this._roundA + ")";
+            },
+            toPercentageRgb: function toPercentageRgb() {
+              return {
+                r: Math.round(bound01(this._r, 255) * 100) + "%",
+                g: Math.round(bound01(this._g, 255) * 100) + "%",
+                b: Math.round(bound01(this._b, 255) * 100) + "%",
+                a: this._a
+              };
+            },
+            toPercentageRgbString: function toPercentageRgbString() {
+              return this._a == 1 ? "rgb(" + Math.round(bound01(this._r, 255) * 100) + "%, " + Math.round(bound01(this._g, 255) * 100) + "%, " + Math.round(bound01(this._b, 255) * 100) + "%)" : "rgba(" + Math.round(bound01(this._r, 255) * 100) + "%, " + Math.round(bound01(this._g, 255) * 100) + "%, " + Math.round(bound01(this._b, 255) * 100) + "%, " + this._roundA + ")";
+            },
+            toName: function toName() {
+              if (this._a === 0) {
                 return "transparent";
-            }
-
-            if (this._a < 1) {
+              }
+              if (this._a < 1) {
                 return false;
-            }
-
-            return hexNames[rgbToHex(this._r, this._g, this._b, true)] || false;
-        },
-        toFilter: function(secondColor) {
-            var hex8String = '#' + rgbaToHex(this._r, this._g, this._b, this._a);
-            var secondHex8String = hex8String;
-            var gradientType = this._gradientType ? "GradientType = 1, " : "";
-
-            if (secondColor) {
+              }
+              return hexNames[rgbToHex(this._r, this._g, this._b, true)] || false;
+            },
+            toFilter: function toFilter(secondColor) {
+              var hex8String = "#" + rgbaToArgbHex(this._r, this._g, this._b, this._a);
+              var secondHex8String = hex8String;
+              var gradientType = this._gradientType ? "GradientType = 1, " : "";
+              if (secondColor) {
                 var s = tinycolor(secondColor);
-                secondHex8String = s.toHex8String();
-            }
-
-            return "progid:DXImageTransform.Microsoft.gradient("+gradientType+"startColorstr="+hex8String+",endColorstr="+secondHex8String+")";
-        },
-        toString: function(format) {
-            var formatSet = !!format;
-            format = format || this._format;
-
-            var formattedString = false;
-            var hasAlpha = this._a < 1 && this._a >= 0;
-            var needsAlphaFormat = !formatSet && hasAlpha && (format === "hex" || format === "hex6" || format === "hex3" || format === "name");
-
-            if (needsAlphaFormat) {
+                secondHex8String = "#" + rgbaToArgbHex(s._r, s._g, s._b, s._a);
+              }
+              return "progid:DXImageTransform.Microsoft.gradient(" + gradientType + "startColorstr=" + hex8String + ",endColorstr=" + secondHex8String + ")";
+            },
+            toString: function toString(format) {
+              var formatSet = !!format;
+              format = format || this._format;
+              var formattedString = false;
+              var hasAlpha = this._a < 1 && this._a >= 0;
+              var needsAlphaFormat = !formatSet && hasAlpha && (format === "hex" || format === "hex6" || format === "hex3" || format === "hex4" || format === "hex8" || format === "name");
+              if (needsAlphaFormat) {
                 // Special case for "transparent", all other non-alpha formats
                 // will return rgba when there is transparency.
                 if (format === "name" && this._a === 0) {
-                    return this.toName();
+                  return this.toName();
                 }
                 return this.toRgbString();
-            }
-            if (format === "rgb") {
+              }
+              if (format === "rgb") {
                 formattedString = this.toRgbString();
-            }
-            if (format === "prgb") {
+              }
+              if (format === "prgb") {
                 formattedString = this.toPercentageRgbString();
-            }
-            if (format === "hex" || format === "hex6") {
+              }
+              if (format === "hex" || format === "hex6") {
                 formattedString = this.toHexString();
-            }
-            if (format === "hex3") {
+              }
+              if (format === "hex3") {
                 formattedString = this.toHexString(true);
-            }
-            if (format === "hex8") {
+              }
+              if (format === "hex4") {
+                formattedString = this.toHex8String(true);
+              }
+              if (format === "hex8") {
                 formattedString = this.toHex8String();
-            }
-            if (format === "name") {
+              }
+              if (format === "name") {
                 formattedString = this.toName();
-            }
-            if (format === "hsl") {
+              }
+              if (format === "hsl") {
                 formattedString = this.toHslString();
-            }
-            if (format === "hsv") {
+              }
+              if (format === "hsv") {
                 formattedString = this.toHsvString();
+              }
+              return formattedString || this.toHexString();
+            },
+            clone: function clone() {
+              return tinycolor(this.toString());
+            },
+            _applyModification: function _applyModification(fn, args) {
+              var color = fn.apply(null, [this].concat([].slice.call(args)));
+              this._r = color._r;
+              this._g = color._g;
+              this._b = color._b;
+              this.setAlpha(color._a);
+              return this;
+            },
+            lighten: function lighten() {
+              return this._applyModification(_lighten, arguments);
+            },
+            brighten: function brighten() {
+              return this._applyModification(_brighten, arguments);
+            },
+            darken: function darken() {
+              return this._applyModification(_darken, arguments);
+            },
+            desaturate: function desaturate() {
+              return this._applyModification(_desaturate, arguments);
+            },
+            saturate: function saturate() {
+              return this._applyModification(_saturate, arguments);
+            },
+            greyscale: function greyscale() {
+              return this._applyModification(_greyscale, arguments);
+            },
+            spin: function spin() {
+              return this._applyModification(_spin, arguments);
+            },
+            _applyCombination: function _applyCombination(fn, args) {
+              return fn.apply(null, [this].concat([].slice.call(args)));
+            },
+            analogous: function analogous() {
+              return this._applyCombination(_analogous, arguments);
+            },
+            complement: function complement() {
+              return this._applyCombination(_complement, arguments);
+            },
+            monochromatic: function monochromatic() {
+              return this._applyCombination(_monochromatic, arguments);
+            },
+            splitcomplement: function splitcomplement() {
+              return this._applyCombination(_splitcomplement, arguments);
+            },
+            // Disabled until https://github.com/bgrins/TinyColor/issues/254
+            // polyad: function (number) {
+            //   return this._applyCombination(polyad, [number]);
+            // },
+            triad: function triad() {
+              return this._applyCombination(polyad, [3]);
+            },
+            tetrad: function tetrad() {
+              return this._applyCombination(polyad, [4]);
             }
-
-            return formattedString || this.toHexString();
-        },
-
-        _applyModification: function(fn, args) {
-            var color = fn.apply(null, [this].concat([].slice.call(args)));
-            this._r = color._r;
-            this._g = color._g;
-            this._b = color._b;
-            this.setAlpha(color._a);
-            return this;
-        },
-        lighten: function() {
-            return this._applyModification(lighten, arguments);
-        },
-        brighten: function() {
-            return this._applyModification(brighten, arguments);
-        },
-        darken: function() {
-            return this._applyModification(darken, arguments);
-        },
-        desaturate: function() {
-            return this._applyModification(desaturate, arguments);
-        },
-        saturate: function() {
-            return this._applyModification(saturate, arguments);
-        },
-        greyscale: function() {
-            return this._applyModification(greyscale, arguments);
-        },
-        spin: function() {
-            return this._applyModification(spin, arguments);
-        },
-
-        _applyCombination: function(fn, args) {
-            return fn.apply(null, [this].concat([].slice.call(args)));
-        },
-        analogous: function() {
-            return this._applyCombination(analogous, arguments);
-        },
-        complement: function() {
-            return this._applyCombination(complement, arguments);
-        },
-        monochromatic: function() {
-            return this._applyCombination(monochromatic, arguments);
-        },
-        splitcomplement: function() {
-            return this._applyCombination(splitcomplement, arguments);
-        },
-        triad: function() {
-            return this._applyCombination(triad, arguments);
-        },
-        tetrad: function() {
-            return this._applyCombination(tetrad, arguments);
-        }
-    };
-
-    // If input is an object, force 1 into "1.0" to handle ratios properly
-    // String input requires "1.0" as input, so 1 will be treated as 1
-    tinycolor.fromRatio = function(color, opts) {
-        if (typeof color == "object") {
-            var newColor = {};
-            for (var i in color) {
+          };
+        
+          // If input is an object, force 1 into "1.0" to handle ratios properly
+          // String input requires "1.0" as input, so 1 will be treated as 1
+          tinycolor.fromRatio = function (color, opts) {
+            if (_typeof(color) == "object") {
+              var newColor = {};
+              for (var i in color) {
                 if (color.hasOwnProperty(i)) {
-                    if (i === "a") {
-                        newColor[i] = color[i];
-                    }
-                    else {
-                        newColor[i] = convertToPercentage(color[i]);
-                    }
+                  if (i === "a") {
+                    newColor[i] = color[i];
+                  } else {
+                    newColor[i] = convertToPercentage(color[i]);
+                  }
                 }
+              }
+              color = newColor;
             }
-            color = newColor;
-        }
-
-        return tinycolor(color, opts);
-    };
-
-    // Given a string or object, convert that input to RGB
-    // Possible string inputs:
-    //
-    //     "red"
-    //     "#f00" or "f00"
-    //     "#ff0000" or "ff0000"
-    //     "#ff000000" or "ff000000"
-    //     "rgb 255 0 0" or "rgb (255, 0, 0)"
-    //     "rgb 1.0 0 0" or "rgb (1, 0, 0)"
-    //     "rgba (255, 0, 0, 1)" or "rgba 255, 0, 0, 1"
-    //     "rgba (1.0, 0, 0, 1)" or "rgba 1.0, 0, 0, 1"
-    //     "hsl(0, 100%, 50%)" or "hsl 0 100% 50%"
-    //     "hsla(0, 100%, 50%, 1)" or "hsla 0 100% 50%, 1"
-    //     "hsv(0, 100%, 100%)" or "hsv 0 100% 100%"
-    //
-    function inputToRGB(color) {
-
-        var rgb = { r: 0, g: 0, b: 0 };
-        var a = 1;
-        var ok = false;
-        var format = false;
-
-        if (typeof color == "string") {
-            color = stringInputToObject(color);
-        }
-
-        if (typeof color == "object") {
-            if (color.hasOwnProperty("r") && color.hasOwnProperty("g") && color.hasOwnProperty("b")) {
+            return tinycolor(color, opts);
+          };
+        
+          // Given a string or object, convert that input to RGB
+          // Possible string inputs:
+          //
+          //     "red"
+          //     "#f00" or "f00"
+          //     "#ff0000" or "ff0000"
+          //     "#ff000000" or "ff000000"
+          //     "rgb 255 0 0" or "rgb (255, 0, 0)"
+          //     "rgb 1.0 0 0" or "rgb (1, 0, 0)"
+          //     "rgba (255, 0, 0, 1)" or "rgba 255, 0, 0, 1"
+          //     "rgba (1.0, 0, 0, 1)" or "rgba 1.0, 0, 0, 1"
+          //     "hsl(0, 100%, 50%)" or "hsl 0 100% 50%"
+          //     "hsla(0, 100%, 50%, 1)" or "hsla 0 100% 50%, 1"
+          //     "hsv(0, 100%, 100%)" or "hsv 0 100% 100%"
+          //
+          function inputToRGB(color) {
+            var rgb = {
+              r: 0,
+              g: 0,
+              b: 0
+            };
+            var a = 1;
+            var s = null;
+            var v = null;
+            var l = null;
+            var ok = false;
+            var format = false;
+            if (typeof color == "string") {
+              color = stringInputToObject(color);
+            }
+            if (_typeof(color) == "object") {
+              if (isValidCSSUnit(color.r) && isValidCSSUnit(color.g) && isValidCSSUnit(color.b)) {
                 rgb = rgbToRgb(color.r, color.g, color.b);
                 ok = true;
                 format = String(color.r).substr(-1) === "%" ? "prgb" : "rgb";
-            }
-            else if (color.hasOwnProperty("h") && color.hasOwnProperty("s") && color.hasOwnProperty("v")) {
-                color.s = convertToPercentage(color.s);
-                color.v = convertToPercentage(color.v);
-                rgb = hsvToRgb(color.h, color.s, color.v);
+              } else if (isValidCSSUnit(color.h) && isValidCSSUnit(color.s) && isValidCSSUnit(color.v)) {
+                s = convertToPercentage(color.s);
+                v = convertToPercentage(color.v);
+                rgb = hsvToRgb(color.h, s, v);
                 ok = true;
                 format = "hsv";
-            }
-            else if (color.hasOwnProperty("h") && color.hasOwnProperty("s") && color.hasOwnProperty("l")) {
-                color.s = convertToPercentage(color.s);
-                color.l = convertToPercentage(color.l);
-                rgb = hslToRgb(color.h, color.s, color.l);
+              } else if (isValidCSSUnit(color.h) && isValidCSSUnit(color.s) && isValidCSSUnit(color.l)) {
+                s = convertToPercentage(color.s);
+                l = convertToPercentage(color.l);
+                rgb = hslToRgb(color.h, s, l);
                 ok = true;
                 format = "hsl";
-            }
-
-            if (color.hasOwnProperty("a")) {
+              }
+              if (color.hasOwnProperty("a")) {
                 a = color.a;
+              }
             }
-        }
-
-        a = boundAlpha(a);
-
-        return {
-            ok: ok,
-            format: color.format || format,
-            r: mathMin(255, mathMax(rgb.r, 0)),
-            g: mathMin(255, mathMax(rgb.g, 0)),
-            b: mathMin(255, mathMax(rgb.b, 0)),
-            a: a
-        };
-    }
-
-
-    // Conversion Functions
-    // --------------------
-
-    // `rgbToHsl`, `rgbToHsv`, `hslToRgb`, `hsvToRgb` modified from:
-    // <http://mjijackson.com/2008/02/rgb-to-hsl-and-rgb-to-hsv-color-model-conversion-algorithms-in-javascript>
-
-    // `rgbToRgb`
-    // Handle bounds / percentage checking to conform to CSS color spec
-    // <http://www.w3.org/TR/css3-color/>
-    // *Assumes:* r, g, b in [0, 255] or [0, 1]
-    // *Returns:* { r, g, b } in [0, 255]
-    function rgbToRgb(r, g, b){
-        return {
-            r: bound01(r, 255) * 255,
-            g: bound01(g, 255) * 255,
-            b: bound01(b, 255) * 255
-        };
-    }
-
-    // `rgbToHsl`
-    // Converts an RGB color value to HSL.
-    // *Assumes:* r, g, and b are contained in [0, 255] or [0, 1]
-    // *Returns:* { h, s, l } in [0,1]
-    function rgbToHsl(r, g, b) {
-
-        r = bound01(r, 255);
-        g = bound01(g, 255);
-        b = bound01(b, 255);
-
-        var max = mathMax(r, g, b), min = mathMin(r, g, b);
-        var h, s, l = (max + min) / 2;
-
-        if(max == min) {
-            h = s = 0; // achromatic
-        }
-        else {
-            var d = max - min;
-            s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-            switch(max) {
-                case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-                case g: h = (b - r) / d + 2; break;
-                case b: h = (r - g) / d + 4; break;
-            }
-
-            h /= 6;
-        }
-
-        return { h: h, s: s, l: l };
-    }
-
-    // `hslToRgb`
-    // Converts an HSL color value to RGB.
-    // *Assumes:* h is contained in [0, 1] or [0, 360] and s and l are contained [0, 1] or [0, 100]
-    // *Returns:* { r, g, b } in the set [0, 255]
-    function hslToRgb(h, s, l) {
-        var r, g, b;
-
-        h = bound01(h, 360);
-        s = bound01(s, 100);
-        l = bound01(l, 100);
-
-        function hue2rgb(p, q, t) {
-            if(t < 0) t += 1;
-            if(t > 1) t -= 1;
-            if(t < 1/6) return p + (q - p) * 6 * t;
-            if(t < 1/2) return q;
-            if(t < 2/3) return p + (q - p) * (2/3 - t) * 6;
-            return p;
-        }
-
-        if(s === 0) {
-            r = g = b = l; // achromatic
-        }
-        else {
-            var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-            var p = 2 * l - q;
-            r = hue2rgb(p, q, h + 1/3);
-            g = hue2rgb(p, q, h);
-            b = hue2rgb(p, q, h - 1/3);
-        }
-
-        return { r: r * 255, g: g * 255, b: b * 255 };
-    }
-
-    // `rgbToHsv`
-    // Converts an RGB color value to HSV
-    // *Assumes:* r, g, and b are contained in the set [0, 255] or [0, 1]
-    // *Returns:* { h, s, v } in [0,1]
-    function rgbToHsv(r, g, b) {
-
-        r = bound01(r, 255);
-        g = bound01(g, 255);
-        b = bound01(b, 255);
-
-        var max = mathMax(r, g, b), min = mathMin(r, g, b);
-        var h, s, v = max;
-
-        var d = max - min;
-        s = max === 0 ? 0 : d / max;
-
-        if(max == min) {
-            h = 0; // achromatic
-        }
-        else {
-            switch(max) {
-                case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-                case g: h = (b - r) / d + 2; break;
-                case b: h = (r - g) / d + 4; break;
-            }
-            h /= 6;
-        }
-        return { h: h, s: s, v: v };
-    }
-
-    // `hsvToRgb`
-    // Converts an HSV color value to RGB.
-    // *Assumes:* h is contained in [0, 1] or [0, 360] and s and v are contained in [0, 1] or [0, 100]
-    // *Returns:* { r, g, b } in the set [0, 255]
-     function hsvToRgb(h, s, v) {
-
-        h = bound01(h, 360) * 6;
-        s = bound01(s, 100);
-        v = bound01(v, 100);
-
-        var i = math.floor(h),
-            f = h - i,
-            p = v * (1 - s),
-            q = v * (1 - f * s),
-            t = v * (1 - (1 - f) * s),
-            mod = i % 6,
-            r = [v, q, p, p, t, v][mod],
-            g = [t, v, v, q, p, p][mod],
-            b = [p, p, t, v, v, q][mod];
-
-        return { r: r * 255, g: g * 255, b: b * 255 };
-    }
-
-    // `rgbToHex`
-    // Converts an RGB color to hex
-    // Assumes r, g, and b are contained in the set [0, 255]
-    // Returns a 3 or 6 character hex
-    function rgbToHex(r, g, b, allow3Char) {
-
-        var hex = [
-            pad2(mathRound(r).toString(16)),
-            pad2(mathRound(g).toString(16)),
-            pad2(mathRound(b).toString(16))
-        ];
-
-        // Return a 3 character hex if possible
-        if (allow3Char && hex[0].charAt(0) == hex[0].charAt(1) && hex[1].charAt(0) == hex[1].charAt(1) && hex[2].charAt(0) == hex[2].charAt(1)) {
-            return hex[0].charAt(0) + hex[1].charAt(0) + hex[2].charAt(0);
-        }
-
-        return hex.join("");
-    }
-        // `rgbaToHex`
-        // Converts an RGBA color plus alpha transparency to hex
-        // Assumes r, g, b and a are contained in the set [0, 255]
-        // Returns an 8 character hex
-        function rgbaToHex(r, g, b, a) {
-
-            var hex = [
-                pad2(convertDecimalToHex(a)),
-                pad2(mathRound(r).toString(16)),
-                pad2(mathRound(g).toString(16)),
-                pad2(mathRound(b).toString(16))
-            ];
-
-            return hex.join("");
-        }
-
-    // `equals`
-    // Can be called with any tinycolor input
-    tinycolor.equals = function (color1, color2) {
-        if (!color1 || !color2) { return false; }
-        return tinycolor(color1).toRgbString() == tinycolor(color2).toRgbString();
-    };
-    tinycolor.random = function() {
-        return tinycolor.fromRatio({
-            r: mathRandom(),
-            g: mathRandom(),
-            b: mathRandom()
-        });
-    };
-
-
-    // Modification Functions
-    // ----------------------
-    // Thanks to less.js for some of the basics here
-    // <https://github.com/cloudhead/less.js/blob/master/lib/less/functions.js>
-
-    function desaturate(color, amount) {
-        amount = (amount === 0) ? 0 : (amount || 10);
-        var hsl = tinycolor(color).toHsl();
-        hsl.s -= amount / 100;
-        hsl.s = clamp01(hsl.s);
-        return tinycolor(hsl);
-    }
-
-    function saturate(color, amount) {
-        amount = (amount === 0) ? 0 : (amount || 10);
-        var hsl = tinycolor(color).toHsl();
-        hsl.s += amount / 100;
-        hsl.s = clamp01(hsl.s);
-        return tinycolor(hsl);
-    }
-
-    function greyscale(color) {
-        return tinycolor(color).desaturate(100);
-    }
-
-    function lighten (color, amount) {
-        amount = (amount === 0) ? 0 : (amount || 10);
-        var hsl = tinycolor(color).toHsl();
-        hsl.l += amount / 100;
-        hsl.l = clamp01(hsl.l);
-        return tinycolor(hsl);
-    }
-
-    function brighten(color, amount) {
-        amount = (amount === 0) ? 0 : (amount || 10);
-        var rgb = tinycolor(color).toRgb();
-        rgb.r = mathMax(0, mathMin(255, rgb.r - mathRound(255 * - (amount / 100))));
-        rgb.g = mathMax(0, mathMin(255, rgb.g - mathRound(255 * - (amount / 100))));
-        rgb.b = mathMax(0, mathMin(255, rgb.b - mathRound(255 * - (amount / 100))));
-        return tinycolor(rgb);
-    }
-
-    function darken (color, amount) {
-        amount = (amount === 0) ? 0 : (amount || 10);
-        var hsl = tinycolor(color).toHsl();
-        hsl.l -= amount / 100;
-        hsl.l = clamp01(hsl.l);
-        return tinycolor(hsl);
-    }
-
-    // Spin takes a positive or negative amount within [-360, 360] indicating the change of hue.
-    // Values outside of this range will be wrapped into this range.
-    function spin(color, amount) {
-        var hsl = tinycolor(color).toHsl();
-        var hue = (mathRound(hsl.h) + amount) % 360;
-        hsl.h = hue < 0 ? 360 + hue : hue;
-        return tinycolor(hsl);
-    }
-
-    // Combination Functions
-    // ---------------------
-    // Thanks to jQuery xColor for some of the ideas behind these
-    // <https://github.com/infusion/jQuery-xcolor/blob/master/jquery.xcolor.js>
-
-    function complement(color) {
-        var hsl = tinycolor(color).toHsl();
-        hsl.h = (hsl.h + 180) % 360;
-        return tinycolor(hsl);
-    }
-
-    function triad(color) {
-        var hsl = tinycolor(color).toHsl();
-        var h = hsl.h;
-        return [
-            tinycolor(color),
-            tinycolor({ h: (h + 120) % 360, s: hsl.s, l: hsl.l }),
-            tinycolor({ h: (h + 240) % 360, s: hsl.s, l: hsl.l })
-        ];
-    }
-
-    function tetrad(color) {
-        var hsl = tinycolor(color).toHsl();
-        var h = hsl.h;
-        return [
-            tinycolor(color),
-            tinycolor({ h: (h + 90) % 360, s: hsl.s, l: hsl.l }),
-            tinycolor({ h: (h + 180) % 360, s: hsl.s, l: hsl.l }),
-            tinycolor({ h: (h + 270) % 360, s: hsl.s, l: hsl.l })
-        ];
-    }
-
-    function splitcomplement(color) {
-        var hsl = tinycolor(color).toHsl();
-        var h = hsl.h;
-        return [
-            tinycolor(color),
-            tinycolor({ h: (h + 72) % 360, s: hsl.s, l: hsl.l}),
-            tinycolor({ h: (h + 216) % 360, s: hsl.s, l: hsl.l})
-        ];
-    }
-
-    function analogous(color, results, slices) {
-        results = results || 6;
-        slices = slices || 30;
-
-        var hsl = tinycolor(color).toHsl();
-        var part = 360 / slices;
-        var ret = [tinycolor(color)];
-
-        for (hsl.h = ((hsl.h - (part * results >> 1)) + 720) % 360; --results; ) {
-            hsl.h = (hsl.h + part) % 360;
-            ret.push(tinycolor(hsl));
-        }
-        return ret;
-    }
-
-    function monochromatic(color, results) {
-        results = results || 6;
-        var hsv = tinycolor(color).toHsv();
-        var h = hsv.h, s = hsv.s, v = hsv.v;
-        var ret = [];
-        var modification = 1 / results;
-
-        while (results--) {
-            ret.push(tinycolor({ h: h, s: s, v: v}));
-            v = (v + modification) % 1;
-        }
-
-        return ret;
-    }
-
-    // Utility Functions
-    // ---------------------
-
-    tinycolor.mix = function(color1, color2, amount) {
-        amount = (amount === 0) ? 0 : (amount || 50);
-
-        var rgb1 = tinycolor(color1).toRgb();
-        var rgb2 = tinycolor(color2).toRgb();
-
-        var p = amount / 100;
-        var w = p * 2 - 1;
-        var a = rgb2.a - rgb1.a;
-
-        var w1;
-
-        if (w * a == -1) {
-            w1 = w;
-        } else {
-            w1 = (w + a) / (1 + w * a);
-        }
-
-        w1 = (w1 + 1) / 2;
-
-        var w2 = 1 - w1;
-
-        var rgba = {
-            r: rgb2.r * w1 + rgb1.r * w2,
-            g: rgb2.g * w1 + rgb1.g * w2,
-            b: rgb2.b * w1 + rgb1.b * w2,
-            a: rgb2.a * p  + rgb1.a * (1 - p)
-        };
-
-        return tinycolor(rgba);
-    };
-
-
-    // Readability Functions
-    // ---------------------
-    // <http://www.w3.org/TR/AERT#color-contrast>
-
-    // `readability`
-    // Analyze the 2 colors and returns an object with the following properties:
-    //    `brightness`: difference in brightness between the two colors
-    //    `color`: difference in color/hue between the two colors
-    tinycolor.readability = function(color1, color2) {
-        var c1 = tinycolor(color1);
-        var c2 = tinycolor(color2);
-        var rgb1 = c1.toRgb();
-        var rgb2 = c2.toRgb();
-        var brightnessA = c1.getBrightness();
-        var brightnessB = c2.getBrightness();
-        var colorDiff = (
-            Math.max(rgb1.r, rgb2.r) - Math.min(rgb1.r, rgb2.r) +
-            Math.max(rgb1.g, rgb2.g) - Math.min(rgb1.g, rgb2.g) +
-            Math.max(rgb1.b, rgb2.b) - Math.min(rgb1.b, rgb2.b)
-        );
-
-        return {
-            brightness: Math.abs(brightnessA - brightnessB),
-            color: colorDiff
-        };
-    };
-
-    // `readable`
-    // http://www.w3.org/TR/AERT#color-contrast
-    // Ensure that foreground and background color combinations provide sufficient contrast.
-    // *Example*
-    //    tinycolor.isReadable("#000", "#111") => false
-    tinycolor.isReadable = function(color1, color2) {
-        var readability = tinycolor.readability(color1, color2);
-        return readability.brightness > 125 && readability.color > 500;
-    };
-
-    // `mostReadable`
-    // Given a base color and a list of possible foreground or background
-    // colors for that base, returns the most readable color.
-    // *Example*
-    //    tinycolor.mostReadable("#123", ["#fff", "#000"]) => "#000"
-    tinycolor.mostReadable = function(baseColor, colorList) {
-        var bestColor = null;
-        var bestScore = 0;
-        var bestIsReadable = false;
-        for (var i=0; i < colorList.length; i++) {
-
-            // We normalize both around the "acceptable" breaking point,
-            // but rank brightness constrast higher than hue.
-
-            var readability = tinycolor.readability(baseColor, colorList[i]);
-            var readable = readability.brightness > 125 && readability.color > 500;
-            var score = 3 * (readability.brightness / 125) + (readability.color / 500);
-
-            if ((readable && ! bestIsReadable) ||
-                (readable && bestIsReadable && score > bestScore) ||
-                ((! readable) && (! bestIsReadable) && score > bestScore)) {
-                bestIsReadable = readable;
-                bestScore = score;
-                bestColor = tinycolor(colorList[i]);
-            }
-        }
-        return bestColor;
-    };
-
-
-    // Big List of Colors
-    // ------------------
-    // <http://www.w3.org/TR/css3-color/#svg-color>
-    var names = tinycolor.names = {
-        aliceblue: "f0f8ff",
-        antiquewhite: "faebd7",
-        aqua: "0ff",
-        aquamarine: "7fffd4",
-        azure: "f0ffff",
-        beige: "f5f5dc",
-        bisque: "ffe4c4",
-        black: "000",
-        blanchedalmond: "ffebcd",
-        blue: "00f",
-        blueviolet: "8a2be2",
-        brown: "a52a2a",
-        burlywood: "deb887",
-        burntsienna: "ea7e5d",
-        cadetblue: "5f9ea0",
-        chartreuse: "7fff00",
-        chocolate: "d2691e",
-        coral: "ff7f50",
-        cornflowerblue: "6495ed",
-        cornsilk: "fff8dc",
-        crimson: "dc143c",
-        cyan: "0ff",
-        darkblue: "00008b",
-        darkcyan: "008b8b",
-        darkgoldenrod: "b8860b",
-        darkgray: "a9a9a9",
-        darkgreen: "006400",
-        darkgrey: "a9a9a9",
-        darkkhaki: "bdb76b",
-        darkmagenta: "8b008b",
-        darkolivegreen: "556b2f",
-        darkorange: "ff8c00",
-        darkorchid: "9932cc",
-        darkred: "8b0000",
-        darksalmon: "e9967a",
-        darkseagreen: "8fbc8f",
-        darkslateblue: "483d8b",
-        darkslategray: "2f4f4f",
-        darkslategrey: "2f4f4f",
-        darkturquoise: "00ced1",
-        darkviolet: "9400d3",
-        deeppink: "ff1493",
-        deepskyblue: "00bfff",
-        dimgray: "696969",
-        dimgrey: "696969",
-        dodgerblue: "1e90ff",
-        firebrick: "b22222",
-        floralwhite: "fffaf0",
-        forestgreen: "228b22",
-        fuchsia: "f0f",
-        gainsboro: "dcdcdc",
-        ghostwhite: "f8f8ff",
-        gold: "ffd700",
-        goldenrod: "daa520",
-        gray: "808080",
-        green: "008000",
-        greenyellow: "adff2f",
-        grey: "808080",
-        honeydew: "f0fff0",
-        hotpink: "ff69b4",
-        indianred: "cd5c5c",
-        indigo: "4b0082",
-        ivory: "fffff0",
-        khaki: "f0e68c",
-        lavender: "e6e6fa",
-        lavenderblush: "fff0f5",
-        lawngreen: "7cfc00",
-        lemonchiffon: "fffacd",
-        lightblue: "add8e6",
-        lightcoral: "f08080",
-        lightcyan: "e0ffff",
-        lightgoldenrodyellow: "fafad2",
-        lightgray: "d3d3d3",
-        lightgreen: "90ee90",
-        lightgrey: "d3d3d3",
-        lightpink: "ffb6c1",
-        lightsalmon: "ffa07a",
-        lightseagreen: "20b2aa",
-        lightskyblue: "87cefa",
-        lightslategray: "789",
-        lightslategrey: "789",
-        lightsteelblue: "b0c4de",
-        lightyellow: "ffffe0",
-        lime: "0f0",
-        limegreen: "32cd32",
-        linen: "faf0e6",
-        magenta: "f0f",
-        maroon: "800000",
-        mediumaquamarine: "66cdaa",
-        mediumblue: "0000cd",
-        mediumorchid: "ba55d3",
-        mediumpurple: "9370db",
-        mediumseagreen: "3cb371",
-        mediumslateblue: "7b68ee",
-        mediumspringgreen: "00fa9a",
-        mediumturquoise: "48d1cc",
-        mediumvioletred: "c71585",
-        midnightblue: "191970",
-        mintcream: "f5fffa",
-        mistyrose: "ffe4e1",
-        moccasin: "ffe4b5",
-        navajowhite: "ffdead",
-        navy: "000080",
-        oldlace: "fdf5e6",
-        olive: "808000",
-        olivedrab: "6b8e23",
-        orange: "ffa500",
-        orangered: "ff4500",
-        orchid: "da70d6",
-        palegoldenrod: "eee8aa",
-        palegreen: "98fb98",
-        paleturquoise: "afeeee",
-        palevioletred: "db7093",
-        papayawhip: "ffefd5",
-        peachpuff: "ffdab9",
-        peru: "cd853f",
-        pink: "ffc0cb",
-        plum: "dda0dd",
-        powderblue: "b0e0e6",
-        purple: "800080",
-        rebeccapurple: "663399",
-        red: "f00",
-        rosybrown: "bc8f8f",
-        royalblue: "4169e1",
-        saddlebrown: "8b4513",
-        salmon: "fa8072",
-        sandybrown: "f4a460",
-        seagreen: "2e8b57",
-        seashell: "fff5ee",
-        sienna: "a0522d",
-        silver: "c0c0c0",
-        skyblue: "87ceeb",
-        slateblue: "6a5acd",
-        slategray: "708090",
-        slategrey: "708090",
-        snow: "fffafa",
-        springgreen: "00ff7f",
-        steelblue: "4682b4",
-        tan: "d2b48c",
-        teal: "008080",
-        thistle: "d8bfd8",
-        tomato: "ff6347",
-        turquoise: "40e0d0",
-        violet: "ee82ee",
-        wheat: "f5deb3",
-        white: "fff",
-        whitesmoke: "f5f5f5",
-        yellow: "ff0",
-        yellowgreen: "9acd32"
-    };
-
-    // Make it easy to access colors via `hexNames[hex]`
-    var hexNames = tinycolor.hexNames = flip(names);
-
-
-    // Utilities
-    // ---------
-
-    // `{ 'name1': 'val1' }` becomes `{ 'val1': 'name1' }`
-    function flip(o) {
-        var flipped = { };
-        for (var i in o) {
-            if (o.hasOwnProperty(i)) {
-                flipped[o[i]] = i;
-            }
-        }
-        return flipped;
-    }
-
-    // Return a valid alpha value [0,1] with all invalid values being set to 1
-    function boundAlpha(a) {
-        a = parseFloat(a);
-
-        if (isNaN(a) || a < 0 || a > 1) {
-            a = 1;
-        }
-
-        return a;
-    }
-
-    // Take input from [0, n] and return it as [0, 1]
-    function bound01(n, max) {
-        if (isOnePointZero(n)) { n = "100%"; }
-
-        var processPercent = isPercentage(n);
-        n = mathMin(max, mathMax(0, parseFloat(n)));
-
-        // Automatically convert percentage into number
-        if (processPercent) {
-            n = parseInt(n * max, 10) / 100;
-        }
-
-        // Handle floating point rounding errors
-        if ((math.abs(n - max) < 0.000001)) {
-            return 1;
-        }
-
-        // Convert into [0, 1] range if it isn't already
-        return (n % max) / parseFloat(max);
-    }
-
-    // Force a number between 0 and 1
-    function clamp01(val) {
-        return mathMin(1, mathMax(0, val));
-    }
-
-    // Parse a base-16 hex value into a base-10 integer
-    function parseIntFromHex(val) {
-        return parseInt(val, 16);
-    }
-
-    // Need to handle 1.0 as 100%, since once it is a number, there is no difference between it and 1
-    // <http://stackoverflow.com/questions/7422072/javascript-how-to-detect-number-as-a-decimal-including-1-0>
-    function isOnePointZero(n) {
-        return typeof n == "string" && n.indexOf('.') != -1 && parseFloat(n) === 1;
-    }
-
-    // Check to see if string passed in is a percentage
-    function isPercentage(n) {
-        return typeof n === "string" && n.indexOf('%') != -1;
-    }
-
-    // Force a hex value to have 2 characters
-    function pad2(c) {
-        return c.length == 1 ? '0' + c : '' + c;
-    }
-
-    // Replace a decimal with it's percentage value
-    function convertToPercentage(n) {
-        if (n <= 1) {
-            n = (n * 100) + "%";
-        }
-
-        return n;
-    }
-
-    // Converts a decimal to a hex value
-    function convertDecimalToHex(d) {
-        return Math.round(parseFloat(d) * 255).toString(16);
-    }
-    // Converts a hex value to a decimal
-    function convertHexToDecimal(h) {
-        return (parseIntFromHex(h) / 255);
-    }
-
-    var matchers = (function() {
-
-        // <http://www.w3.org/TR/css3-values/#integers>
-        var CSS_INTEGER = "[-\\+]?\\d+%?";
-
-        // <http://www.w3.org/TR/css3-values/#number-value>
-        var CSS_NUMBER = "[-\\+]?\\d*\\.\\d+%?";
-
-        // Allow positive/negative integer/number.  Don't capture the either/or, just the entire outcome.
-        var CSS_UNIT = "(?:" + CSS_NUMBER + ")|(?:" + CSS_INTEGER + ")";
-
-        // Actual matching.
-        // Parentheses and commas are optional, but not required.
-        // Whitespace can take the place of commas or opening paren
-        var PERMISSIVE_MATCH3 = "[\\s|\\(]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")\\s*\\)?";
-        var PERMISSIVE_MATCH4 = "[\\s|\\(]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")\\s*\\)?";
-
-        return {
-            rgb: new RegExp("rgb" + PERMISSIVE_MATCH3),
-            rgba: new RegExp("rgba" + PERMISSIVE_MATCH4),
-            hsl: new RegExp("hsl" + PERMISSIVE_MATCH3),
-            hsla: new RegExp("hsla" + PERMISSIVE_MATCH4),
-            hsv: new RegExp("hsv" + PERMISSIVE_MATCH3),
-            hsva: new RegExp("hsva" + PERMISSIVE_MATCH4),
-            hex3: /^([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
-            hex6: /^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
-            hex8: /^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/
-        };
-    })();
-
-    // `stringInputToObject`
-    // Permissive string parsing.  Take in a number of formats, and output an object
-    // based on detected format.  Returns `{ r, g, b }` or `{ h, s, l }` or `{ h, s, v}`
-    function stringInputToObject(color) {
-
-        color = color.replace(trimLeft,'').replace(trimRight, '').toLowerCase();
-        var named = false;
-        if (names[color]) {
-            color = names[color];
-            named = true;
-        }
-        else if (color == 'transparent') {
-            return { r: 0, g: 0, b: 0, a: 0, format: "name" };
-        }
-
-        // Try to match string input using regular expressions.
-        // Keep most of the number bounding out of this function - don't worry about [0,1] or [0,100] or [0,360]
-        // Just return an object and let the conversion functions handle that.
-        // This way the result will be the same whether the tinycolor is initialized with string or object.
-        var match;
-        if ((match = matchers.rgb.exec(color))) {
-            return { r: match[1], g: match[2], b: match[3] };
-        }
-        if ((match = matchers.rgba.exec(color))) {
-            return { r: match[1], g: match[2], b: match[3], a: match[4] };
-        }
-        if ((match = matchers.hsl.exec(color))) {
-            return { h: match[1], s: match[2], l: match[3] };
-        }
-        if ((match = matchers.hsla.exec(color))) {
-            return { h: match[1], s: match[2], l: match[3], a: match[4] };
-        }
-        if ((match = matchers.hsv.exec(color))) {
-            return { h: match[1], s: match[2], v: match[3] };
-        }
-        if ((match = matchers.hsva.exec(color))) {
-            return { h: match[1], s: match[2], v: match[3], a: match[4] };
-        }
-        if ((match = matchers.hex8.exec(color))) {
+            a = boundAlpha(a);
             return {
-                a: convertHexToDecimal(match[1]),
-                r: parseIntFromHex(match[2]),
-                g: parseIntFromHex(match[3]),
-                b: parseIntFromHex(match[4]),
-                format: named ? "name" : "hex8"
+              ok: ok,
+              format: color.format || format,
+              r: Math.min(255, Math.max(rgb.r, 0)),
+              g: Math.min(255, Math.max(rgb.g, 0)),
+              b: Math.min(255, Math.max(rgb.b, 0)),
+              a: a
             };
-        }
-        if ((match = matchers.hex6.exec(color))) {
+          }
+        
+          // Conversion Functions
+          // --------------------
+        
+          // `rgbToHsl`, `rgbToHsv`, `hslToRgb`, `hsvToRgb` modified from:
+          // <http://mjijackson.com/2008/02/rgb-to-hsl-and-rgb-to-hsv-color-model-conversion-algorithms-in-javascript>
+        
+          // `rgbToRgb`
+          // Handle bounds / percentage checking to conform to CSS color spec
+          // <http://www.w3.org/TR/css3-color/>
+          // *Assumes:* r, g, b in [0, 255] or [0, 1]
+          // *Returns:* { r, g, b } in [0, 255]
+          function rgbToRgb(r, g, b) {
             return {
+              r: bound01(r, 255) * 255,
+              g: bound01(g, 255) * 255,
+              b: bound01(b, 255) * 255
+            };
+          }
+        
+          // `rgbToHsl`
+          // Converts an RGB color value to HSL.
+          // *Assumes:* r, g, and b are contained in [0, 255] or [0, 1]
+          // *Returns:* { h, s, l } in [0,1]
+          function rgbToHsl(r, g, b) {
+            r = bound01(r, 255);
+            g = bound01(g, 255);
+            b = bound01(b, 255);
+            var max = Math.max(r, g, b),
+              min = Math.min(r, g, b);
+            var h,
+              s,
+              l = (max + min) / 2;
+            if (max == min) {
+              h = s = 0; // achromatic
+            } else {
+              var d = max - min;
+              s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+              switch (max) {
+                case r:
+                  h = (g - b) / d + (g < b ? 6 : 0);
+                  break;
+                case g:
+                  h = (b - r) / d + 2;
+                  break;
+                case b:
+                  h = (r - g) / d + 4;
+                  break;
+              }
+              h /= 6;
+            }
+            return {
+              h: h,
+              s: s,
+              l: l
+            };
+          }
+        
+          // `hslToRgb`
+          // Converts an HSL color value to RGB.
+          // *Assumes:* h is contained in [0, 1] or [0, 360] and s and l are contained [0, 1] or [0, 100]
+          // *Returns:* { r, g, b } in the set [0, 255]
+          function hslToRgb(h, s, l) {
+            var r, g, b;
+            h = bound01(h, 360);
+            s = bound01(s, 100);
+            l = bound01(l, 100);
+            function hue2rgb(p, q, t) {
+              if (t < 0) t += 1;
+              if (t > 1) t -= 1;
+              if (t < 1 / 6) return p + (q - p) * 6 * t;
+              if (t < 1 / 2) return q;
+              if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+              return p;
+            }
+            if (s === 0) {
+              r = g = b = l; // achromatic
+            } else {
+              var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+              var p = 2 * l - q;
+              r = hue2rgb(p, q, h + 1 / 3);
+              g = hue2rgb(p, q, h);
+              b = hue2rgb(p, q, h - 1 / 3);
+            }
+            return {
+              r: r * 255,
+              g: g * 255,
+              b: b * 255
+            };
+          }
+        
+          // `rgbToHsv`
+          // Converts an RGB color value to HSV
+          // *Assumes:* r, g, and b are contained in the set [0, 255] or [0, 1]
+          // *Returns:* { h, s, v } in [0,1]
+          function rgbToHsv(r, g, b) {
+            r = bound01(r, 255);
+            g = bound01(g, 255);
+            b = bound01(b, 255);
+            var max = Math.max(r, g, b),
+              min = Math.min(r, g, b);
+            var h,
+              s,
+              v = max;
+            var d = max - min;
+            s = max === 0 ? 0 : d / max;
+            if (max == min) {
+              h = 0; // achromatic
+            } else {
+              switch (max) {
+                case r:
+                  h = (g - b) / d + (g < b ? 6 : 0);
+                  break;
+                case g:
+                  h = (b - r) / d + 2;
+                  break;
+                case b:
+                  h = (r - g) / d + 4;
+                  break;
+              }
+              h /= 6;
+            }
+            return {
+              h: h,
+              s: s,
+              v: v
+            };
+          }
+        
+          // `hsvToRgb`
+          // Converts an HSV color value to RGB.
+          // *Assumes:* h is contained in [0, 1] or [0, 360] and s and v are contained in [0, 1] or [0, 100]
+          // *Returns:* { r, g, b } in the set [0, 255]
+          function hsvToRgb(h, s, v) {
+            h = bound01(h, 360) * 6;
+            s = bound01(s, 100);
+            v = bound01(v, 100);
+            var i = Math.floor(h),
+              f = h - i,
+              p = v * (1 - s),
+              q = v * (1 - f * s),
+              t = v * (1 - (1 - f) * s),
+              mod = i % 6,
+              r = [v, q, p, p, t, v][mod],
+              g = [t, v, v, q, p, p][mod],
+              b = [p, p, t, v, v, q][mod];
+            return {
+              r: r * 255,
+              g: g * 255,
+              b: b * 255
+            };
+          }
+        
+          // `rgbToHex`
+          // Converts an RGB color to hex
+          // Assumes r, g, and b are contained in the set [0, 255]
+          // Returns a 3 or 6 character hex
+          function rgbToHex(r, g, b, allow3Char) {
+            var hex = [pad2(Math.round(r).toString(16)), pad2(Math.round(g).toString(16)), pad2(Math.round(b).toString(16))];
+        
+            // Return a 3 character hex if possible
+            if (allow3Char && hex[0].charAt(0) == hex[0].charAt(1) && hex[1].charAt(0) == hex[1].charAt(1) && hex[2].charAt(0) == hex[2].charAt(1)) {
+              return hex[0].charAt(0) + hex[1].charAt(0) + hex[2].charAt(0);
+            }
+            return hex.join("");
+          }
+        
+          // `rgbaToHex`
+          // Converts an RGBA color plus alpha transparency to hex
+          // Assumes r, g, b are contained in the set [0, 255] and
+          // a in [0, 1]. Returns a 4 or 8 character rgba hex
+          function rgbaToHex(r, g, b, a, allow4Char) {
+            var hex = [pad2(Math.round(r).toString(16)), pad2(Math.round(g).toString(16)), pad2(Math.round(b).toString(16)), pad2(convertDecimalToHex(a))];
+        
+            // Return a 4 character hex if possible
+            if (allow4Char && hex[0].charAt(0) == hex[0].charAt(1) && hex[1].charAt(0) == hex[1].charAt(1) && hex[2].charAt(0) == hex[2].charAt(1) && hex[3].charAt(0) == hex[3].charAt(1)) {
+              return hex[0].charAt(0) + hex[1].charAt(0) + hex[2].charAt(0) + hex[3].charAt(0);
+            }
+            return hex.join("");
+          }
+        
+          // `rgbaToArgbHex`
+          // Converts an RGBA color to an ARGB Hex8 string
+          // Rarely used, but required for "toFilter()"
+          function rgbaToArgbHex(r, g, b, a) {
+            var hex = [pad2(convertDecimalToHex(a)), pad2(Math.round(r).toString(16)), pad2(Math.round(g).toString(16)), pad2(Math.round(b).toString(16))];
+            return hex.join("");
+          }
+        
+          // `equals`
+          // Can be called with any tinycolor input
+          tinycolor.equals = function (color1, color2) {
+            if (!color1 || !color2) return false;
+            return tinycolor(color1).toRgbString() == tinycolor(color2).toRgbString();
+          };
+          tinycolor.random = function () {
+            return tinycolor.fromRatio({
+              r: Math.random(),
+              g: Math.random(),
+              b: Math.random()
+            });
+          };
+        
+          // Modification Functions
+          // ----------------------
+          // Thanks to less.js for some of the basics here
+          // <https://github.com/cloudhead/less.js/blob/master/lib/less/functions.js>
+        
+          function _desaturate(color, amount) {
+            amount = amount === 0 ? 0 : amount || 10;
+            var hsl = tinycolor(color).toHsl();
+            hsl.s -= amount / 100;
+            hsl.s = clamp01(hsl.s);
+            return tinycolor(hsl);
+          }
+          function _saturate(color, amount) {
+            amount = amount === 0 ? 0 : amount || 10;
+            var hsl = tinycolor(color).toHsl();
+            hsl.s += amount / 100;
+            hsl.s = clamp01(hsl.s);
+            return tinycolor(hsl);
+          }
+          function _greyscale(color) {
+            return tinycolor(color).desaturate(100);
+          }
+          function _lighten(color, amount) {
+            amount = amount === 0 ? 0 : amount || 10;
+            var hsl = tinycolor(color).toHsl();
+            hsl.l += amount / 100;
+            hsl.l = clamp01(hsl.l);
+            return tinycolor(hsl);
+          }
+          function _brighten(color, amount) {
+            amount = amount === 0 ? 0 : amount || 10;
+            var rgb = tinycolor(color).toRgb();
+            rgb.r = Math.max(0, Math.min(255, rgb.r - Math.round(255 * -(amount / 100))));
+            rgb.g = Math.max(0, Math.min(255, rgb.g - Math.round(255 * -(amount / 100))));
+            rgb.b = Math.max(0, Math.min(255, rgb.b - Math.round(255 * -(amount / 100))));
+            return tinycolor(rgb);
+          }
+          function _darken(color, amount) {
+            amount = amount === 0 ? 0 : amount || 10;
+            var hsl = tinycolor(color).toHsl();
+            hsl.l -= amount / 100;
+            hsl.l = clamp01(hsl.l);
+            return tinycolor(hsl);
+          }
+        
+          // Spin takes a positive or negative amount within [-360, 360] indicating the change of hue.
+          // Values outside of this range will be wrapped into this range.
+          function _spin(color, amount) {
+            var hsl = tinycolor(color).toHsl();
+            var hue = (hsl.h + amount) % 360;
+            hsl.h = hue < 0 ? 360 + hue : hue;
+            return tinycolor(hsl);
+          }
+        
+          // Combination Functions
+          // ---------------------
+          // Thanks to jQuery xColor for some of the ideas behind these
+          // <https://github.com/infusion/jQuery-xcolor/blob/master/jquery.xcolor.js>
+        
+          function _complement(color) {
+            var hsl = tinycolor(color).toHsl();
+            hsl.h = (hsl.h + 180) % 360;
+            return tinycolor(hsl);
+          }
+          function polyad(color, number) {
+            if (isNaN(number) || number <= 0) {
+              throw new Error("Argument to polyad must be a positive number");
+            }
+            var hsl = tinycolor(color).toHsl();
+            var result = [tinycolor(color)];
+            var step = 360 / number;
+            for (var i = 1; i < number; i++) {
+              result.push(tinycolor({
+                h: (hsl.h + i * step) % 360,
+                s: hsl.s,
+                l: hsl.l
+              }));
+            }
+            return result;
+          }
+          function _splitcomplement(color) {
+            var hsl = tinycolor(color).toHsl();
+            var h = hsl.h;
+            return [tinycolor(color), tinycolor({
+              h: (h + 72) % 360,
+              s: hsl.s,
+              l: hsl.l
+            }), tinycolor({
+              h: (h + 216) % 360,
+              s: hsl.s,
+              l: hsl.l
+            })];
+          }
+          function _analogous(color, results, slices) {
+            results = results || 6;
+            slices = slices || 30;
+            var hsl = tinycolor(color).toHsl();
+            var part = 360 / slices;
+            var ret = [tinycolor(color)];
+            for (hsl.h = (hsl.h - (part * results >> 1) + 720) % 360; --results;) {
+              hsl.h = (hsl.h + part) % 360;
+              ret.push(tinycolor(hsl));
+            }
+            return ret;
+          }
+          function _monochromatic(color, results) {
+            results = results || 6;
+            var hsv = tinycolor(color).toHsv();
+            var h = hsv.h,
+              s = hsv.s,
+              v = hsv.v;
+            var ret = [];
+            var modification = 1 / results;
+            while (results--) {
+              ret.push(tinycolor({
+                h: h,
+                s: s,
+                v: v
+              }));
+              v = (v + modification) % 1;
+            }
+            return ret;
+          }
+        
+          // Utility Functions
+          // ---------------------
+        
+          tinycolor.mix = function (color1, color2, amount) {
+            amount = amount === 0 ? 0 : amount || 50;
+            var rgb1 = tinycolor(color1).toRgb();
+            var rgb2 = tinycolor(color2).toRgb();
+            var p = amount / 100;
+            var rgba = {
+              r: (rgb2.r - rgb1.r) * p + rgb1.r,
+              g: (rgb2.g - rgb1.g) * p + rgb1.g,
+              b: (rgb2.b - rgb1.b) * p + rgb1.b,
+              a: (rgb2.a - rgb1.a) * p + rgb1.a
+            };
+            return tinycolor(rgba);
+          };
+        
+          // Readability Functions
+          // ---------------------
+          // <http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef (WCAG Version 2)
+        
+          // `contrast`
+          // Analyze the 2 colors and returns the color contrast defined by (WCAG Version 2)
+          tinycolor.readability = function (color1, color2) {
+            var c1 = tinycolor(color1);
+            var c2 = tinycolor(color2);
+            return (Math.max(c1.getLuminance(), c2.getLuminance()) + 0.05) / (Math.min(c1.getLuminance(), c2.getLuminance()) + 0.05);
+          };
+        
+          // `isReadable`
+          // Ensure that foreground and background color combinations meet WCAG2 guidelines.
+          // The third argument is an optional Object.
+          //      the 'level' property states 'AA' or 'AAA' - if missing or invalid, it defaults to 'AA';
+          //      the 'size' property states 'large' or 'small' - if missing or invalid, it defaults to 'small'.
+          // If the entire object is absent, isReadable defaults to {level:"AA",size:"small"}.
+        
+          // *Example*
+          //    tinycolor.isReadable("#000", "#111") => false
+          //    tinycolor.isReadable("#000", "#111",{level:"AA",size:"large"}) => false
+          tinycolor.isReadable = function (color1, color2, wcag2) {
+            var readability = tinycolor.readability(color1, color2);
+            var wcag2Parms, out;
+            out = false;
+            wcag2Parms = validateWCAG2Parms(wcag2);
+            switch (wcag2Parms.level + wcag2Parms.size) {
+              case "AAsmall":
+              case "AAAlarge":
+                out = readability >= 4.5;
+                break;
+              case "AAlarge":
+                out = readability >= 3;
+                break;
+              case "AAAsmall":
+                out = readability >= 7;
+                break;
+            }
+            return out;
+          };
+        
+          // `mostReadable`
+          // Given a base color and a list of possible foreground or background
+          // colors for that base, returns the most readable color.
+          // Optionally returns Black or White if the most readable color is unreadable.
+          // *Example*
+          //    tinycolor.mostReadable(tinycolor.mostReadable("#123", ["#124", "#125"],{includeFallbackColors:false}).toHexString(); // "#112255"
+          //    tinycolor.mostReadable(tinycolor.mostReadable("#123", ["#124", "#125"],{includeFallbackColors:true}).toHexString();  // "#ffffff"
+          //    tinycolor.mostReadable("#a8015a", ["#faf3f3"],{includeFallbackColors:true,level:"AAA",size:"large"}).toHexString(); // "#faf3f3"
+          //    tinycolor.mostReadable("#a8015a", ["#faf3f3"],{includeFallbackColors:true,level:"AAA",size:"small"}).toHexString(); // "#ffffff"
+          tinycolor.mostReadable = function (baseColor, colorList, args) {
+            var bestColor = null;
+            var bestScore = 0;
+            var readability;
+            var includeFallbackColors, level, size;
+            args = args || {};
+            includeFallbackColors = args.includeFallbackColors;
+            level = args.level;
+            size = args.size;
+            for (var i = 0; i < colorList.length; i++) {
+              readability = tinycolor.readability(baseColor, colorList[i]);
+              if (readability > bestScore) {
+                bestScore = readability;
+                bestColor = tinycolor(colorList[i]);
+              }
+            }
+            if (tinycolor.isReadable(baseColor, bestColor, {
+              level: level,
+              size: size
+            }) || !includeFallbackColors) {
+              return bestColor;
+            } else {
+              args.includeFallbackColors = false;
+              return tinycolor.mostReadable(baseColor, ["#fff", "#000"], args);
+            }
+          };
+        
+          // Big List of Colors
+          // ------------------
+          // <https://www.w3.org/TR/css-color-4/#named-colors>
+          var names = tinycolor.names = {
+            aliceblue: "f0f8ff",
+            antiquewhite: "faebd7",
+            aqua: "0ff",
+            aquamarine: "7fffd4",
+            azure: "f0ffff",
+            beige: "f5f5dc",
+            bisque: "ffe4c4",
+            black: "000",
+            blanchedalmond: "ffebcd",
+            blue: "00f",
+            blueviolet: "8a2be2",
+            brown: "a52a2a",
+            burlywood: "deb887",
+            burntsienna: "ea7e5d",
+            cadetblue: "5f9ea0",
+            chartreuse: "7fff00",
+            chocolate: "d2691e",
+            coral: "ff7f50",
+            cornflowerblue: "6495ed",
+            cornsilk: "fff8dc",
+            crimson: "dc143c",
+            cyan: "0ff",
+            darkblue: "00008b",
+            darkcyan: "008b8b",
+            darkgoldenrod: "b8860b",
+            darkgray: "a9a9a9",
+            darkgreen: "006400",
+            darkgrey: "a9a9a9",
+            darkkhaki: "bdb76b",
+            darkmagenta: "8b008b",
+            darkolivegreen: "556b2f",
+            darkorange: "ff8c00",
+            darkorchid: "9932cc",
+            darkred: "8b0000",
+            darksalmon: "e9967a",
+            darkseagreen: "8fbc8f",
+            darkslateblue: "483d8b",
+            darkslategray: "2f4f4f",
+            darkslategrey: "2f4f4f",
+            darkturquoise: "00ced1",
+            darkviolet: "9400d3",
+            deeppink: "ff1493",
+            deepskyblue: "00bfff",
+            dimgray: "696969",
+            dimgrey: "696969",
+            dodgerblue: "1e90ff",
+            firebrick: "b22222",
+            floralwhite: "fffaf0",
+            forestgreen: "228b22",
+            fuchsia: "f0f",
+            gainsboro: "dcdcdc",
+            ghostwhite: "f8f8ff",
+            gold: "ffd700",
+            goldenrod: "daa520",
+            gray: "808080",
+            green: "008000",
+            greenyellow: "adff2f",
+            grey: "808080",
+            honeydew: "f0fff0",
+            hotpink: "ff69b4",
+            indianred: "cd5c5c",
+            indigo: "4b0082",
+            ivory: "fffff0",
+            khaki: "f0e68c",
+            lavender: "e6e6fa",
+            lavenderblush: "fff0f5",
+            lawngreen: "7cfc00",
+            lemonchiffon: "fffacd",
+            lightblue: "add8e6",
+            lightcoral: "f08080",
+            lightcyan: "e0ffff",
+            lightgoldenrodyellow: "fafad2",
+            lightgray: "d3d3d3",
+            lightgreen: "90ee90",
+            lightgrey: "d3d3d3",
+            lightpink: "ffb6c1",
+            lightsalmon: "ffa07a",
+            lightseagreen: "20b2aa",
+            lightskyblue: "87cefa",
+            lightslategray: "789",
+            lightslategrey: "789",
+            lightsteelblue: "b0c4de",
+            lightyellow: "ffffe0",
+            lime: "0f0",
+            limegreen: "32cd32",
+            linen: "faf0e6",
+            magenta: "f0f",
+            maroon: "800000",
+            mediumaquamarine: "66cdaa",
+            mediumblue: "0000cd",
+            mediumorchid: "ba55d3",
+            mediumpurple: "9370db",
+            mediumseagreen: "3cb371",
+            mediumslateblue: "7b68ee",
+            mediumspringgreen: "00fa9a",
+            mediumturquoise: "48d1cc",
+            mediumvioletred: "c71585",
+            midnightblue: "191970",
+            mintcream: "f5fffa",
+            mistyrose: "ffe4e1",
+            moccasin: "ffe4b5",
+            navajowhite: "ffdead",
+            navy: "000080",
+            oldlace: "fdf5e6",
+            olive: "808000",
+            olivedrab: "6b8e23",
+            orange: "ffa500",
+            orangered: "ff4500",
+            orchid: "da70d6",
+            palegoldenrod: "eee8aa",
+            palegreen: "98fb98",
+            paleturquoise: "afeeee",
+            palevioletred: "db7093",
+            papayawhip: "ffefd5",
+            peachpuff: "ffdab9",
+            peru: "cd853f",
+            pink: "ffc0cb",
+            plum: "dda0dd",
+            powderblue: "b0e0e6",
+            purple: "800080",
+            rebeccapurple: "663399",
+            red: "f00",
+            rosybrown: "bc8f8f",
+            royalblue: "4169e1",
+            saddlebrown: "8b4513",
+            salmon: "fa8072",
+            sandybrown: "f4a460",
+            seagreen: "2e8b57",
+            seashell: "fff5ee",
+            sienna: "a0522d",
+            silver: "c0c0c0",
+            skyblue: "87ceeb",
+            slateblue: "6a5acd",
+            slategray: "708090",
+            slategrey: "708090",
+            snow: "fffafa",
+            springgreen: "00ff7f",
+            steelblue: "4682b4",
+            tan: "d2b48c",
+            teal: "008080",
+            thistle: "d8bfd8",
+            tomato: "ff6347",
+            turquoise: "40e0d0",
+            violet: "ee82ee",
+            wheat: "f5deb3",
+            white: "fff",
+            whitesmoke: "f5f5f5",
+            yellow: "ff0",
+            yellowgreen: "9acd32"
+          };
+        
+          // Make it easy to access colors via `hexNames[hex]`
+          var hexNames = tinycolor.hexNames = flip(names);
+        
+          // Utilities
+          // ---------
+        
+          // `{ 'name1': 'val1' }` becomes `{ 'val1': 'name1' }`
+          function flip(o) {
+            var flipped = {};
+            for (var i in o) {
+              if (o.hasOwnProperty(i)) {
+                flipped[o[i]] = i;
+              }
+            }
+            return flipped;
+          }
+        
+          // Return a valid alpha value [0,1] with all invalid values being set to 1
+          function boundAlpha(a) {
+            a = parseFloat(a);
+            if (isNaN(a) || a < 0 || a > 1) {
+              a = 1;
+            }
+            return a;
+          }
+        
+          // Take input from [0, n] and return it as [0, 1]
+          function bound01(n, max) {
+            if (isOnePointZero(n)) n = "100%";
+            var processPercent = isPercentage(n);
+            n = Math.min(max, Math.max(0, parseFloat(n)));
+        
+            // Automatically convert percentage into number
+            if (processPercent) {
+              n = parseInt(n * max, 10) / 100;
+            }
+        
+            // Handle floating point rounding errors
+            if (Math.abs(n - max) < 0.000001) {
+              return 1;
+            }
+        
+            // Convert into [0, 1] range if it isn't already
+            return n % max / parseFloat(max);
+          }
+        
+          // Force a number between 0 and 1
+          function clamp01(val) {
+            return Math.min(1, Math.max(0, val));
+          }
+        
+          // Parse a base-16 hex value into a base-10 integer
+          function parseIntFromHex(val) {
+            return parseInt(val, 16);
+          }
+        
+          // Need to handle 1.0 as 100%, since once it is a number, there is no difference between it and 1
+          // <http://stackoverflow.com/questions/7422072/javascript-how-to-detect-number-as-a-decimal-including-1-0>
+          function isOnePointZero(n) {
+            return typeof n == "string" && n.indexOf(".") != -1 && parseFloat(n) === 1;
+          }
+        
+          // Check to see if string passed in is a percentage
+          function isPercentage(n) {
+            return typeof n === "string" && n.indexOf("%") != -1;
+          }
+        
+          // Force a hex value to have 2 characters
+          function pad2(c) {
+            return c.length == 1 ? "0" + c : "" + c;
+          }
+        
+          // Replace a decimal with it's percentage value
+          function convertToPercentage(n) {
+            if (n <= 1) {
+              n = n * 100 + "%";
+            }
+            return n;
+          }
+        
+          // Converts a decimal to a hex value
+          function convertDecimalToHex(d) {
+            return Math.round(parseFloat(d) * 255).toString(16);
+          }
+          // Converts a hex value to a decimal
+          function convertHexToDecimal(h) {
+            return parseIntFromHex(h) / 255;
+          }
+          var matchers = function () {
+            // <http://www.w3.org/TR/css3-values/#integers>
+            var CSS_INTEGER = "[-\\+]?\\d+%?";
+        
+            // <http://www.w3.org/TR/css3-values/#number-value>
+            var CSS_NUMBER = "[-\\+]?\\d*\\.\\d+%?";
+        
+            // Allow positive/negative integer/number.  Don't capture the either/or, just the entire outcome.
+            var CSS_UNIT = "(?:" + CSS_NUMBER + ")|(?:" + CSS_INTEGER + ")";
+        
+            // Actual matching.
+            // Parentheses and commas are optional, but not required.
+            // Whitespace can take the place of commas or opening paren
+            var PERMISSIVE_MATCH3 = "[\\s|\\(]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")\\s*\\)?";
+            var PERMISSIVE_MATCH4 = "[\\s|\\(]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")\\s*\\)?";
+            return {
+              CSS_UNIT: new RegExp(CSS_UNIT),
+              rgb: new RegExp("rgb" + PERMISSIVE_MATCH3),
+              rgba: new RegExp("rgba" + PERMISSIVE_MATCH4),
+              hsl: new RegExp("hsl" + PERMISSIVE_MATCH3),
+              hsla: new RegExp("hsla" + PERMISSIVE_MATCH4),
+              hsv: new RegExp("hsv" + PERMISSIVE_MATCH3),
+              hsva: new RegExp("hsva" + PERMISSIVE_MATCH4),
+              hex3: /^#?([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
+              hex6: /^#?([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
+              hex4: /^#?([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
+              hex8: /^#?([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/
+            };
+          }();
+        
+          // `isValidCSSUnit`
+          // Take in a single string / number and check to see if it looks like a CSS unit
+          // (see `matchers` above for definition).
+          function isValidCSSUnit(color) {
+            return !!matchers.CSS_UNIT.exec(color);
+          }
+        
+          // `stringInputToObject`
+          // Permissive string parsing.  Take in a number of formats, and output an object
+          // based on detected format.  Returns `{ r, g, b }` or `{ h, s, l }` or `{ h, s, v}`
+          function stringInputToObject(color) {
+            color = color.replace(trimLeft, "").replace(trimRight, "").toLowerCase();
+            var named = false;
+            if (names[color]) {
+              color = names[color];
+              named = true;
+            } else if (color == "transparent") {
+              return {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0,
+                format: "name"
+              };
+            }
+        
+            // Try to match string input using regular expressions.
+            // Keep most of the number bounding out of this function - don't worry about [0,1] or [0,100] or [0,360]
+            // Just return an object and let the conversion functions handle that.
+            // This way the result will be the same whether the tinycolor is initialized with string or object.
+            var match;
+            if (match = matchers.rgb.exec(color)) {
+              return {
+                r: match[1],
+                g: match[2],
+                b: match[3]
+              };
+            }
+            if (match = matchers.rgba.exec(color)) {
+              return {
+                r: match[1],
+                g: match[2],
+                b: match[3],
+                a: match[4]
+              };
+            }
+            if (match = matchers.hsl.exec(color)) {
+              return {
+                h: match[1],
+                s: match[2],
+                l: match[3]
+              };
+            }
+            if (match = matchers.hsla.exec(color)) {
+              return {
+                h: match[1],
+                s: match[2],
+                l: match[3],
+                a: match[4]
+              };
+            }
+            if (match = matchers.hsv.exec(color)) {
+              return {
+                h: match[1],
+                s: match[2],
+                v: match[3]
+              };
+            }
+            if (match = matchers.hsva.exec(color)) {
+              return {
+                h: match[1],
+                s: match[2],
+                v: match[3],
+                a: match[4]
+              };
+            }
+            if (match = matchers.hex8.exec(color)) {
+              return {
+                r: parseIntFromHex(match[1]),
+                g: parseIntFromHex(match[2]),
+                b: parseIntFromHex(match[3]),
+                a: convertHexToDecimal(match[4]),
+                format: named ? "name" : "hex8"
+              };
+            }
+            if (match = matchers.hex6.exec(color)) {
+              return {
                 r: parseIntFromHex(match[1]),
                 g: parseIntFromHex(match[2]),
                 b: parseIntFromHex(match[3]),
                 format: named ? "name" : "hex"
-            };
-        }
-        if ((match = matchers.hex3.exec(color))) {
-            return {
-                r: parseIntFromHex(match[1] + '' + match[1]),
-                g: parseIntFromHex(match[2] + '' + match[2]),
-                b: parseIntFromHex(match[3] + '' + match[3]),
+              };
+            }
+            if (match = matchers.hex4.exec(color)) {
+              return {
+                r: parseIntFromHex(match[1] + "" + match[1]),
+                g: parseIntFromHex(match[2] + "" + match[2]),
+                b: parseIntFromHex(match[3] + "" + match[3]),
+                a: convertHexToDecimal(match[4] + "" + match[4]),
+                format: named ? "name" : "hex8"
+              };
+            }
+            if (match = matchers.hex3.exec(color)) {
+              return {
+                r: parseIntFromHex(match[1] + "" + match[1]),
+                g: parseIntFromHex(match[2] + "" + match[2]),
+                b: parseIntFromHex(match[3] + "" + match[3]),
                 format: named ? "name" : "hex"
+              };
+            }
+            return false;
+          }
+          function validateWCAG2Parms(parms) {
+            // return valid WCAG2 parms for isReadable.
+            // If input parms are invalid, return {"level":"AA", "size":"small"}
+            var level, size;
+            parms = parms || {
+              level: "AA",
+              size: "small"
             };
-        }
-
-        return false;
-    }
-
+            level = (parms.level || "AA").toUpperCase();
+            size = (parms.size || "small").toLowerCase();
+            if (level !== "AA" && level !== "AAA") {
+              level = "AA";
+            }
+            if (size !== "small" && size !== "large") {
+              size = "small";
+            }
+            return {
+              level: level,
+              size: size
+            };
+          }
+        
     window.tinycolor = tinycolor;
     })();
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -26,19 +26,20 @@ onload = function() {
 
     // Declare custom color picker
     $(colorpicker_special).spectrum({
-        type: "component",
+        type: "color",
         preferredFormat: "hex",
         showInput: true,
         chooseText: "OK",
         // cancelText: "No way",
         // showAlpha: true,
-        // allowAlpha: true,
-        // allowEmpty: true,
+        allowAlpha: true,
+        allowEmpty: true,
+        showInitial: true,
         togglePaletteOnly: true,
         togglePaletteMoreText: 'more',
         togglePaletteLessText: 'less',
         showPalette: true,
-        hideAfterPaletteSelect: true,
+        //hideAfterPaletteSelect: true,
         maxSelectionSize: 8,
         showSelectionPalette: true,
         palette: [
@@ -52,6 +53,7 @@ onload = function() {
         ],
         localStorageKey: "spectrum.homepage", // Any Spectrum with the same string will share selection, data stored locally in the browser
     });
+    $(colorpicker_special).on('change', function(e, color) { pu.update_customcolor(color ? color.toRgbString() : color); });
 
     boot();
 

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -348,10 +348,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'wall', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': ['msli_degital', 'ul_degital']
+        'exceptions': ['custom_color_lb', 'msli_degital', 'ul_degital']
     },
     'iso': {
         //modes

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -401,10 +401,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': ['msli_degital', 'ul_degital']
+        'exceptions': ['custom_color_lb', 'msli_degital', 'ul_degital']
     },
     'tetrakis_square': {
         //modes
@@ -454,10 +454,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': []
+        'exceptions': ['custom_color_lb']
     },
     'truncated_square': {
         //modes
@@ -507,10 +507,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': []
+        'exceptions': ['custom_color_lb']
     },
     'snub_square': {
         //modes
@@ -560,10 +560,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': []
+        'exceptions': ['custom_color_lb']
     },
     'cairo_pentagonal': {
         //modes
@@ -613,10 +613,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': []
+        'exceptions': ['custom_color_lb']
     },
     'rhombitrihexagonal': {
         //modes
@@ -666,10 +666,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': []
+        'exceptions': ['custom_color_lb']
     },
     'deltoidal_trihexagonal': {
         //modes
@@ -719,9 +719,9 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': []
+        'exceptions': ['custom_color_lb']
     },
 };

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -294,10 +294,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE','surface', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': ['msli_degital', 'ul_degital']
+        'exceptions': ['custom_color_lb', 'msli_degital', 'ul_degital']
     },
     'pyramid': {
         //modes

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -1,5 +1,25 @@
 /* Contains complete list of all the supported modes */
 const penpa_types = ['mode', 'sub', 'combisub', 'ms', 'ms1', 'ms3', 'ms4', 'st', 'symmode', 'combimode', 'customcolor'];
+const penpa_modes_map = {
+    'surface': 'surface',
+    'number': 'number',
+    'numberS': 'numberS',
+    'symbol': 'symbol',
+    'line': 'line',
+    'freeline': 'line',
+    'lineE': 'lineE',
+    'freelineE': 'lineE',
+    'deletelineE': 'lineE',
+    'wall': 'wall',
+    'cage': 'cage',
+    'thermo': 'special',
+    'nobulbthermo': 'special',
+    'arrows': 'special',
+    'direction': 'special',
+    'killercages': 'cage',
+    'squareframe': 'special',
+    'polygon': 'special',
+};
 const penpa_modes = {
     'square': {
         //modes
@@ -50,10 +70,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': ['custom_color_lb'],
+        'customcolor': ['line', 'lineE', 'wall', 'surface', 'cage', 'special', 'symbol'],
         'top_buttons': ['input_sudoku', 'rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': ['msli_degital',
+        'exceptions': ['custom_color_lb', 'msli_degital',
             'combili_shaka', 'combili_battleship', 'combili_arrowS',
             'ul_degital', 'ul_bars'
         ]
@@ -107,10 +127,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': ['custom_color_lb'],
+        'customcolor': ['line', 'lineE', 'wall', 'surface', 'cage', 'special', 'symbol'],
         'top_buttons': ['input_sudoku', 'rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': ['msli_degital',
+        'exceptions': ['custom_color_lb', 'msli_degital',
             'combili_shaka', 'combili_battleship', 'combili_arrowS',
             'ul_degital', 'ul_bars'
         ]
@@ -164,10 +184,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': ['custom_color_lb'],
+        'customcolor': ['line', 'lineE', 'wall', 'surface', 'cage', 'special', 'symbol'],
         'top_buttons': ['input_sudoku', 'rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': ['msli_degital',
+        'exceptions': ['custom_color_lb', 'msli_degital',
             'combili_shaka', 'combili_battleship', 'combili_arrowS',
             'ul_degital', 'ul_bars'
         ]
@@ -221,10 +241,10 @@ const penpa_modes = {
         ],
         'symmode': ['content'],
         'combimode': ['content'],
-        'customcolor': [],
+        'customcolor': ['line', 'lineE', 'wall', 'surface', 'cage', 'special', 'symbol'],
         'top_buttons': ['rotation'],
         // unique IDs that doesn't follow regular id naming
-        'exceptions': ['msli_degital', 'ul_degital']
+        'exceptions': ['custom_color_lb', 'msli_degital', 'ul_degital']
     },
     'tri': {
         //modes

--- a/docs/js/settings.js
+++ b/docs/js/settings.js
@@ -143,21 +143,6 @@ const UserSettings = {
     },
 
     _custom_colors_on: false,
-    _custom_color_supported_grids: {
-        square: 1,
-        sudoku: 1,
-        kakuro: 1,
-        hex: 1
-    },
-    _custom_color_supported_modes: {
-        line: 1,
-        lineE: 1,
-        wall: 1,
-        surface: 1,
-        cage: 1,
-        special: 1,
-        symbol: 1
-    },
     set custom_colors_on(newValue) {
         if (typeof newValue === 'string') {
             const valueInt = newValue ? parseInt(newValue, 10) : 1;
@@ -169,9 +154,7 @@ const UserSettings = {
         if (this._custom_colors_on) {
             // On
             let mode = pu.mode[pu.mode.qa].edit_mode;
-            if (this._custom_color_supported_grids[pu.gridtype] && this._custom_color_supported_modes[mode]) {
-                document.getElementById('style_special').style.display = 'inline';
-            }
+            pu.mode_set(mode);  // Update mode UI, including custom color selector
         } else {
             // Off
             document.getElementById('style_special').style.display = 'none';


### PR DESCRIPTION
This PR is mainly about UX improvements regarding custom color.

Functional changes
- Fixed surface painting with custom color. Now the color is correct.
- Fixed transparency color editing. Upgrade to tinycolor 1.5.2. Old version uses #argb and not the web standard #rgba.
- Fixed unavailable submode selection. To reproduce: E.g. Create new Hexagon grid, select mode 'Cage', start drawing cage lines.
- Move 'Sudoku' to 2nd position in drop down list, for easier access.
- The Symbol panel will now display symbols in the selected custom color.
- The selected custom color is now stored per mode, and will persist across sessions.
- Implement custom color for all board types:
    - Triangle
    - Pyramid
    - Cube
    - Kakuro
    - Truncated square
    - Snub square
    - Cairo pentagonal
    - Rhombitrihexagonal
    - Deltoidal trihexagonal

Technical changes:
- Move custom color configuration to penpa_modes (where is belongs IMHO).
- Move draw_surface to base class, because the implementation is identical for all board types.
- Refactor default custom color selection for all modes and sub modes into a separate customcolor.js file.
- Simplify custom color implementation to reduce code.
- Custom color info is now only added to the puzzle when it is not the default custom color, and will delete it otherwise. This will reduce the puzzle URL length.