### PR TITLE
Save puzzle progress on `visibilitychange` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * unreleased
 	* Arrow circle without arrow single cell added to arrowsums option
 	* moved gtag code back to html file as Adblock Ultimate was blocking Identity.js file for some users
+	* Make puzzle progress saving more robust, especially on mobile browsers.
 * 2023/09/24 ver 3.0.9
     * New options in Screenshot to include Author and Rules for png and jpeg. svg support not included.
     * Use new clipboard API when able. (Fixes Copy on iOS.)

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2065,10 +2065,9 @@ onload = function() {
 
     function save_progress() {
         // Save puzzle progress
-        let local_storage_setting = document.getElementById("clear_storage_opt").value;
         if (pu.url.length !== 0 &&
             pu.mmode === "solve" &&
-            local_storage_setting === "1" &&
+            UserSettings.local_storage === 1 &&
             !pu.replay) {
             // get md5 hash for unique id
             let hash = "penpa_" + md5(pu.url);

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2070,6 +2070,25 @@ onload = function() {
         }
     });
 
+    document.addEventListener("visibilitychange", function() {
+        if (document.visibilityState === "hidden") {
+            // Save puzzle progress
+            let local_storage_setting = document.getElementById("clear_storage_opt").value;
+            if (pu.url.length !== 0 &&
+                pu.mmode === "solve" &&
+                local_storage_setting === "1" &&
+                !pu.replay) {
+                // get md5 hash for unique id
+                let hash = "penpa_" + md5(pu.url);
+
+                // generate duplicate link
+                let rstr = pu.maketext_duplicate() + "&l=solvedup";
+
+                localStorage.setItem(hash, rstr);
+            }
+        }
+    });
+
     // Adding on change events for general settings
     // Theme Setting
     document.getElementById("theme_mode_opt").onchange = function() {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2054,6 +2054,16 @@ onload = function() {
             e.returnValue = '';
         }
 
+        save_progress();
+    });
+
+    document.addEventListener("visibilitychange", function() {
+        if (document.visibilityState === "hidden") {
+            save_progress();
+        }
+    });
+
+    function save_progress() {
         // Save puzzle progress
         let local_storage_setting = document.getElementById("clear_storage_opt").value;
         if (pu.url.length !== 0 &&
@@ -2068,26 +2078,7 @@ onload = function() {
 
             localStorage.setItem(hash, rstr);
         }
-    });
-
-    document.addEventListener("visibilitychange", function() {
-        if (document.visibilityState === "hidden") {
-            // Save puzzle progress
-            let local_storage_setting = document.getElementById("clear_storage_opt").value;
-            if (pu.url.length !== 0 &&
-                pu.mmode === "solve" &&
-                local_storage_setting === "1" &&
-                !pu.replay) {
-                // get md5 hash for unique id
-                let hash = "penpa_" + md5(pu.url);
-
-                // generate duplicate link
-                let rstr = pu.maketext_duplicate() + "&l=solvedup";
-
-                localStorage.setItem(hash, rstr);
-            }
-        }
-    });
+    }
 
     // Adding on change events for general settings
     // Theme Setting
@@ -2317,4 +2308,4 @@ function clear_storage_all() {
         html: '<h2 class="info">Local Storage is Cleared</h2>',
         icon: 'info'
     });
-}
+}

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2307,4 +2307,4 @@ function clear_storage_all() {
         html: '<h2 class="info">Local Storage is Cleared</h2>',
         icon: 'info'
     });
-}
+}


### PR DESCRIPTION
This adds an event listener for `visibilitychange`, and saves the current puzzle state when the document is hidden.

The `visibilitychange` event is more reliable than `beforeunload`, especially on mobile devices. For example, the [usage notes for `beforeunload` on MDN][1] list one common problematic situation:

> For example, the beforeunload event is not fired at all in the following scenario:
> 
> 1.  A mobile user visits your page.
> 2.  The user then switches to a different app.
> 3.  Later, the user closes the browser from the app manager.

In this case penpa+ currently lose the puzzle progress.

MDN recommends to use `visibilitychange` as a more reliable alternative instead.

This merge request adds progress saving on `visibilitychange` *in addition* to `beforeunload` to be on the save side. If everybody is using an up-to-date browser, `visibilitychange` should in theory cover all cases by itself.

 [1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes