### PR TITLE
Fix incorrectly URL encoded empty centerlist

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -2827,9 +2827,12 @@ class Puzzle {
     }
 
     __export_list_tab_shared() {
-        var list = [this.centerlist[0]];
-        for (var i = 1; i < this.centerlist.length; i++) {
-            list.push(this.centerlist[i] - this.centerlist[i - 1]);
+        var list = [];
+        if (this.centerlist.length > 0) {
+            list.push(this.centerlist[0]);
+            for (var i = 1; i < this.centerlist.length; i++) {
+                list.push(this.centerlist[i] - this.centerlist[i - 1]);
+            }
         }
         var text = JSON.stringify(list) + "\n";
 

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -2009,6 +2009,7 @@ function load(urlParam, type = 'url', origurl = null) {
         rtext[2] = rtext[2].split(pu.replace[i][1]).join(pu.replace[i][0]);
         rtext[3] = rtext[3].split(pu.replace[i][1]).join(pu.replace[i][0]);
         rtext[4] = rtext[4].split(pu.replace[i][1]).join(pu.replace[i][0]);
+        rtext[5] = rtext[5].split(pu.replace[i][1]).join(pu.replace[i][0]);
 
         // submode, style settings
         if (rtext[11]) {
@@ -2027,6 +2028,10 @@ function load(urlParam, type = 'url', origurl = null) {
         }
     }
     rtext[5] = JSON.parse(rtext[5]);
+    // workaround for incorrectly encoded empty centerlist
+    if (rtext[5][0] == null) {
+        rtext[5] = [];
+    }
     for (var i = 1; i < rtext[5].length; i++) {
         rtext[5][i] = (rtext[5][i - 1] + rtext[5][i]);
     }


### PR DESCRIPTION
When the user removes all boxes, the puzzle will be incorrectly encoded in the URL and results in a corrupted puzzle.

These are the encoding steps which result in incorrect URL:
pu.centerlist = [] -> [null] ->  "[null]" -> "[zO]"
Decoding:
"[zO]" -> Error: invalid JSON

This reveils two issues:
1. Empty centerlists are not encode correctly.
2. Encoding (replacing text with short strings) of puzzle data is done on all data, but the decoding is only done on selected parts.

Issue 2 is a fundamental flaw in the encoder/decoder which needs an overhaul to be robust and maintainable.