### PR TITLE
Penrose tiling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## History
+* unreleased
+	* Support for Penrose rhombus ("P3") tilings.
 * 2024/07/16 ver 3.1.4
 	* Code refactoring.
 	* Added non-alphanumeric genre tag to allow answer check on non-alphanumeric characters.

--- a/docs/index.html
+++ b/docs/index.html
@@ -818,6 +818,7 @@
                     <option value="cairo_pentagonal" id="nb_gridtype11_lb"> Cairo pentagonal </option>
                     <option value="rhombitrihexagonal" id="nb_gridtype12_lb"> Rhombitrihexagonal </option>
                     <option value="deltoidal_trihexagonal" id="nb_gridtype13_lb"> Deltoidal trihexagonal </option>
+                    <option value="penrose_P3" id="nb_gridtype14_p3"> Penrose P3 </option>
                 </select>
             </span><br>
             <h4><label class="label_nb" id="nb_size_lb">Size:</label></h4>

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -129,7 +129,8 @@ class Puzzle {
             'snub': 20,
             'cairo': 20,
             'rhombitrihex': 20,
-            'deltoidal': 20
+            'deltoidal': 20,
+            'penrose': 20
         }; // also defined in general.js
         this.replace = [
             ["\"qa\"", "z9"],
@@ -8720,7 +8721,8 @@ class Puzzle {
             if (this.selection.length === 1 && parseInt(this.selection[0] / (this.nx0 * this.ny0)) > 0 &&
                 this.gridtype !== "iso" && this.gridtype !== "tetrakis_square" && this.gridtype !== "truncated_square" &&
                 this.gridtype !== "snub_square" && this.gridtype !== "cairo_pentagonal" &&
-                this.gridtype !== "rhombitrihexagonal" && this.gridtype !== "deltoidal_trihexagonal") {
+                this.gridtype !== "rhombitrihexagonal" && this.gridtype !== "deltoidal_trihexagonal" &&
+                this.gridtype !== "penrose_P3") {
                 // do nothing
             } else if (!this.selection.includes(num) & this.drawing) {
                 this.selection.push(num);

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -7326,202 +7326,32 @@ class Puzzle_penrose_P3 extends Puzzle {
                 c = b[3];
                 break;
         }
-        var quotient = parseInt(this.cursol / 27);
+
         if (this.mode[this.mode.qa].edit_mode === "number" || this.mode[this.mode.qa].edit_mode === "symbol") {
-            if (this.cursol % 27 === 0) { // top side
-                switch (c) {
-                    case 0: //left
-                        // if cursor already on the left border
-                        if (quotient % this.nx0 === 0) {
-                            a = this.cursol + 1;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        } else {
-                            a = this.cursol - 27;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        }
-                        break;
-                    case 1: //up
-                        a = this.cursol + 27 * this.nx0;
-                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        break;
-                    case 2: //right
-                        a = this.cursol + 27;
-                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        break;
-                    case 3: //down
-                        // if cursor already on the bottom border
-                        if (quotient < this.nx0) {
-                            a = this.cursol * this.nx0 + 2;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        } else {
-                            a = this.cursol - 27 * this.nx0;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        }
-                        break;
-                }
-            } else if (this.cursol % 27 === 1) { // left side
-                switch (c) {
-                    case 0: //left
-                        a = this.cursol + 27 * this.nx0;
-                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        break;
-                    case 1: //up
-                        // if cursor already on the up border
-                        if (quotient % this.nx0 === 0) {
-                            a = this.cursol - 1;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        } else {
-                            a = this.cursol - 27;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        }
-                        break;
-                    case 2: //right
-                        // if cursor already on the right border
-                        if (quotient < this.nx0) {
-                            a = this.cursol + 1;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        } else {
-                            a = this.cursol - 27 * this.nx0;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        }
-                        break;
-                    case 3: //down
-                        a = this.cursol + 27;
-                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        break;
-                }
-            } else if (this.cursol % 27 === 2) { // right side
-                switch (c) {
-                    case 0: //left
-                        // if cursor already on the left border
-                        if (quotient < this.nx0) {
-                            a = this.cursol - 1;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        } else {
-                            a = this.cursol - 27 * this.nx0;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        }
-                        break;
-                    case 1: //up
-                        // if cursor already on the up border
-                        if (quotient % this.nx0 === 0) {
-                            a = parseInt((this.cursol - 2) / this.nx0);
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        } else {
-                            a = this.cursol - 27;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        }
-                        break;
-                    case 2: //right
-                        a = this.cursol + 27 * this.nx0;
-                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        break;
-                    case 3: //down
-                        a = this.cursol + 27;
-                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                        break;
-                }
-            }
+            let q = this.point[this.cursol].surround;
+	    let q0 = this.point[q[0]], q1 = this.point[q[1]], q2 = this.point[q[2]];
+	    // sin(A+B) ≥ 0 iff (A+B)/2 is in first or third quadrant.
+	    // Applying this to lattice generators tells us which should
+	    // be assigned as horizontal and which as vertical.
+	    let sin_iplusj = (q1.x-q0.x)*(q1.y-q2.y) + (q0.y-q1.y)*(q2.x-q1.x);
+	    let cc = (c + ((sin_iplusj < 0)?1:0) + ((q0.y<q2.y)?2:0)) % 4;
+	    a = this.point[this.cursol].adjacent[cc]
+            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
             this.selection = [];
             if (!this.selection.includes(this.cursol)) {
                 this.selection.push(this.cursol);
             }
         } else if (this.mode[this.mode.qa].edit_mode === "sudoku") {
             if (this.selection.length >= 1) {
-                if (this.cursol % 27 === 0) { // top side
-                    switch (c) {
-                        case 0: //left
-                            // if cursor already on the left border
-                            if (quotient % this.nx0 === 0) {
-                                a = this.cursol + 1;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            } else {
-                                a = this.cursol - 27;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            }
-                            break;
-                        case 1: //up
-                            a = this.cursol + 27 * this.nx0;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            break;
-                        case 2: //right
-                            a = this.cursol + 27;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            break;
-                        case 3: //down
-                            // if cursor already on the bottom border
-                            if (quotient < this.nx0) {
-                                a = this.cursol * this.nx0 + 2;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            } else {
-                                a = this.cursol - 27 * this.nx0;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            }
-                            break;
-                    }
-                } else if (this.cursol % 27 === 1) { // left side
-                    switch (c) {
-                        case 0: //left
-                            a = this.cursol + 27 * this.nx0;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            break;
-                        case 1: //up
-                            // if cursor already on the up border
-                            if (quotient % this.nx0 === 0) {
-                                a = this.cursol - 1;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            } else {
-                                a = this.cursol - 27;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            }
-                            break;
-                        case 2: //right
-                            // if cursor already on the right border
-                            if (quotient < this.nx0) {
-                                a = this.cursol + 1;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            } else {
-                                a = this.cursol - 27 * this.nx0;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            }
-                            break;
-                        case 3: //down
-                            a = this.cursol + 27;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            break;
-                    }
-                } else if (this.cursol % 27 === 2) { // right side
-                    switch (c) {
-                        case 0: //left
-                            // if cursor already on the left border
-                            if (quotient < this.nx0) {
-                                a = this.cursol - 1;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            } else {
-                                a = this.cursol - 27 * this.nx0;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            }
-                            break;
-                        case 1: //up
-                            // if cursor already on the up border
-                            if (quotient % this.nx0 === 0) {
-                                a = parseInt((this.cursol - 2) / this.nx0);
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            } else {
-                                a = this.cursol - 27;
-                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            }
-                            break;
-                        case 2: //right
-                            a = this.cursol + 27 * this.nx0;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            break;
-                        case 3: //down
-                            a = this.cursol + 27;
-                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
-                            break;
-                    }
-                }
+		let q = this.point[this.cursol].surround;
+		let q0 = this.point[q[0]], q1 = this.point[q[1]], q2 = this.point[q[2]];
+		// sin(A+B) ≥ 0 iff (A+B)/2 is in first or third quadrant.
+		// Applying this to lattice generators tells us which should
+		// be assigned as horizontal and which as vertical.
+		let sin_iplusj = (q1.x-q0.x)*(q1.y-q2.y) + (q0.y-q1.y)*(q2.x-q1.x);
+		let cc = (c + ((sin_iplusj < 0)?1:0) + ((q0.y<q2.y)?2:0)) % 4;
+		a = this.point[this.cursol].adjacent[cc]
+                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
                 if (this.point[a] && this.point[a].use === 1) {
                     if (!ctrl_key) {
                         this.selection = [];

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -6778,3 +6778,2715 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
         }
     }
 }
+
+class Puzzle_penrose_P3 extends Puzzle {
+    constructor(side, order, size) {
+        //盤面情報
+        super('penrose_P3');
+        this.nx = side;
+        this.ny = side;
+        this.nx0 = this.nx + 2;
+        this.ny0 = this.ny + 2;
+        this.margin = -1; //for arrow of number pointing outside of the grid
+        this.sudoku = [0, 0, 0, 0]; // This is for sudoku settings
+        this.ngrids = order;
+        // The grid_offset coefficients determine which part of the infinite
+        // Penrose tiling you get. Ideally we would make them configurable,
+        // but it's a bit fiddly. They must not be integer. To ensure a valid
+        // aperiodic tiling, the sum of all values should be an integer.
+        this.grid_offset = Array(this.ngrids).fill(1/this.ngrids);
+        this.width0 = this.nx;
+        this.height0 = this.ny;
+        this.width_c = this.width0;
+        this.height_c = this.height0;
+        this.width = this.width_c;
+        this.height = this.height_c;
+        this.canvasx = this.width_c * this.size;
+        this.canvasy = this.height_c * this.size;
+        this.space = [];
+        this.size = size;
+        this.onoff_symbolmode_list = {
+            "cross": 4,
+            "arrow_cross": 4,
+            "arrow_fourtip": 4,
+            "degital": 7,
+            "degital_f": 7,
+            "arrow_eight": 8,
+            "arrow_fouredge_B": 8,
+            "arrow_fouredge_G": 8,
+            "arrow_fouredge_E": 8,
+            "dice": 9,
+            "polyomino": 9
+        };
+        this.reset();
+        PenpaUI.set_visible_modes_by_gridtype(this.gridtype);
+    }
+
+    create_point() {
+	const PI = Math.PI;
+	const pixel_sqradius = (this.nx*this.ny*this.size*this.size)
+	const pixel_sqradius0 = (this.nx0*this.ny0*this.size*this.size)
+
+	// Compute the identity of the next tile in the tiling,
+	// using a de Bruijn grid.
+	// Ref.: https://www.mathpages.com/home/kmath621/kmath621.htm
+	var next_gridpoint = (x, y, i, j, dir) => {
+	    const rel = (this.ngrids + j - i) % this.ngrids;
+	    const costh = Math.cos(rel * 2 * PI / this.ngrids);
+	    const sinth = Math.sin(rel * 2 * PI / this.ngrids);
+	    let yco = -(x+this.grid_offset[i]) * (costh / sinth) + (y+this.grid_offset[j]) / sinth;
+	    let nextyco = yco + dir*1000;
+	    let bestp = null;
+	    let besty = null;
+	    for (let p = 1; p < this.ngrids; p++) {
+                if (p == rel) { continue; }
+	        const costh = Math.cos(p * 2 * PI / this.ngrids);
+	        const sinth = Math.sin(p * 2 * PI / this.ngrids);
+	        const base = -(x+this.grid_offset[i]) * (costh / sinth);
+	        const off = Math.abs(1 / sinth);
+	        const go = this.grid_offset[(i+p)%this.ngrids];
+		if (dir > 0) {
+	            const thisy = Math.ceil(((yco - base) / off) - go*Math.sign(sinth));
+	            const higher = base + off * (thisy + go*Math.sign(sinth));
+
+	            if (higher < nextyco) {
+	                nextyco = higher;
+	                bestp = p;
+	                besty = 0+thisy * Math.sign(sinth);
+	            }
+	        } else {
+	            const thisy = Math.floor(((yco - base) / off) - go*Math.sign(sinth));
+	            const lower = base + off * (thisy + go*Math.sign(sinth));
+	            if (lower > nextyco) {
+	                nextyco = lower;
+	                bestp = p;
+	                besty = 0+thisy * Math.sign(sinth);
+	            }
+	        }
+	    }
+	    const bestj = (this.ngrids + i + bestp) % this.ngrids;
+	    return { xnum: x, ynum: besty, i: i, j: bestj }
+	}
+
+        var k = 0;
+        var point = [];
+	// List of tile-specs to add in next phase
+	var queue = [], oldqueue;
+        // Map of tile-specs to their index in point[]
+	var existing_tiles = new Map();
+
+	var get_tile_name = (spec) => {
+	    var rel = (this.ngrids+spec.j-spec.i)%this.ngrids;
+	    if (rel>this.ngrids/2) {  // swap i,j
+	       return "<" + spec.j + "|" + spec.i + ">(" + spec.ynum + "," + spec.xnum + ")";
+	    } else {
+	       return "<" + spec.i + "|" + spec.j + ">(" + spec.xnum + "," + spec.ynum + ")";
+	    }
+	}
+	// closure modifies 'queue' and 'existing_tiles'
+	var add_tile = (tile_spec, loc_spec) => {
+	    var name = get_tile_name(tile_spec);
+	    if (existing_tiles.has(name)) {
+	      return;
+	    }
+            console.log("Adding new tile", name)
+	    var rel = (this.ngrids+tile_spec.j-tile_spec.i)%this.ngrids;
+	    var i,j,xnum,ynum;
+	    if (rel>this.ngrids/2) {  // swap i,j
+              i = tile_spec.j; j = tile_spec.i;
+	      xnum = tile_spec.ynum; ynum = tile_spec.xnum;
+	    } else {
+              i = tile_spec.i; j = tile_spec.j;
+	      xnum = tile_spec.xnum; ynum = tile_spec.ynum;
+	    }
+	    var xoffi = Math.sin(2*i*PI/this.ngrids)*this.size, yoffi = -Math.cos(2*i*PI/this.ngrids)*this.size;
+	    var xoffj = Math.sin(2*j*PI/this.ngrids)*this.size, yoffj = -Math.cos(2*j*PI/this.ngrids)*this.size;
+	    var xco = loc_spec.xco, yco = loc_spec.yco;
+	    if (rel>this.ngrids/2) {
+	        if (loc_spec.dir>0) {
+		    xco = xco - xoffi;
+		    yco = yco - yoffi;
+		} else {
+		    xco = xco - xoffj;
+		    yco = yco - yoffj;
+		}
+            } else if (loc_spec.dir<0) {
+	        xco = xco - xoffi - xoffj;
+		yco = yco - yoffi - yoffj;
+	    }
+	    var xcen = xco + 0.5*xoffi + 0.5*xoffj, ycen = yco + 0.5*yoffi + 0.5*yoffj;
+	    var sqdist = xcen*xcen + ycen*ycen;
+            if (sqdist > pixel_sqradius0) {
+		// far from origin: abort
+		return
+	    }
+	    var use = (sqdist <= pixel_sqradius) ? 1 : 0;
+
+
+	    var xco = [xco, xco + xoffi, xco + xoffi + xoffj, xco + xoffj];
+	    var yco = [yco, yco + yoffi, yco + yoffi + yoffj, yco + yoffj];
+
+            var loc_spec, nbr_spec, s, nbr;
+	    var surround = [null, null, null, null];
+	    var edge = [null, null, null, null];
+	    var adja = [null, null, null, null];
+
+            // For each of the four directions, compute the name of
+            // the tile that should be adjacent, and look up whether
+            // it already exists. If it does, update the adjacency
+            // information from it. If it does not, add it to the
+            // queue to be created in the next pass.
+
+            nbr_spec = next_gridpoint(xnum, ynum, i, j, 1) // next along xline
+	    nbr = existing_tiles.get(get_tile_name(nbr_spec))
+	    if (nbr) {
+	       adja[2] = nbr
+	       nbr = point[nbr]
+	       s = ((this.ngrids+nbr_spec.j-nbr_spec.i)%this.ngrids)>this.ngrids/2
+	       surround[3] = s ? nbr.surround[1] : nbr.surround[0]
+	       surround[2] = s ? nbr.surround[2] : nbr.surround[1]
+	       edge[2] = s ? nbr.neighbor[1] : nbr.neighbor[0]
+	    } else {
+	       loc_spec = { xco: xco[3], yco: yco[3], dir: 1 }
+	       queue.push({tile_spec: nbr_spec, loc_spec: loc_spec})
+	    }
+            nbr_spec = next_gridpoint(xnum, ynum, i, j, -1) // prev along xline
+	    nbr = existing_tiles.get(get_tile_name(nbr_spec))
+	    if (nbr) {
+	       adja[0] = nbr
+	       nbr = point[nbr]
+	       s = ((this.ngrids+nbr_spec.j-nbr_spec.i)%this.ngrids)>this.ngrids/2
+	       surround[1] = s ? nbr.surround[3] : nbr.surround[2]
+	       surround[0] = s ? nbr.surround[0] : nbr.surround[3]
+	       edge[0] = s ? nbr.neighbor[3] : nbr.neighbor[2]
+	    } else {
+	       loc_spec = { xco: xco[1], yco: yco[1], dir: -1 }
+	       queue.push({tile_spec: nbr_spec, loc_spec: loc_spec})
+	    }
+            nbr_spec = next_gridpoint(ynum, xnum, j, i, 1) // next along yline
+	    nbr = existing_tiles.get(get_tile_name(nbr_spec))
+	    if (nbr) {
+	       adja[3] = nbr
+	       nbr = point[nbr]
+	       s = ((this.ngrids+nbr_spec.j-nbr_spec.i)%this.ngrids)>this.ngrids/2
+	       surround[0] = s ? nbr.surround[1] : nbr.surround[0]
+	       surround[3] = s ? nbr.surround[2] : nbr.surround[1]
+	       edge[3] = s ? nbr.neighbor[1] : nbr.neighbor[0]
+	    } else {
+	       loc_spec = { xco: xco[0], yco: yco[0], dir: 1 }
+	       queue.push({tile_spec: nbr_spec, loc_spec: loc_spec})
+	    }
+            nbr_spec = next_gridpoint(ynum, xnum, j, i, -1) // prev along yline
+	    nbr = existing_tiles.get(get_tile_name(nbr_spec))
+	    if (nbr) {
+	       adja[1] = nbr
+	       nbr = point[nbr]
+	       s = ((this.ngrids+nbr_spec.j-nbr_spec.i)%this.ngrids)>this.ngrids/2
+	       surround[2] = s ? nbr.surround[3] : nbr.surround[2]
+	       surround[1] = s ? nbr.surround[0] : nbr.surround[3]
+	       edge[1] = s ? nbr.neighbor[3] : nbr.neighbor[2]
+	    } else {
+	       loc_spec = { xco: xco[2], yco: yco[2], dir: -1 }
+	       queue.push({tile_spec: nbr_spec, loc_spec: loc_spec})
+	    }
+
+            // Create vertices if they don't already exist
+            var type = 1;
+	    for (let e = 0; e < 4; e++) {
+	      if (surround[e] == null) {
+	        point[k] = new Point(xco[e], yco[e], type, [], [], use, []);
+		surround[e] = k;
+	        k++;
+	      } else if (use == 1) {
+		point[surround[e]].use = 1;
+	      }
+	    }
+	    for (let e = 0; e < 4; e++) {
+	      // Update mapping vertex -> adjacent vertex
+	      let se = surround[e], sf = surround[(e+1)%4];
+	      if (point[se].adjacent.indexOf(sf) == -1) {
+	        point[se].adjacent = point[se].adjacent.concat([sf])
+	      }
+	      if (point[sf].adjacent.indexOf(se) == -1) {
+	        point[sf].adjacent = point[sf].adjacent.concat([se])
+	      }
+	    }
+            // Create edges if they don't already exist
+            type = 2;
+	    for (let e = 0; e < 4; e++) {
+	      if (edge[e] == null) {
+	        point[k] = new Point((point[surround[e]].x + point[surround[(e+1)%4]].x)/2,
+		                     (point[surround[e]].y + point[surround[(e+1)%4]].y)/2, 
+		                     type, [], [], use, []);
+		edge[e] = k;
+	        k++;
+	      } else if (use == 1) {
+		point[edge[e]].use = 1;
+	      }
+	    }
+
+	    // Create face
+	    type = 0;
+	    point[k] = new Point(xcen, ycen, type, adja, surround, use, edge);
+	    for (let e = 0; e < 4; e++) {
+	      // Update mapping edge -> face
+	      point[edge[e]].neighbor = point[edge[e]].neighbor.concat([k])
+	      if (adja[e] != null) {
+	        // Update mapping face -> adjacent face
+	        point[adja[e]].adjacent[ point[adja[e]].neighbor.indexOf(edge[e]) ] = k
+	      }
+	    }
+	    existing_tiles.set(name, k);
+	    k++;
+	}
+
+	// Initial tile
+	add_tile({ xnum: 0, ynum: 0, i: 0, j: 1 }, {xco: 0.0, yco: 0.0, dir: 1 })
+	for (var iter = 0; (queue.length > 0) && (iter < 100); iter++) {
+	    oldqueue = queue;
+	    queue = [];
+	    for (var n = 0; n < oldqueue.length; n++) {
+	        add_tile(oldqueue[n].tile_spec, oldqueue[n].loc_spec);
+	    }
+	    if (queue.length == 0) { break; }
+	}
+
+        this.point = point;
+    }
+
+    reset_frame() {
+        this.create_point();
+        this.space = [];
+
+        this.centerlist = [];
+        for (var i = 0; i < this.point.length; i++) {
+            if (this.point[i] && this.point[i].use === 1 && this.point[i].type === 0) {
+                this.centerlist.push(i);
+            }
+        }
+        this.search_center();
+        this.width_c = this.width;
+        this.height_c = this.height;
+        this.center_n0 = this.center_n;
+        this.canvasxy_update();
+        this.canvas_size_setting();
+        this.point_move((this.canvasx * 0.5 - this.point[this.center_n].x + 0.5), (this.canvasy * 0.5 - this.point[this.center_n].y + 0.5), this.theta);
+
+        this.make_frameline();
+        this.cursol = this.centerlist[0];
+        this.cursolS = 4 * (this.nx0) * (this.ny0) + 4 + 4 * (this.nx0);
+    }
+
+    search_center() {
+        var xmax = 0,
+            xmin = 1e5;
+        var ymax = 0,
+            ymin = 1e5;
+        for (var i of this.centerlist) {
+            if (this.point[i].x > xmax) { xmax = this.point[i].x; }
+            if (this.point[i].x < xmin) { xmin = this.point[i].x; }
+            if (this.point[i].y > ymax) { ymax = this.point[i].y; }
+            if (this.point[i].y < ymin) { ymin = this.point[i].y; }
+        }
+        var x = (xmax + xmin) / 2;
+        var y = (ymax + ymin) / 2;
+        this.width = (xmax - xmin) / this.size + 2.5;
+        this.height = (ymax - ymin) / this.size + 2.5;
+
+        var min0, min = 10e6;
+        var num = 0;
+        for (var i in this.point) {
+            min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
+            if (min0 < min) {
+                min = min0;
+                num = i;
+            }
+        }
+        this.center_n = parseInt(num);
+    }
+
+    type_set() {
+        var type
+        switch (this.mode[this.mode.qa].edit_mode) {
+            case "surface":
+            case "board":
+                type = [0];
+                break;
+            case "symbol":
+            case "move":
+                if (!UserSettings.draw_edges) {
+                    type = [0];
+                } else {
+                    type = [0, 1, 2];
+                }
+                break;
+            case "number":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                    type = [4];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                    type = [5];
+                } else {
+                    if (!UserSettings.draw_edges) {
+                        type = [0];
+                    } else {
+                        type = [0, 1, 2];
+                    }
+                }
+                break;
+            case "line":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                    type = [2];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [0, 1];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                    type = [0, 2];
+                } else {
+                    type = [0];
+                }
+                break;
+            case "lineE":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                    type = [2];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [0, 1];
+                } else {
+                    type = [1];
+                }
+                break;
+            case "wall":
+                if (this.drawing) {
+                    type = [this.point[this.last].type];
+                } else {
+                    type = [2];
+                }
+                break;
+            case "cage":
+                type = [4];
+                break;
+            case "special":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                    type = [1];
+                } else {
+                    type = [0, 1];
+                }
+                break;
+            case "combi":
+                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                    case "tents":
+                    case "linex":
+                    case "yajilin":
+                        type = [0, 2];
+                        break;
+                    case "edgex":
+                    case "edgexoi":
+                    case "star":
+                        type = [0, 1, 2];
+                        break;
+                    case "blpo":
+                    case "blwh":
+                    case "battleship":
+                    case "magnets":
+                    case "lineox":
+                    case "hashi":
+                    case "arrowS":
+                    case "shaka":
+                    case "numfl":
+                    case "alfl":
+                        type = [0];
+                        break;
+                    case "edgesub":
+                        type = [0, 1];
+                        break;
+                    case "akari":
+                        type = [0, 2];
+                        break;
+                    case "mines":
+                        type = [0, 1, 2];
+                        break;
+                }
+                break;
+            case "sudoku":
+                type = [0];
+                break;
+        }
+        return type;
+    }
+
+    recalculate_num(x, y, num) {
+        var min0, min = 10e6;
+        var num0 = 0;
+        var r0 = 0.5 * Math.sqrt(2) / Math.cos(2 * Math.PI / 360 * 22.5);
+        var r1 = Math.sqrt(2) - 1;
+        if (this.point[num].type != 0) { return num; }
+
+        for (var i = 0; i < this.point.length; i++) {
+            if (this.point[i] && this.point[i].type === 0 && this.point[i].use === 1) {
+                min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
+                if (min0 < min) {
+                    if (this.point[i].type2 === 0 && min0 > (r0 * this.size) ** 2) { continue; } //円形の内側に入っていなければ更新しない
+                    if (this.point[i].type2 === 1 && min0 > (r1 * this.size) ** 2) { continue; }
+                    min = min0;
+                    num = i;
+                }
+            }
+        }
+        return parseInt(num);
+    }
+
+    coord_p_edgex(x, y) {
+        var min0, min = 10e6;
+        var num = 0;
+        for (var i = 0; i < this.point.length; i++) {
+            if (this.point[i] && this.type.indexOf(this.point[i].type) != -1) {
+                min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
+                if (min0 < min) {
+                    if (this.point[i].type === 2 || this.point[i].type === 3) {
+                        if (min0 > (0.3 * this.size) ** 2) {
+                            continue;
+                        }
+                    }
+                    min = min0;
+                    num = i;
+                }
+            }
+        }
+        return parseInt(num);
+    }
+
+    coord_p_edgex_star(x, y, hitboxfactor) {
+        var min0, min = 10e6;
+        var num = 0;
+        for (var i = 0; i < this.point.length; i++) {
+            if (this.type.indexOf(this.point[i].type) != -1) {
+                min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
+                if (min0 < min) {
+                    if (this.point[i].type === 1 || this.point[i].type === 2 || this.point[i].type === 3) {
+                        if (min0 > (hitboxfactor * this.size) ** 2) {
+                            break;
+                        }
+                    }
+                    min = min0;
+                    num = i;
+                }
+            }
+        }
+        return parseInt(num);
+    }
+
+    rotate_left() {
+        this.theta = (this.theta - 45 * this.reflect[0] * this.reflect[1] + 360) % 360;
+        this.point_move(0, 0, -45);
+        this.redraw();
+    }
+
+    rotate_right() {
+        this.theta = (this.theta + 45 * this.reflect[0] * this.reflect[1] + 360) % 360;
+        this.point_move(0, 0, +45);
+        this.redraw();
+    }
+
+    cursolcheck() {
+        if (this.mode[this.mode.qa].edit_mode === "number" && this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+            if (this.cursolS > 8 * (this.nx0) * (this.ny0)) {
+                this.cursolS -= 4 * (this.nx0) * (this.ny0);
+            }
+        } else if (this.mode[this.mode.qa].edit_mode === "number" && this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+            if (this.cursolS < 8 * (this.nx0) * (this.ny0)) {
+                this.cursolS += 4 * (this.nx0) * (this.ny0);
+            }
+        }
+    }
+
+    key_arrow(key_code, ctrl_key = false) {
+        var a, b, c;
+        b = [0, 1, 2, 3];
+        if (this.reflect[0] === -1) {
+            c = b[0];
+            b[0] = b[2];
+            b[2] = c;
+        }
+        if (this.reflect[1] === -1) {
+            c = b[1];
+            b[1] = b[3];
+            b[3] = c;
+        }
+        switch (key_code) {
+            case "ArrowLeft":
+                c = b[0];
+                break;
+            case "ArrowUp":
+                c = b[1];
+                break;
+            case "ArrowRight":
+                c = b[2];
+                break;
+            case "ArrowDown":
+                c = b[3];
+                break;
+        }
+        var quotient = parseInt(this.cursol / 27);
+        if (this.mode[this.mode.qa].edit_mode === "number" || this.mode[this.mode.qa].edit_mode === "symbol") {
+            if (this.cursol % 27 === 0) { // top side
+                switch (c) {
+                    case 0: //left
+                        // if cursor already on the left border
+                        if (quotient % this.nx0 === 0) {
+                            a = this.cursol + 1;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        } else {
+                            a = this.cursol - 27;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        }
+                        break;
+                    case 1: //up
+                        a = this.cursol + 27 * this.nx0;
+                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        break;
+                    case 2: //right
+                        a = this.cursol + 27;
+                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        break;
+                    case 3: //down
+                        // if cursor already on the bottom border
+                        if (quotient < this.nx0) {
+                            a = this.cursol * this.nx0 + 2;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        } else {
+                            a = this.cursol - 27 * this.nx0;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        }
+                        break;
+                }
+            } else if (this.cursol % 27 === 1) { // left side
+                switch (c) {
+                    case 0: //left
+                        a = this.cursol + 27 * this.nx0;
+                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        break;
+                    case 1: //up
+                        // if cursor already on the up border
+                        if (quotient % this.nx0 === 0) {
+                            a = this.cursol - 1;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        } else {
+                            a = this.cursol - 27;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        }
+                        break;
+                    case 2: //right
+                        // if cursor already on the right border
+                        if (quotient < this.nx0) {
+                            a = this.cursol + 1;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        } else {
+                            a = this.cursol - 27 * this.nx0;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        }
+                        break;
+                    case 3: //down
+                        a = this.cursol + 27;
+                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        break;
+                }
+            } else if (this.cursol % 27 === 2) { // right side
+                switch (c) {
+                    case 0: //left
+                        // if cursor already on the left border
+                        if (quotient < this.nx0) {
+                            a = this.cursol - 1;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        } else {
+                            a = this.cursol - 27 * this.nx0;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        }
+                        break;
+                    case 1: //up
+                        // if cursor already on the up border
+                        if (quotient % this.nx0 === 0) {
+                            a = parseInt((this.cursol - 2) / this.nx0);
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        } else {
+                            a = this.cursol - 27;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        }
+                        break;
+                    case 2: //right
+                        a = this.cursol + 27 * this.nx0;
+                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        break;
+                    case 3: //down
+                        a = this.cursol + 27;
+                        if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                        break;
+                }
+            }
+            this.selection = [];
+            if (!this.selection.includes(this.cursol)) {
+                this.selection.push(this.cursol);
+            }
+        } else if (this.mode[this.mode.qa].edit_mode === "sudoku") {
+            if (this.selection.length >= 1) {
+                if (this.cursol % 27 === 0) { // top side
+                    switch (c) {
+                        case 0: //left
+                            // if cursor already on the left border
+                            if (quotient % this.nx0 === 0) {
+                                a = this.cursol + 1;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            } else {
+                                a = this.cursol - 27;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            }
+                            break;
+                        case 1: //up
+                            a = this.cursol + 27 * this.nx0;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            break;
+                        case 2: //right
+                            a = this.cursol + 27;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            break;
+                        case 3: //down
+                            // if cursor already on the bottom border
+                            if (quotient < this.nx0) {
+                                a = this.cursol * this.nx0 + 2;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            } else {
+                                a = this.cursol - 27 * this.nx0;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            }
+                            break;
+                    }
+                } else if (this.cursol % 27 === 1) { // left side
+                    switch (c) {
+                        case 0: //left
+                            a = this.cursol + 27 * this.nx0;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            break;
+                        case 1: //up
+                            // if cursor already on the up border
+                            if (quotient % this.nx0 === 0) {
+                                a = this.cursol - 1;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            } else {
+                                a = this.cursol - 27;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            }
+                            break;
+                        case 2: //right
+                            // if cursor already on the right border
+                            if (quotient < this.nx0) {
+                                a = this.cursol + 1;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            } else {
+                                a = this.cursol - 27 * this.nx0;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            }
+                            break;
+                        case 3: //down
+                            a = this.cursol + 27;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            break;
+                    }
+                } else if (this.cursol % 27 === 2) { // right side
+                    switch (c) {
+                        case 0: //left
+                            // if cursor already on the left border
+                            if (quotient < this.nx0) {
+                                a = this.cursol - 1;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            } else {
+                                a = this.cursol - 27 * this.nx0;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            }
+                            break;
+                        case 1: //up
+                            // if cursor already on the up border
+                            if (quotient % this.nx0 === 0) {
+                                a = parseInt((this.cursol - 2) / this.nx0);
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            } else {
+                                a = this.cursol - 27;
+                                if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            }
+                            break;
+                        case 2: //right
+                            a = this.cursol + 27 * this.nx0;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            break;
+                        case 3: //down
+                            a = this.cursol + 27;
+                            if (this.point[a] && this.point[a].use === 1) { this.cursol = a; }
+                            break;
+                    }
+                }
+                if (this.point[a] && this.point[a].use === 1) {
+                    if (!ctrl_key) {
+                        this.selection = [];
+                    }
+                    if (!this.selection.includes(a)) {
+                        this.selection.push(a);
+                    }
+                }
+            }
+        }
+        this.redraw();
+    }
+
+    direction_arrow8(x, y, x0, y0) {
+        var angle = Math.atan2(y - y0, x - x0) * 360 / 2 / Math.PI + 180;
+        if (this.reflect[0] === -1) { angle = (180 - angle + 360) % 360; }
+        if (this.reflect[1] === -1) { angle = (360 - angle + 360) % 360; }
+        angle = (angle - this.theta + 360) % 360;
+        angle -= 180;
+        var a;
+        if (angle < -157.5 || angle > 157.5) {
+            a = 1;
+        } else if (angle > -157.5 && angle < -112.5) {
+            a = 4;
+        } else if (angle > -112.5 && angle < -67.5) {
+            a = 0;
+        } else if (angle > -67.5 && angle < -22.5) {
+            a = 5;
+        } else if (angle > -22.5 && angle < 22.5) {
+            a = 2;
+        } else if (angle > 22.5 && angle < 67.5) {
+            a = 7;
+        } else if (angle > 67.5 && angle < 112.5) {
+            a = 3;
+        } else if (angle > 112.5 && angle < 157.5) {
+            a = 6;
+        }
+        return a;
+    }
+
+    ////////////////draw/////////////////////
+
+    draw() {
+        var present_mode = this.mode.qa;
+        if (present_mode !== "pu_q" || UserSettings.show_solution) {
+            this.draw_surface("pu_q");
+            this.draw_surface("pu_a");
+            this.draw_symbol("pu_q", 1);
+            this.draw_symbol("pu_a", 1);
+            this.draw_frame();
+            this.draw_polygonsp("pu_q");
+            this.draw_polygonsp("pu_a");
+            this.draw_freeline("pu_q");
+            this.draw_freeline("pu_a");
+            this.draw_line("pu_q");
+            this.draw_line("pu_a");
+            this.draw_lattice();
+            this.draw_selection();
+            this.draw_frameBold();
+            this.draw_symbol("pu_q", 2);
+            this.draw_symbol("pu_a", 2);
+            this.draw_number("pu_q");
+            this.draw_number("pu_a");
+            this.draw_cursol();
+            this.draw_freecircle();
+        } else {
+            this.draw_surface("pu_q");
+            this.draw_symbol("pu_q", 1);
+            this.draw_frame();
+            this.draw_polygonsp("pu_q");
+            this.draw_freeline("pu_q");
+            this.draw_line("pu_q");
+            this.draw_lattice();
+            this.draw_selection();
+            this.draw_frameBold();
+            this.draw_symbol("pu_q", 2);
+            this.draw_number("pu_q");
+            this.draw_cursol();
+            this.draw_freecircle();
+        }
+    }
+
+    draw_lattice() {
+        if (this.mode.grid[1] === "1") {
+            this.ctx.fillStyle = Color.BLACK;
+            var verticelist = [];
+            for (var i = 0; i < this.centerlist.length; i++) {
+                for (var j = 0; j < this.point[this.centerlist[i]].surround.length; j++) {
+                    verticelist.push(this.point[this.centerlist[i]].surround[j]);
+                }
+            }
+            verticelist = Array.from(new Set(verticelist));
+            for (var i = 0; i < verticelist.length; i++) {
+                this.ctx.beginPath();
+                this.ctx.arc(this.point[verticelist[i]].x, this.point[verticelist[i]].y, 2.1, 0, 2 * Math.PI, true);
+                this.ctx.fill();
+            }
+        }
+    }
+
+    draw_polygon(ctx, x, y, r, n, th) {
+        ctx.LineCap = "round";
+        ctx.beginPath();
+        ctx.moveTo(x - r * Math.cos(th * (Math.PI / 180)) * this.size, y - r * Math.sin(th * (Math.PI / 180)) * this.size);
+        for (var i = 0; i < n - 1; i++) {
+            th += 360 / n;
+            ctx.lineTo(x - r * Math.cos(th * (Math.PI / 180)) * this.size, y - r * Math.sin(th * (Math.PI / 180)) * this.size);
+        }
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+    }
+
+    draw_direction(pu) {
+        for (var i = 0; i < this[pu].direction.length; i++) {
+            if (this[pu].direction[i][0]) {
+                this.ctx.setLineDash([]);
+                this.ctx.lineCap = "square";
+                if (UserSettings.custom_colors_on && this[pu + "_col"].direction[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].direction[i];
+                } else {
+                    this.ctx.strokeStyle = Color.GREY_DARK_LIGHT;
+                }
+                this.ctx.lineWidth = 3;
+                this.ctx.beginPath();
+                this.ctx.moveTo(this.point[this[pu].direction[i][0]].x, this.point[this[pu].direction[i][0]].y);
+                for (var j = 1; j < this[pu].direction[i].length - 1; j++) {
+                    this.ctx.lineTo(this.point[this[pu].direction[i][j]].x, this.point[this[pu].direction[i][j]].y);
+                }
+                this.ctx.stroke();
+
+                j = this[pu].direction[i].length - 1;
+                this.ctx.lineJoin = "bevel";
+                this.ctx.beginPath();
+                this.ctx.arrow(this.point[this[pu].direction[i][j - 1]].x, this.point[this[pu].direction[i][j - 1]].y,
+                    this.point[this[pu].direction[i][j]].x, this.point[this[pu].direction[i][j]].y, [-0.00001, 0, -0.25 * this.size, 0.25 * this.size]);
+                this.ctx.stroke();
+                this.ctx.lineJoin = "miter";
+            }
+        }
+    }
+
+    draw_line(pu) {
+        for (var i in this[pu].line) {
+            if (this[pu].line[i] === 98) {
+                var r = 0.2;
+                var x = this.point[i].x;
+                var y = this.point[i].y;
+                set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
+                this.ctx.beginPath();
+                this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
+                this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
+                this.ctx.stroke();
+                this.ctx.beginPath();
+                this.ctx.moveTo(x + r * Math.cos(135 * (Math.PI / 180)) * this.size, y + r * Math.sin(135 * (Math.PI / 180)) * this.size);
+                this.ctx.lineTo(x + r * Math.cos(315 * (Math.PI / 180)) * this.size, y + r * Math.sin(315 * (Math.PI / 180)) * this.size);
+                this.ctx.stroke();
+            } else {
+                set_line_style(this.ctx, this[pu].line[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].line[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].line[i];
+                }
+                var i1 = i.split(",")[0];
+                var i2 = i.split(",")[1];
+                this.ctx.beginPath();
+                if (this[pu].line[i] === 40) {
+                    var r = 0.8;
+                    var x1 = r * this.point[i1].x + (1 - r) * this.point[i2].x;
+                    var y1 = r * this.point[i1].y + (1 - r) * this.point[i2].y;
+                    var x2 = (1 - r) * this.point[i1].x + r * this.point[i2].x;
+                    var y2 = (1 - r) * this.point[i1].y + r * this.point[i2].y;
+                    this.ctx.moveTo(x1, y1);
+                    this.ctx.lineTo(x2, y2);
+                } else if (this[pu].line[i] === 30) {
+                    var r = 0.15 * this.size;
+                    var dx = this.point[i1].x - this.point[i2].x;
+                    var dy = this.point[i1].y - this.point[i2].y;
+                    var d = Math.sqrt(dx ** 2 + dy ** 2);
+                    this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
+                    this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
+                    this.ctx.stroke();
+                    this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
+                    this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
+                } else {
+                    if (this.point[i1].type === 2 || this.point[i1].type === 3) { //for centerline
+                        this.ctx.moveTo(this.point[i2].x, this.point[i2].y);
+                        this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
+                        this.ctx.stroke();
+                        this.ctx.lineCap = "butt";
+                    } else if (this.point[i2].type === 2 || this.point[i2].type === 3) {
+                        this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
+                        this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
+                        this.ctx.stroke();
+                        this.ctx.lineCap = "butt";
+                    }
+                    this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
+                    this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
+                }
+                this.ctx.stroke();
+            }
+        }
+        for (var i in this[pu].lineE) {
+            if (this[pu].lineE[i] === 98) {
+                var r = 0.2;
+                var x = this.point[i].x;
+                var y = this.point[i].y;
+                set_line_style(this.ctx, 98);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
+                this.ctx.beginPath();
+                this.ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
+                this.ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
+                this.ctx.stroke();
+                this.ctx.beginPath();
+                this.ctx.moveTo(x + r * Math.cos(135 * (Math.PI / 180)) * this.size, y + r * Math.sin(135 * (Math.PI / 180)) * this.size);
+                this.ctx.lineTo(x + r * Math.cos(315 * (Math.PI / 180)) * this.size, y + r * Math.sin(315 * (Math.PI / 180)) * this.size);
+                this.ctx.stroke();
+            } else {
+                set_line_style(this.ctx, this[pu].lineE[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].lineE[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].lineE[i];
+                }
+                var i1 = i.split(",")[0];
+                var i2 = i.split(",")[1];
+                this.ctx.beginPath();
+                if (this[pu].lineE[i] === 30) {
+                    var r = 0.15 * this.size;
+                    var dx = this.point[i1].x - this.point[i2].x;
+                    var dy = this.point[i1].y - this.point[i2].y;
+                    var d = Math.sqrt(dx ** 2 + dy ** 2);
+                    this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
+                    this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
+                    this.ctx.stroke();
+                    this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
+                    this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
+                } else {
+                    this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
+                    this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
+                }
+                this.ctx.stroke();
+            }
+        }
+    }
+
+    draw_freeline(pu) {
+        /*freeline*/
+        for (var i in this[pu].freeline) {
+            set_line_style(this.ctx, this[pu].freeline[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
+            }
+            var i1 = i.split(",")[0];
+            var i2 = i.split(",")[1];
+            this.ctx.beginPath();
+            if (this[pu].freeline[i] === 30) {
+                var r = 0.15 * this.size;
+                var dx = this.point[i1].x - this.point[i2].x;
+                var dy = this.point[i1].y - this.point[i2].y;
+                var d = Math.sqrt(dx ** 2 + dy ** 2);
+                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
+                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
+                this.ctx.stroke();
+                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
+                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
+            } else {
+                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
+                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
+            }
+            this.ctx.stroke();
+        }
+        for (var i in this[pu].freelineE) {
+            set_line_style(this.ctx, this[pu].freelineE[i]);
+            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
+                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
+            }
+            var i1 = i.split(",")[0];
+            var i2 = i.split(",")[1];
+            this.ctx.beginPath();
+            if (this[pu].freelineE[i] === 30) {
+                var r = 0.15 * this.size;
+                var dx = this.point[i1].x - this.point[i2].x;
+                var dy = this.point[i1].y - this.point[i2].y;
+                var d = Math.sqrt(dx ** 2 + dy ** 2);
+                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
+                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
+                this.ctx.stroke();
+                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
+                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
+            } else {
+                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
+                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
+            }
+            this.ctx.stroke();
+        }
+    }
+
+    draw_symbol(pu, layer) {
+        /*symbol_layer*/
+        var p_x, p_y;
+        for (var i in this[pu].symbol) {
+            if (i.slice(-1) === "E") { //辺モードでの重ね書き
+                p_x = this.point[i.slice(0, -1)].x;
+                p_y = this.point[i.slice(0, -1)].y;
+            } else {
+                p_x = this.point[i].x;
+                p_y = this.point[i].y;
+            }
+            if (this[pu].symbol[i][2] === layer) {
+                try {
+                    this.draw_symbol_select(this.ctx, p_x, p_y, this[pu].symbol[i][0], this[pu].symbol[i][1], i, pu);
+                } catch (err) {
+                    console.error(err);
+                }
+            }
+        }
+    }
+
+    draw_number(pu) {
+        /*number*/
+        var p_x, p_y;
+        for (var i in this[pu].number) {
+            if (i.slice(-1) === "E") { // Overwriting in edge mode
+                p_x = this.point[i.slice(0, -1)].x;
+                p_y = this.point[i.slice(0, -1)].y;
+            } else {
+                p_x = this.point[i].x;
+                p_y = this.point[i].y;
+            }
+            switch (this[pu].number[i][2]) {
+                case "1": //normal
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
+                    set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
+                    this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.06 * this.size, this.size * 0.8);
+                    break;
+                case "2": //arrow
+                    var arrowlength = 0.7;
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
+                    set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
+                    var direction = {
+                        "_0": 90,
+                        "_1": 180,
+                        "_2": 0,
+                        "_3": 270,
+                        "_4": 135,
+                        "_5": 45,
+                        "_6": 225,
+                        "_7": 315,
+                    }
+                    var direction = (direction[this[pu].number[i][0].slice(-2)] - this.theta + 360) % 360;
+                    if (this.reflect[0] === -1) { direction = (180 - direction + 360) % 360; }
+                    if (this.reflect[1] === -1) { direction = (360 - direction + 360) % 360; }
+                    switch (direction) {
+
+                        case 180:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x + 0.0 * this.size, p_y + 0.15 * this.size, this.size * 0.8);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x + (arrowlength * 0.5 + 0.0) * this.size, p_y + (arrowlength * 0.0 - 0.3) * this.size,
+                                p_x + (-arrowlength * 0.5 + 0.0) * this.size, p_y + (-arrowlength * 0.0 - 0.3) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        case 0:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x + 0.0 * this.size, p_y + 0.15 * this.size, this.size * 0.8);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x - (arrowlength * 0.5 + 0.0) * this.size, p_y + (arrowlength * 0.0 - 0.3) * this.size,
+                                p_x - (-arrowlength * 0.5 + 0.0) * this.size, p_y + (-arrowlength * 0.0 - 0.3) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        case 90:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x - 0.1 * this.size, p_y + 0.05 * this.size, this.size * 0.7);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x + (arrowlength * 0.0 + 0.3) * this.size, p_y + (arrowlength * 0.5 - 0.0) * this.size,
+                                p_x + (-arrowlength * 0.0 + 0.3) * this.size, p_y + (-arrowlength * 0.5 - 0.0) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        case 270:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x - 0.1 * this.size, p_y + 0.05 * this.size, this.size * 0.7);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x + (arrowlength * 0.0 + 0.3) * this.size, p_y + (-arrowlength * 0.5 - 0.0) * this.size,
+                                p_x + (-arrowlength * 0.0 + 0.3) * this.size, p_y + (arrowlength * 0.5 - 0.0) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        case 45:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x + 0.05 * this.size, p_y + 0.15 * this.size, this.size * 0.7);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x + (-arrowlength * 0.35 - 0.2) * this.size, p_y + (arrowlength * 0.35 - 0.2) * this.size,
+                                p_x + (arrowlength * 0.35 - 0.2) * this.size, p_y + (-arrowlength * 0.35 - 0.2) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        case 225:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x + 0.05 * this.size, p_y + 0.15 * this.size, this.size * 0.7);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x + (arrowlength * 0.35 - 0.2) * this.size, p_y + (-arrowlength * 0.35 - 0.2) * this.size,
+                                p_x + (-arrowlength * 0.35 - 0.2) * this.size, p_y + (arrowlength * 0.35 - 0.2) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        case 135:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x - 0.05 * this.size, p_y + 0.15 * this.size, this.size * 0.7);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x + (arrowlength * 0.35 + 0.2) * this.size, p_y + (arrowlength * 0.35 - 0.2) * this.size,
+                                p_x + (-arrowlength * 0.35 + 0.2) * this.size, p_y + (-arrowlength * 0.35 - 0.2) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        case 315:
+                            this.ctx.text(this[pu].number[i][0].slice(0, -2), p_x - 0.05 * this.size, p_y + 0.15 * this.size, this.size * 0.7);
+                            this.ctx.beginPath();
+                            this.ctx.arrow(p_x + (-arrowlength * 0.35 + 0.2) * this.size, p_y + (-arrowlength * 0.35 - 0.2) * this.size,
+                                p_x + (arrowlength * 0.35 + 0.2) * this.size, p_y + (arrowlength * 0.35 - 0.2) * this.size, [0, 1, -0.25 * this.size, 1, -0.25 * this.size, 3]);
+                            this.ctx.stroke();
+                            this.ctx.fill();
+                            break;
+                        default:
+                            set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);;
+                            this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.06 * this.size, this.size * 0.8);
+                            break;
+                    }
+                    break;
+                case "4": //tapa
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.44);
+                    if (this[pu].number[i][0].length === 1) {
+                        set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
+                        this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.06 * this.size, this.size * 0.8);
+                    } else if (this[pu].number[i][0].length === 2) {
+                        set_font_style(this.ctx, 0.48 * this.size.toString(10), this[pu].number[i][1]);
+                        this.ctx.text(this[pu].number[i][0].slice(0, 1), p_x - 0.16 * this.size, p_y - 0.15 * this.size, this.size * 0.8);
+                        this.ctx.text(this[pu].number[i][0].slice(1, 2), p_x + 0.18 * this.size, p_y + 0.19 * this.size, this.size * 0.8);
+                    } else if (this[pu].number[i][0].length === 3) {
+                        set_font_style(this.ctx, 0.45 * this.size.toString(10), this[pu].number[i][1]);
+                        this.ctx.text(this[pu].number[i][0].slice(0, 1), p_x - 0.22 * this.size, p_y - 0.14 * this.size, this.size * 0.8);
+                        this.ctx.text(this[pu].number[i][0].slice(1, 2), p_x + 0.24 * this.size, p_y - 0.05 * this.size, this.size * 0.8);
+                        this.ctx.text(this[pu].number[i][0].slice(2, 3), p_x - 0.0 * this.size, p_y + 0.3 * this.size, this.size * 0.8);
+                    } else if (this[pu].number[i][0].length === 4) {
+                        set_font_style(this.ctx, 0.4 * this.size.toString(10), this[pu].number[i][1]);
+                        this.ctx.text(this[pu].number[i][0].slice(0, 1), p_x - 0.0 * this.size, p_y - 0.22 * this.size, this.size * 0.8);
+                        this.ctx.text(this[pu].number[i][0].slice(1, 2), p_x - 0.26 * this.size, p_y + 0.04 * this.size, this.size * 0.8);
+                        this.ctx.text(this[pu].number[i][0].slice(2, 3), p_x + 0.26 * this.size, p_y + 0.04 * this.size, this.size * 0.8);
+                        this.ctx.text(this[pu].number[i][0].slice(3, 4), p_x - 0.0 * this.size, p_y + 0.3 * this.size, this.size * 0.8);
+                    }
+                    break;
+                case "5": //small
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.17);
+                    set_font_style(this.ctx, 0.25 * this.size.toString(10), this[pu].number[i][1]);
+                    this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.02 * this.size, this.size * 0.8);
+                    break;
+                case "6": //medium
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.25);
+                    set_font_style(this.ctx, 0.4 * this.size.toString(10), this[pu].number[i][1]);
+                    this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.03 * this.size, this.size * 0.8);
+                    break;
+                case "10": //big
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.36);
+                    set_font_style(this.ctx, 0.6 * this.size.toString(10), this[pu].number[i][1]);
+                    this.ctx.text(this[pu].number[i][0], p_x, p_y + 0.03 * this.size, this.size * 0.8);
+                    break;
+                case "7": //sudoku
+                    this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
+                    var sum = 0,
+                        pos = 0;
+                    for (var j = 0; j < 9; j++) {
+                        if (this[pu].number[i][0][j] === 1) {
+                            sum += 1;
+                            pos = j;
+                        }
+                    }
+                    if (sum === 1) {
+                        set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
+                        this.ctx.text((pos + 1).toString(), p_x, p_y + 0.06 * this.size, this.size * 0.8);
+                    } else {
+                        set_font_style(this.ctx, 0.3 * this.size.toString(10), this[pu].number[i][1]);
+                        for (var j = 0; j < 9; j++) {
+                            if (this[pu].number[i][0][j] === 1) {
+                                this.ctx.text((j + 1).toString(), p_x + ((j % 3 - 1) * 0.28) * this.size, p_y + (((j / 3 | 0) - 1) * 0.28 + 0.02) * this.size);
+                            }
+                        }
+                    }
+                    break;
+                case "8": //long
+                    if (this[pu].number[i][1] === 5) {
+                        set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
+                        set_circle_style(this.ctx, 7);
+                        this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    }
+                    set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
+                    this.ctx.textAlign = "left";
+                    this.ctx.text(this[pu].number[i][0], p_x - 0.2 * this.size, p_y);
+                    break;
+            }
+        }
+
+        for (var i in this[pu].numberS) {
+            if (this[pu].numberS[i][1] === 5) {
+                set_circle_style(this.ctx, 7);
+                this.draw_polygon(this.ctx, this.point[i].x, this.point[i].y, 0.27, 4, 45);
+            } else if (this[pu].numberS[i][1] === 6) {
+                set_circle_style(this.ctx, 1);
+                this.draw_circle(this.ctx, this.point[i].x, this.point[i].y, 0.18);
+            } else if (this[pu].numberS[i][1] === 7) {
+                set_circle_style(this.ctx, 2);
+                this.draw_circle(this.ctx, this.point[i].x, this.point[i].y, 0.18);
+            }
+            if (true) { //(this[pu].numberS[i][0].length <= 2 )
+                set_font_style(this.ctx, 0.32 * this.size.toString(10), this[pu].numberS[i][1]);
+                this.ctx.textAlign = "center";
+                this.ctx.text(this[pu].numberS[i][0], this.point[i].x, this.point[i].y + 0.03 * this.size, this.size * 0.48);
+                //else
+                //  set_font_style(this.ctx,0.28*this.size.toString(10),this[pu].numberS[i][1]);
+                //  this.ctx.textAlign = "left";
+                //  this.ctx.text(this[pu].numberS[i][0],this.point[i].x-0.15*this.size,this.point[i].y+0.03*this.size,this.size*0.8);
+            }
+        }
+    }
+
+    draw_numbercircle(pu, i, p_x, p_y, size) {
+        if (this[pu].number[i][1] === 5) {
+            set_circle_style(this.ctx, 7);
+            this.draw_circle(this.ctx, p_x, p_y, size);
+        } else if (this[pu].number[i][1] === 6) {
+            set_circle_style(this.ctx, 1);
+            this.draw_circle(this.ctx, p_x, p_y, size);
+        } else if (this[pu].number[i][1] === 7) {
+            set_circle_style(this.ctx, 2);
+            this.draw_circle(this.ctx, p_x, p_y, size);
+        } else if (this[pu].number[i][1] === 11) {
+            set_circle_style(this.ctx, 11);
+            this.draw_circle(this.ctx, p_x, p_y, size);
+        }
+    }
+
+    draw_numbercircle_iso(pu, i, size) {
+        if (this[pu].number[i][1] === 5) {
+            set_circle_style(this.ctx, 7);
+            this.draw_circle(this.ctx, this.point[i].x, this.point[i].y, size);
+        } else if (this[pu].number[i][1] === 6) {
+            set_circle_style(this.ctx, 1);
+            this.draw_circle(this.ctx, this.point[i].x, this.point[i].y, size);
+        } else if (this[pu].number[i][1] === 7) {
+            set_circle_style(this.ctx, 2);
+            this.draw_circle(this.ctx, this.point[i].x, this.point[i].y, size);
+        } else if (this[pu].number[i][1] === 11) {
+            set_circle_style(this.ctx, 11);
+            this.draw_circle(this.ctx, this.point[i].x, this.point[i].y, size);
+        }
+    }
+
+    draw_symbol_select(ctx, x, y, num, sym, i = 'panel', qamode) {
+        let ccolor = undefined;
+        if (i !== 'panel' && UserSettings.custom_colors_on && this[qamode + "_col"].symbol[i]) {
+            ccolor = this[qamode + "_col"].symbol[i];
+        }
+        this.draw_symbol_select_ccolor(ctx, x, y, num, sym, i, ccolor);
+    }
+
+    draw_symbol_select_ccolor(ctx, x, y, num, sym, loc, ccolor) {
+        switch (sym) {
+            /* figure */
+            case "circle_L":
+                if (num === 0) {
+                    set_circle_style(ctx, 1);
+                    this.draw_circle(ctx, x, y, 0.43);
+                    this.draw_circle(ctx, x, y, 0.32);
+                } else {
+                    set_circle_style(ctx, num, ccolor);
+                    this.draw_circle(ctx, x, y, 0.43);
+                }
+                break;
+            case "circle_M":
+                if (num === 0) {
+                    set_circle_style(ctx, 1);
+                    this.draw_circle(ctx, x, y, 0.35);
+                    this.draw_circle(ctx, x, y, 0.25);
+                } else {
+                    set_circle_style(ctx, num, ccolor);
+                    this.draw_circle(ctx, x, y, 0.35);
+                }
+                break;
+            case "circle_S":
+                if (num === 0) {
+                    set_circle_style(ctx, 1);
+                    this.draw_circle(ctx, x, y, 0.22);
+                    this.draw_circle(ctx, x, y, 0.14);
+                } else {
+                    set_circle_style(ctx, num, ccolor);
+                    this.draw_circle(ctx, x, y, 0.22);
+                }
+                break;
+            case "circle_SS":
+                if (num === 0) {
+                    set_circle_style(ctx, 1);
+                    this.draw_circle(ctx, x, y, 0.13);
+                    this.draw_circle(ctx, x, y, 0.07);
+                } else {
+                    set_circle_style(ctx, num, ccolor);
+                    this.draw_circle(ctx, x, y, 0.13);
+                }
+                break;
+            case "square_LL":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.5 * Math.sqrt(2), 4, 45);
+                break;
+            case "square_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.4 * Math.sqrt(2), 4, 45);
+                break;
+            case "square_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.35 * Math.sqrt(2), 4, 45);
+                break;
+            case "square_S":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.22 * Math.sqrt(2), 4, 45);
+                break;
+            case "square_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.13 * Math.sqrt(2), 4, 45);
+                break;
+            case "triup_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y + 0.5 * 0.25 * this.size, 0.5, 3, 90);
+                break;
+            case "triup_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y + 0.4 * 0.25 * this.size, 0.4, 3, 90);
+                break;
+            case "triup_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y + 0.16 * 0.25 * this.size, 0.16, 3, 90);
+                break;
+            case "tridown_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y - 0.5 * 0.25 * this.size, 0.5, 3, -90);
+                break;
+            case "tridown_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y - 0.4 * 0.25 * this.size, 0.4, 3, -90);
+                break;
+            case "tridown_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y - 0.16 * 0.25 * this.size, 0.16, 3, -90);
+                break;
+            case "diamond_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.43, 4, 0);
+                break;
+            case "diamond_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.35, 4, 0);
+                break;
+            case "diamond_S":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.22, 4, 0);
+                break;
+            case "diamond_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.13, 4, 0);
+                break;
+            case "hexpoint_LL":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 30);
+                break;
+            case "hexpoint_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 30);
+                break;
+            case "hexpoint_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 30);
+                break;
+            case "hexpoint_S":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 30);
+                break;
+            case "hexpoint_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 30);
+                break;
+            case "hexflat_LL":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.48, 6, 0);
+                break;
+            case "hexflat_L":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.4, 6, 0);
+                break;
+            case "hexflat_M":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.3, 6, 0);
+                break;
+            case "hexflat_S":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.2, 6, 0);
+                break;
+            case "hexflat_SS":
+                set_circle_style(ctx, num, ccolor);
+                this.draw_polygon(ctx, x, y, 0.13, 6, 0);
+                break;
+            case "ox_B":
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.fillStyle = Color.TRANSPARENTWHITE;
+                ctx.strokeStyle = ccolor || Color.BLACK;
+                ctx.lineWidth = 2;
+                this.draw_ox(ctx, num, x, y);
+                break;
+            case "ox_E":
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.fillStyle = Color.TRANSPARENTWHITE;
+                ctx.strokeStyle = Color.GREEN;
+                ctx.lineWidth = 2;
+                this.draw_ox(ctx, num, x, y);
+                break;
+            case "ox_G":
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.fillStyle = Color.TRANSPARENTWHITE;
+                ctx.strokeStyle = Color.GREY;
+                ctx.lineWidth = 2;
+                this.draw_ox(ctx, num, x, y);
+                break;
+            case "tri":
+                this.draw_tri(ctx, num, x, y, ccolor);
+                break;
+            case "cross":
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.fillStyle = Color.TRANSPARENTBLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
+                ctx.lineWidth = 3;
+                this.draw_cross(ctx, num, x, y);
+                break;
+            case "line":
+                this.draw_linesym(ctx, num, x, y, ccolor);
+                break;
+            case "frameline":
+                this.draw_framelinesym(ctx, num, x, y, ccolor);
+                break;
+
+                //number
+            case "inequality":
+                set_circle_style(ctx, 10, ccolor);
+                this.draw_inequality(ctx, num, x, y);
+                break;
+            case "math":
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 1, ccolor);
+                this.draw_math(ctx, num, x, y + 0.05 * pu.size);
+                break;
+            case "math_G":
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 2, ccolor);
+                this.draw_math(ctx, num, x, y + 0.05 * pu.size);
+                break;
+            case "degital":
+                this.draw_degital(ctx, num, x, y, ccolor);
+                break;
+            case "degital_f":
+                this.draw_degital_f(ctx, num, x, y, ccolor);
+                break;
+            case "dice":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_dice(ctx, num, x, y);
+                break;
+            case "pills":
+                set_circle_style(ctx, 3, ccolor);
+                this.draw_pills(ctx, num, x, y);
+                break;
+
+                /* arrow */
+            case "arrow_B_B":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowB(ctx, num, x, y);
+                break;
+            case "arrow_B_G":
+                set_circle_style(ctx, 3, ccolor);
+                this.draw_arrowB(ctx, num, x, y);
+                break;
+            case "arrow_B_W":
+                set_circle_style(ctx, 1, ccolor);
+                this.draw_arrowB(ctx, num, x, y);
+                break;
+            case "arrow_N_B":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowN(ctx, num, x, y);
+                break;
+            case "arrow_N_G":
+                set_circle_style(ctx, 3, ccolor);
+                this.draw_arrowN(ctx, num, x, y);
+                break;
+            case "arrow_N_W":
+                set_circle_style(ctx, 1, ccolor);
+                this.draw_arrowN(ctx, num, x, y);
+                break;
+            case "arrow_S":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowS(ctx, num, x, y);
+                break;
+            case "arrow_GP":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowGP(ctx, num, x, y);
+                break;
+            case "arrow_GP_C":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowGP_C(ctx, num, x, y);
+                break;
+            case "arrow_Short":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowShort(ctx, num, x, y);
+                break;
+            case "arrow_tri_B":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowtri(ctx, num, x, y);
+                break;
+            case "arrow_tri_G":
+                set_circle_style(ctx, 3, ccolor);
+                this.draw_arrowtri(ctx, num, x, y);
+                break;
+            case "arrow_tri_W":
+                set_circle_style(ctx, 1, ccolor);
+                this.draw_arrowtri(ctx, num, x, y);
+                break;
+            case "arrow_cross":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowcross(ctx, num, x, y);
+                break;
+            case "arrow_eight":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arroweight(ctx, num, x, y);
+                break;
+            case "arrow_fourtip":
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_arrowfourtip(ctx, num, x, y);
+                break;
+            case "arrow_fouredge_B":
+                set_circle_style(ctx, 2, ccolor);
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                this.draw_arrowfouredge(ctx, num, x, y);
+                break;
+            case "arrow_fouredge_G":
+                set_circle_style(ctx, 2);
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.fillStyle = Color.GREY;
+                this.draw_arrowfouredge(ctx, num, x, y);
+                break;
+            case "arrow_fouredge_E":
+                set_circle_style(ctx, 2);
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.fillStyle = Color.GREEN_LIGHT;
+                this.draw_arrowfouredge(ctx, num, x, y);
+                break;
+                /* special */
+                // case "kakuro":
+                //     this.draw_kakuro(ctx, num, x, y, ccolor);
+                //     break;
+                // case "compass":
+                //     this.draw_compass(ctx, num, x, y, ccolor);
+                //     break;
+            case "star":
+                this.draw_star(ctx, num, x, y, loc, ccolor);
+                break;
+            case "tents":
+                this.draw_tents(ctx, num, x, y, ccolor);
+                break;
+                // case "battleship_B":
+                //     set_circle_style(ctx, 2);
+                //     this.draw_battleship(ctx, num, x, y, ccolor);
+                //     break;
+                // case "battleship_G":
+                //     set_circle_style(ctx, 3);
+                //     ctx.fillStyle = Color.GREY;
+                //     this.draw_battleship(ctx, num, x, y);
+                //     break;
+                // case "battleship_W":
+                //     ctx.setLineDash([]);
+                //     ctx.lineCap = "butt";
+                //     ctx.fillStyle = Color.TRANSPARENTBLACK;
+                //     ctx.strokeStyle = Color.BLACK;
+                //     ctx.lineWidth = 2;
+                //     this.draw_battleship(ctx, num, x, y);
+                //     break;
+            case "angleloop":
+                this.draw_angleloop(ctx, num, x, y, ccolor);
+                break;
+            case "firefly":
+                this.draw_firefly(ctx, num, x, y, ccolor);
+                break;
+            case "sun_moon":
+                this.draw_sun_moon(ctx, num, x, y, loc, ccolor);
+                break;
+            case "sudokuetc":
+                this.draw_sudokuetc(ctx, num, x, y, ccolor);
+                break;
+            case "polyomino":
+                this.draw_polyomino(ctx, num, x, y, ccolor);
+                break;
+                // case "pencils":
+                //     this.draw_pencils(ctx, num, x, y);
+                //     break;
+        }
+    }
+
+    draw_circle(ctx, x, y, r) {
+        ctx.beginPath();
+        ctx.arc(x, y, r * pu.size, 0, Math.PI * 2, false);
+        ctx.fill();
+        ctx.stroke();
+    }
+
+    draw_x(ctx, x, y, r) {
+        ctx.beginPath();
+        ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * this.size, y + r * Math.sin(45 * (Math.PI / 180)) * this.size);
+        ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * this.size, y + r * Math.sin(225 * (Math.PI / 180)) * this.size);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(x + r * Math.cos(135 * (Math.PI / 180)) * this.size, y + r * Math.sin(135 * (Math.PI / 180)) * this.size);
+        ctx.lineTo(x + r * Math.cos(315 * (Math.PI / 180)) * this.size, y + r * Math.sin(315 * (Math.PI / 180)) * this.size);
+        ctx.stroke();
+    }
+
+    draw_ast(ctx, x, y, r) {
+        var th;
+        th = 45 + this.theta % 180;
+        ctx.beginPath();
+        ctx.moveTo(x + r * Math.cos(th * (Math.PI / 180)) * this.size, y + r * Math.sin(th * (Math.PI / 180)) * this.size);
+        ctx.lineTo(x + r * Math.cos((th + 180) * (Math.PI / 180)) * this.size, y + r * Math.sin((th + 180) * (Math.PI / 180)) * this.size);
+        ctx.stroke();
+        th = 135 + this.theta % 180;
+        ctx.beginPath();
+        ctx.moveTo(x + r * Math.cos(th * (Math.PI / 180)) * this.size, y + r * Math.sin(th * (Math.PI / 180)) * this.size);
+        ctx.lineTo(x + r * Math.cos((th + 180) * (Math.PI / 180)) * this.size, y + r * Math.sin((th + 180) * (Math.PI / 180)) * this.size);
+        ctx.stroke();
+    }
+
+    draw_slash(ctx, x, y, r) {
+        var th;
+        th = 45 + this.theta % 180;
+        ctx.beginPath();
+        ctx.moveTo(x + r * Math.cos(th * (Math.PI / 180)) * this.size, y + r * Math.sin(th * (Math.PI / 180)) * this.size);
+        ctx.lineTo(x + r * Math.cos((th + 180) * (Math.PI / 180)) * this.size, y + r * Math.sin((th + 180) * (Math.PI / 180)) * this.size);
+        ctx.stroke();
+    }
+
+    draw_ox(ctx, num, x, y) {
+        var r = 0.3;
+        switch (num) {
+            case 1:
+                this.draw_circle(ctx, x, y, r);
+                break;
+            case 2:
+                this.draw_polygon(ctx, x, y + 0.05 * this.size, 0.3, 3, 90);
+                break;
+            case 3:
+                this.draw_polygon(ctx, x, y, 0.35, 4, 45);
+                break;
+            case 4:
+                this.draw_x(ctx, x, y, r);
+                break;
+            case 5:
+                r = 0.5;
+                ctx.beginPath();
+                ctx.moveTo(x + r * Math.cos(45 * (Math.PI / 180)) * pu.size, y + r * Math.sin(45 * (Math.PI / 180)) * pu.size);
+                ctx.lineTo(x + r * Math.cos(225 * (Math.PI / 180)) * pu.size, y + r * Math.sin(225 * (Math.PI / 180)) * pu.size);
+                ctx.stroke();
+                break;
+            case 6:
+                r = 0.5;
+                ctx.beginPath();
+                ctx.moveTo(x + r * Math.cos(135 * (Math.PI / 180)) * pu.size, y + r * Math.sin(135 * (Math.PI / 180)) * pu.size);
+                ctx.lineTo(x + r * Math.cos(315 * (Math.PI / 180)) * pu.size, y + r * Math.sin(315 * (Math.PI / 180)) * pu.size);
+                ctx.stroke();
+                break;
+            case 7:
+                this.draw_x(ctx, x, y, 0.5);
+                break;
+            case 8:
+                r = 0.05;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.fillStyle = ctx.strokeStyle;
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 2;
+                this.draw_circle(ctx, x, y, r);
+                break;
+            case 9:
+                r = 0.3;
+                this.draw_circle(ctx, x, y, r);
+                this.draw_x(ctx, x, y, 0.45);
+                break;
+        }
+    }
+
+    draw_cross(ctx, num, x, y) {
+        for (var i = 0; i < 4; i++) {
+            if (num[i] === 1) {
+                var th = this.rotate_theta(i * 90 - 180);
+                ctx.beginPath();
+                ctx.moveTo(x + ctx.lineWidth * 0.3 * Math.cos(th), y + ctx.lineWidth * 0.3 * Math.sin(th));
+                ctx.lineTo(x - 0.5 * pu.size * Math.cos(th), y - 0.5 * pu.size * Math.sin(th));
+                ctx.stroke();
+            }
+        }
+    }
+
+    draw_linesym(ctx, num, x, y, ccolor) {
+        var r = 0.32;
+        ctx.setLineDash([]);
+        ctx.lineCap = "round";
+        ctx.fillStyle = Color.TRANSPARENTBLACK;
+        ctx.strokeStyle = ccolor || Color.BLACK;
+        ctx.lineWidth = 3;
+        switch (num) {
+            case 1:
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - 0 * pu.size);
+                ctx.lineTo(x + r * pu.size, y + 0 * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 2:
+                ctx.beginPath();
+                ctx.moveTo(x - 0 * pu.size, y - r * pu.size);
+                ctx.lineTo(x + 0 * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 3:
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 4:
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 5:
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - 0 * pu.size);
+                ctx.lineTo(x + r * pu.size, y + 0 * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                ctx.beginPath();
+                ctx.moveTo(x - 0 * pu.size, y - r * pu.size);
+                ctx.lineTo(x + 0 * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 6:
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                ctx.beginPath();
+                ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+        }
+    }
+
+    draw_framelinesym(ctx, num, x, y, ccolor) {
+        var r = 0.32;
+        ctx.setLineDash([]);
+        ctx.lineCap = "round";
+        ctx.fillStyle = Color.TRANSPARENTBLACK;
+        ctx.strokeStyle = Color.BLACK;
+        ctx.lineWidth = 3;
+        switch (num) {
+            case 1:
+                set_line_style(ctx, 115, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 2:
+                set_line_style(ctx, 15, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 3:
+                set_line_style(ctx, 16, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 4:
+                set_line_style(ctx, 110, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x + r * pu.size, y - r * pu.size);
+                ctx.lineTo(x - r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 5:
+                set_line_style(ctx, 115, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 6:
+                set_line_style(ctx, 15, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 7:
+                set_line_style(ctx, 16, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 8:
+                set_line_style(ctx, 110, ccolor);
+                r = r / Math.sqrt(2);
+                ctx.beginPath();
+                ctx.moveTo(x - r * pu.size, y - r * pu.size);
+                ctx.lineTo(x + r * pu.size, y + r * pu.size);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+        }
+    }
+
+
+    draw_inequality(ctx, num, x, y) {
+        var th;
+        var len = 0.14;
+        switch (num) {
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+                ctx.beginPath();
+                th = this.rotate_theta((num - 1) * 90 + 45);
+                ctx.moveTo(x + len * Math.sqrt(2) * pu.size * Math.cos(th), y + len * Math.sqrt(2) * pu.size * Math.sin(th));
+                th = this.rotate_theta((num - 1) * 90 + 180);
+                ctx.lineTo(x + len * pu.size * Math.cos(th), y + len * pu.size * Math.sin(th));
+                th = this.rotate_theta((num - 1) * 90 + 315);
+                ctx.lineTo(x + len * Math.sqrt(2) * pu.size * Math.cos(th), y + len * Math.sqrt(2) * pu.size * Math.sin(th));
+                ctx.fill();
+                ctx.stroke();
+                break;
+                //for square
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+                len = 0.12;
+                set_circle_style(ctx, 10);
+                ctx.beginPath();
+                th = this.rotate_theta((num - 1) * 90 + 80);
+                ctx.moveTo(x + len * Math.sqrt(2) * pu.size * Math.cos(th), y + len * Math.sqrt(2) * pu.size * Math.sin(th));
+                th = this.rotate_theta((num - 1) * 90 + 180);
+                ctx.lineTo(x + len * pu.size * Math.cos(th), y + len * pu.size * Math.sin(th));
+                th = this.rotate_theta((num - 1) * 90 + 280);
+                ctx.lineTo(x + len * Math.sqrt(2) * pu.size * Math.cos(th), y + len * Math.sqrt(2) * pu.size * Math.sin(th));
+                ctx.stroke();
+                break;
+        }
+    }
+
+    draw_math(ctx, num, x, y) {
+        switch (num) {
+            case 1:
+                ctx.font = 0.8 * pu.size + "px sans-serif";
+                ctx.text("\u{221E}", x, y);
+                break;
+            case 2:
+                ctx.font = 0.7 * pu.size + "px Helvetica,Arial";
+                ctx.text("＋", x, y);
+                break;
+            case 3:
+                ctx.font = 0.7 * pu.size + "px Helvetica,Arial";
+                ctx.text("－", x, y);
+                break;
+            case 4:
+                ctx.text("×", x, y);
+                break;
+            case 5:
+                ctx.font = 0.7 * pu.size + "px Helvetica,Arial";
+                ctx.text("＊", x, y);
+                break;
+            case 6:
+                ctx.text("÷", x, y);
+                break;
+            case 7:
+                ctx.font = 0.7 * pu.size + "px Helvetica,Arial";
+                ctx.text("＝", x, y);
+                break;
+            case 8:
+                ctx.text("≠", x, y);
+                break;
+            case 9:
+                ctx.text("≦", x, y);
+                break;
+            case 0:
+                ctx.text("≧", x, y);
+                break;
+
+        }
+    }
+
+    draw_degital(ctx, num, x, y, ccolor) {
+        set_circle_style(ctx, 2, ccolor);
+        var w1, w2, w3, w4, z1, z2;
+        z1 = 0.17;
+        z2 = 0.015;
+        w3 = 0.05;
+        w4 = 0.05;
+        for (var i = 0; i < 7; i++) {
+            if (num[0] === 1) {
+                w1 = z1;
+                w2 = -2 * (z1 + z2);
+                ctx.beginPath();
+                ctx.arrow(x - w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + w2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+                ctx.fill();
+            }
+            if (num[1] === 1) {
+                w1 = -(z1 + z2);
+                w2 = -2 * z1;
+                ctx.beginPath();
+                ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y - 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+                ctx.fill();
+            }
+            if (num[2] === 1) {
+                w1 = z1 + z2;
+                w2 = -2 * z1;
+                ctx.beginPath();
+                ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y - 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+                ctx.fill();
+            }
+            if (num[3] === 1) {
+                w1 = z1;
+                w2 = 0;
+                ctx.beginPath();
+                ctx.arrow(x - w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + w2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+                ctx.fill();
+            }
+            if (num[4] === 1) {
+                w1 = -(z1 + z2);
+                w2 = 2 * z1;
+                ctx.beginPath();
+                ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+                ctx.fill();
+            }
+            if (num[5] === 1) {
+                w1 = z1 + z2;
+                w2 = 2 * z1;
+                ctx.beginPath();
+                ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+                ctx.fill();
+            }
+            if (num[6] === 1) {
+                w1 = z1;
+                w2 = 2 * (z1 + z2);
+                ctx.beginPath();
+                ctx.arrow(x - w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + w2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+                ctx.fill();
+            }
+        }
+    }
+
+    draw_degital_f(ctx, num, x, y, ccolor) {
+        set_circle_style(ctx, 3);
+        var w1, w2, w3, w4, z1, z2;
+        z1 = 0.17;
+        z2 = 0.015;
+        w3 = 0.05;
+        w4 = 0.05;
+        //frame
+        w1 = z1;
+        w2 = -2 * (z1 + z2);
+        ctx.beginPath();
+        ctx.arrow(x - w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + w2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+        ctx.stroke();
+        ctx.fill();
+        w1 = -(z1 + z2);
+        w2 = -2 * z1;
+        ctx.beginPath();
+        ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y - 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+        ctx.stroke();
+        ctx.fill();
+        w1 = z1 + z2;
+        w2 = -2 * z1;
+        ctx.beginPath();
+        ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y - 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+        ctx.stroke();
+        ctx.fill();
+        w1 = z1;
+        w2 = 0;
+        ctx.beginPath();
+        ctx.arrow(x - w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + w2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+        ctx.stroke();
+        ctx.fill();
+        w1 = -(z1 + z2);
+        w2 = 2 * z1;
+        ctx.beginPath();
+        ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+        ctx.stroke();
+        ctx.fill();
+        w1 = z1 + z2;
+        w2 = 2 * z1;
+        ctx.beginPath();
+        ctx.arrow(x + w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + 2 * z2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+        ctx.stroke();
+        ctx.fill();
+        w1 = z1;
+        w2 = 2 * (z1 + z2);
+        ctx.beginPath();
+        ctx.arrow(x - w1 * pu.size, y + w2 * pu.size, x + w1 * pu.size, y + w2 * pu.size, [w3 * pu.size, w4 * pu.size, -w3 * pu.size, w4 * pu.size]);
+        ctx.stroke();
+        ctx.fill();
+
+        //contents
+        this.draw_degital(ctx, num, x, y, ccolor);
+    }
+
+    draw_dice(ctx, num, x, y) {
+        for (var i = 0; i < 9; i++) {
+            if (num[i] === 1) {
+                this.draw_circle(ctx, x + (i % 3 - 1) * 0.25 * pu.size, y + ((i / 3 | 0) - 1) * 0.25 * pu.size, 0.09);
+            }
+        }
+    }
+
+    draw_pills(ctx, num, x, y) {
+        var r = 0.15;
+        ctx.fillStyle = Color.GREY
+        switch (num) {
+            case 1:
+                this.draw_circle(ctx, x, y, r);
+                break;
+            case 2:
+                this.draw_circle(ctx, x - 0.22 * pu.size, y - 0.22 * pu.size, r);
+                this.draw_circle(ctx, x + 0.22 * pu.size, y + 0.22 * pu.size, r);
+                break;
+            case 3:
+                this.draw_circle(ctx, x - 0 * pu.size, y - 0.23 * pu.size, r);
+                this.draw_circle(ctx, x + 0.23 * pu.size, y + 0.2 * pu.size, r);
+                this.draw_circle(ctx, x - 0.23 * pu.size, y + 0.2 * pu.size, r);
+                break;
+            case 4:
+                this.draw_circle(ctx, x - 0.22 * pu.size, y - 0.22 * pu.size, r);
+                this.draw_circle(ctx, x + 0.22 * pu.size, y + 0.22 * pu.size, r);
+                this.draw_circle(ctx, x - 0.22 * pu.size, y + 0.22 * pu.size, r);
+                this.draw_circle(ctx, x + 0.22 * pu.size, y - 0.22 * pu.size, r);
+                break;
+            case 5:
+                this.draw_circle(ctx, x, y, r);
+                this.draw_circle(ctx, x - 0.24 * pu.size, y - 0.24 * pu.size, r);
+                this.draw_circle(ctx, x + 0.24 * pu.size, y + 0.24 * pu.size, r);
+                this.draw_circle(ctx, x - 0.24 * pu.size, y + 0.24 * pu.size, r);
+                this.draw_circle(ctx, x + 0.24 * pu.size, y - 0.24 * pu.size, r);
+                break;
+        }
+    }
+
+
+    draw_arrowB(ctx, num, x, y) {
+        var len1 = 0.38; //nemoto
+        var len2 = 0.4; //tip
+        var w1 = 0.2;
+        var w2 = 0.4;
+        var ri = -0.4;
+        this.draw_arrow(ctx, num, x, y, len1, len2, w1, w2, ri);
+    }
+
+    draw_arrowN(ctx, num, x, y) {
+        var len1 = 0.38; //nemoto
+        var len2 = 0.4; //tip
+        var w1 = 0.03;
+        var w2 = 0.13;
+        var ri = -0.25;
+        this.draw_arrow(ctx, num, x, y, len1, len2, w1, w2, ri);
+    }
+
+    draw_arrowS(ctx, num, x, y) {
+        var len1 = 0.3; //nemoto
+        var len2 = 0.32; //tip
+        var w1 = 0.02;
+        var w2 = 0.12;
+        var ri = -0.2;
+        this.draw_arrow(ctx, num, x, y, len1, len2, w1, w2, ri);
+    }
+
+    draw_arrowGP(ctx, num, x, y) {
+        var len1 = 0.35; //nemoto
+        var len2 = 0.35; //tip
+        var w1 = 0.12;
+        var w2 = 0.23;
+        var w3 = 0.34;
+        var r1 = -0.33;
+        var r2 = -0.44;
+        var r3 = -0.32;
+        var th;
+        if (num > 0 && num <= 6) {
+            th = this.rotate_theta((num - 1) * 60 - 150);
+            ctx.beginPath();
+            ctx.arrow(x - len1 * pu.size * Math.cos(th), y - len1 * pu.size * Math.sin(th), x + len2 * pu.size * Math.cos(th), y + len2 * pu.size * Math.sin(th), [0, w1 * pu.size, r1 * pu.size, w1 * pu.size, r2 * pu.size, w2 * pu.size, r3 * pu.size, w3 * pu.size]);
+            ctx.fill();
+            ctx.stroke();
+        }
+    }
+
+    draw_arrowGP_C(ctx, num, x, y) {
+        if (num > 0 && num <= 6) {
+            var th = this.rotate_theta((num - 1) * 60 - 150);
+            this.draw_circle(ctx, x, y, 0.35);
+            this.draw_arrowGP(ctx, num, x + 0.5 * pu.size * Math.cos(th), y + 0.5 * pu.size * Math.sin(th));
+        }
+    }
+
+    draw_arrowShort(ctx, num, x, y) {
+        var len1 = 0.3; //nemoto
+        var len2 = 0.3; //tip
+        var w1 = 0.15;
+        var w2 = 0.31;
+        var ri = -0.33;
+        this.draw_arrow(ctx, num, x, y, len1, len2, w1, w2, ri);
+    }
+
+    draw_arrowtri(ctx, num, x, y) {
+        var len1 = 0.25; //nemoto
+        var len2 = 0.4; //tip
+        var w1 = 0;
+        var w2 = 0.35;
+        var ri = 0;
+        this.draw_arrow(ctx, num, x, y, len1, len2, w1, w2, ri);
+    }
+
+    draw_arrow(ctx, num, x, y, len1, len2, w1, w2, ri) {
+        var th;
+        if (num > 0 && num <= 8) {
+            th = this.rotate_theta((num - 1) * 45 - 180);
+            ctx.beginPath();
+            ctx.arrow(x - len1 * pu.size * Math.cos(th), y - len1 * pu.size * Math.sin(th), x + len2 * pu.size * Math.cos(th), y + len2 * pu.size * Math.sin(th), [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
+            ctx.fill();
+            ctx.stroke();
+        }
+    }
+
+    draw_arrowcross(ctx, num, x, y) {
+        var w1 = 0.025;
+        var w2 = 0.12;
+        var len1 = 0.5 * w1; //nemoto
+        var len2 = 0.45; //tip
+        var ri = -0.18;
+        var th;
+        for (var i = 0; i < 4; i++) {
+            if (num[i] === 1) {
+                th = this.rotate_theta(i * 90 - 180);
+                ctx.beginPath();
+                ctx.arrow(x - len1 * pu.size * Math.cos(th), y - len1 * pu.size * Math.sin(th), x + len2 * pu.size * Math.cos(th), y + len2 * pu.size * Math.sin(th), [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
+                ctx.fill();
+            }
+        }
+    }
+
+    draw_arroweight(ctx, num, x, y) {
+        var len1 = -0.2; //nemoto
+        var len2 = 0.45; //tip
+        var w1 = 0.025;
+        var w2 = 0.10;
+        var ri = -0.15;
+        for (var i = 0; i < 8; i++) {
+            if (num[i] === 1) {
+                this.draw_arrow8(ctx, i + 1, x, y, len1, len2, w1, w2, ri);
+            }
+        }
+    }
+
+    draw_arrow8(ctx, num, x, y, len1, len2, w1, w2, ri) {
+        var th;
+        if (num === 2 || num === 4 || num === 6 || num === 8) {
+            len1 *= 1.3;
+            len2 *= 1.2;
+        }
+        if (num > 0 && num <= 8) {
+            th = this.rotate_theta((num - 1) * 45 - 180);
+            ctx.beginPath();
+            ctx.arrow(x - len1 * pu.size * Math.cos(th), y - len1 * pu.size * Math.sin(th), x + len2 * pu.size * Math.cos(th), y + len2 * pu.size * Math.sin(th), [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
+            ctx.fill();
+            ctx.stroke();
+        }
+    }
+
+    draw_arrowfourtip(ctx, num, x, y) {
+        var len1 = 0.5; //nemoto
+        var len2 = -0.25; //tip
+        var w1 = 0.0;
+        var w2 = 0.2;
+        var ri = 0.0;
+        for (var i = 0; i < 4; i++) {
+            if (num[i] === 1) {
+                this.draw_arrow4(ctx, i + 1, x, y, len1, len2, w1, w2, ri);
+            }
+        }
+    }
+
+    draw_arrow4(ctx, num, x, y, len1, len2, w1, w2, ri) {
+        var th;
+        if (num > 0 && num <= 4) {
+            th = this.rotate_theta((num - 1) * 90);
+            ctx.beginPath();
+            ctx.arrow(x - len1 * pu.size * Math.cos(th), y - len1 * pu.size * Math.sin(th), x + len2 * pu.size * Math.cos(th), y + len2 * pu.size * Math.sin(th), [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
+            ctx.fill();
+            ctx.stroke();
+        }
+    }
+
+    draw_arrowfouredge(ctx, num, x, y) {
+        var len1 = 0.5; //nemoto
+        var len2 = 0.5;
+        var t1 = 0.00;
+        var t2 = 0.50;
+        var w1 = 0.02;
+        var w2 = 0.07;
+        var ri = 0.42;
+        var th1, th2;
+        for (var i = 0; i < 4; i++) {
+            if (num[i] === 1) {
+                th1 = this.rotate_theta(225 + 90 * i);
+                th2 = this.rotate_theta(90 * i);
+                ctx.beginPath();
+                ctx.arrow(x + len1 * pu.size * Math.cos(th1 + Math.PI * t1) + 0.1 * pu.size * Math.cos(th2), y + len1 * pu.size * Math.sin(th1 + Math.PI * t1) + 0.1 * pu.size * Math.sin(th2), x + len2 * pu.size * Math.cos(th1 + Math.PI * t2) - 0.05 * pu.size * Math.cos(th2), y + len2 * pu.size * Math.sin(th1 + Math.PI * t2) - 0.05 * pu.size * Math.sin(th2), [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
+                ctx.fill();
+                ctx.stroke();
+            }
+        }
+        for (var i = 4; i < 8; i++) {
+            if (num[i] === 1) {
+                th1 = this.rotate_theta(225 + 90 * i);
+                th2 = this.rotate_theta(90 * i);
+                ctx.beginPath();
+                ctx.arrow(x + len2 * pu.size * Math.cos(th1 + Math.PI * t2) - 0.1 * pu.size * Math.cos(th2), y + len2 * pu.size * Math.sin(th1 + Math.PI * t2) - 0.1 * pu.size * Math.sin(th2), x + len1 * pu.size * Math.cos(th1 + Math.PI * t1) + 0.05 * pu.size * Math.cos(th2), y + len1 * pu.size * Math.sin(th1 + Math.PI * t1) + 0.05 * pu.size * Math.sin(th2), [0, w1 * pu.size, ri * pu.size, w1 * pu.size, ri * pu.size, w2 * pu.size]);
+                ctx.fill();
+                ctx.stroke();
+            }
+        }
+    }
+
+    draw_tents(ctx, num, x, y, ccolor) {
+        switch (num) {
+            case 1:
+                var r1;
+                var r2;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.BLACK;
+                ctx.lineWidth = 1;
+                ctx.fillStyle = Color.WHITE;
+                r1 = 0.1;
+                r2 = 0.4;
+                ctx.beginPath();
+                ctx.moveTo(x - r1 * pu.size, y);
+                ctx.lineTo(x + r1 * pu.size, y);
+                ctx.lineTo(x + r1 * pu.size, y + r2 * pu.size);
+                ctx.lineTo(x - r1 * pu.size, y + r2 * pu.size);
+                ctx.lineTo(x - r1 * pu.size, y);
+                ctx.fill();
+                ctx.stroke();
+
+                r1 = 0.2;
+                r2 = 0.4;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.GREY;
+                ctx.lineWidth = 1;
+                ctx.beginPath();
+                ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) + 0) * pu.size);
+                ctx.lineTo(x - r2 * Math.cos(210 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(210 * (Math.PI / 180)) + 0) * pu.size);
+                ctx.lineTo(x - r2 * Math.cos(330 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(330 * (Math.PI / 180)) + 0) * pu.size);
+                //ctx.arc(x,y-0.1*pu.size,0.3*pu.size,0,2*Math.PI,false);
+                ctx.fill();
+                ctx.beginPath();
+                ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) + 0.2) * pu.size);
+                ctx.lineTo(x - r2 * Math.cos(210 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(210 * (Math.PI / 180)) + 0.2) * pu.size);
+                ctx.lineTo(x - r2 * Math.cos(330 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(330 * (Math.PI / 180)) + 0.2) * pu.size);
+                ctx.fill();
+                break;
+            case 2:
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.BLACK;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
+                ctx.lineWidth = 1;
+                r1 = 0.3;
+                r2 = 0.4;
+                ctx.beginPath();
+                ctx.moveTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) - 0.1) * pu.size);
+                ctx.lineTo(x - r2 * Math.cos(210 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(210 * (Math.PI / 180)) - 0.1) * pu.size);
+                ctx.lineTo(x - r2 * Math.cos(330 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(330 * (Math.PI / 180)) - 0.1) * pu.size);
+                ctx.lineTo(x - r1 * Math.cos(90 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(90 * (Math.PI / 180)) - 0.1) * pu.size);
+                ctx.lineTo(x - r2 * Math.cos(210 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(210 * (Math.PI / 180)) - 0.1) * pu.size);
+                ctx.fill();
+                ctx.stroke();
+                break;
+            case 3: //anglers
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = ccolor || Color.BLACK;
+                ctx.fillStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.moveTo(x - 0.35 * pu.size, y);
+                ctx.quadraticCurveTo(x - 0. * pu.size, y + 0.37 * pu.size, x + 0.3 * pu.size, y - 0.2 * pu.size);
+                ctx.stroke();
+                ctx.moveTo(x - 0.35 * pu.size, y);
+                ctx.quadraticCurveTo(x - 0. * pu.size, y - 0.37 * pu.size, x + 0.3 * pu.size, y + 0.2 * pu.size);
+                ctx.stroke();
+                break;
+            case 4:
+                set_font_style(ctx, 0.8 * pu.size.toString(10), 1, ccolor);
+                ctx.text("～", x, y - 0.11 * pu.size);
+                ctx.text("～", x, y + 0.09 * pu.size);
+                ctx.text("～", x, y + 0.29 * pu.size);
+                break;
+        }
+    }
+
+    draw_star(ctx, num, x, y, loc, ccolor) {
+        if (parseInt(loc % 2) === 0) { // Even numbers are octa shape, odd numbers are square shape
+            var r1 = 0.5;
+            var r = 0.5;
+        } else {
+            var r = 0.3;
+            var r1 = 0.25;
+        }
+        var r2 = 0.382 * r1;
+        switch (num) {
+            case 1:
+                ctx.fillStyle = ccolor || Color.WHITE;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.BLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
+                break;
+            case 2:
+                ctx.fillStyle = ccolor || Color.BLACK;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
+                break;
+            case 3:
+                ctx.fillStyle = Color.GREY;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y + 0.03 * pu.size, r1, r2, 5);
+                break;
+            case 4:
+                ctx.fillStyle = ccolor || Color.WHITE;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.BLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
+                break;
+            case 5:
+                ctx.fillStyle = ccolor || Color.BLACK;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
+                break;
+            case 6:
+                ctx.fillStyle = Color.GREY;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y, r1, r2 * 0.9, 4);
+                break;
+            case 7:
+                ctx.fillStyle = ccolor || Color.WHITE;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.BLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
+                break;
+            case 8:
+                ctx.fillStyle = ccolor || Color.BLACK;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
+                break;
+            case 9:
+                ctx.fillStyle = Color.GREY;
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 1;
+                this.draw_star0(ctx, x, y, r2 * 0.9, r1, 4);
+                break;
+            case 0:
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.strokeStyle = ccolor || Color.BLACK;
+                ctx.lineWidth = 1;
+                this.draw_x(ctx, x, y, r)
+                break;
+        }
+    }
+
+    draw_star0(ctx, x, y, r1, r2, n) {
+        var th1 = 90;
+        var th2 = th1 + 180 / n;
+        ctx.lineCap = "round";
+        ctx.beginPath();
+        ctx.moveTo(x - r1 * Math.cos(th1 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(th1 * (Math.PI / 180)) - 0) * pu.size);
+        ctx.lineTo(x - r2 * Math.cos(th2 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(th2 * (Math.PI / 180)) - 0) * pu.size);
+        for (var i = 0; i < n; i++) {
+            th1 += 360 / n;
+            th2 += 360 / n;
+            ctx.lineTo(x - r1 * Math.cos(th1 * (Math.PI / 180)) * pu.size, y - (r1 * Math.sin(th1 * (Math.PI / 180)) - 0) * pu.size);
+            ctx.lineTo(x - r2 * Math.cos(th2 * (Math.PI / 180)) * pu.size, y - (r2 * Math.sin(th2 * (Math.PI / 180)) - 0) * pu.size);
+        }
+        ctx.fill();
+        ctx.stroke();
+    }
+
+    draw_angleloop(ctx, num, x, y, ccolor) {
+        var r;
+        switch (num) {
+            case 1:
+                r = 0.24;
+                set_circle_style(ctx, 2, ccolor);
+                this.draw_polygon(ctx, x, y, r, 3, 90);
+                break;
+            case 2:
+                r = 0.24;
+                set_circle_style(ctx, 5);
+                ctx.fillStyle = ccolor || Color.GREY;
+                this.draw_polygon(ctx, x, y, r, 4, 45);
+                break;
+            case 3:
+                r = 0.215;
+                set_circle_style(ctx, 1, ccolor);
+                ctx.lineWidth = 1;
+                this.draw_polygon(ctx, x, y, r, 5, 90);
+                break;
+            case 4:
+                r = 0.25;
+                set_circle_style(ctx, 1);
+                ctx.lineWidth = 2;
+                this.draw_x(ctx, x, y, r);
+                break;
+        }
+    }
+
+    draw_firefly(ctx, num, x, y, ccolor) {
+        var r1 = 0.25,
+            r2 = 0.09;
+        ctx.setLineDash([]);
+        ctx.lineCap = "butt";
+        const thMap = { 1: -90, 2: 90, 3: -45, 4: 45, 5: -225, 6: 225, 7: 135, 8: 180, 9: 0 };
+        switch (num) {
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+            case 9:
+                var th = this.rotate_theta(thMap[num]);
+                set_circle_style(ctx, 1, ccolor);
+                this.draw_circle(ctx, x, y, r1);
+                ctx.fillStyle = Color.BLACK;
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.lineWidth = 2;
+                this.draw_circle(ctx, x - r1 * pu.size * Math.cos(th), y - r1 * pu.size * Math.sin(th), r2);
+                break;
+            case 0:
+                set_circle_style(ctx, 1, ccolor);
+                this.draw_circle(ctx, x, y, r1);
+                break;
+        }
+    }
+
+    draw_sun_moon(ctx, num, x, y, loc, ccolor) {
+        if (this.point[loc].surround.length === 4) {
+            var r1 = 0.24,
+                r2 = 0.22,
+                alp1 = 0.4,
+                alp2 = 0.5,
+                alp3 = 0.6;
+        } else {
+            var r1 = 0.45,
+                r2 = 0.43,
+                alp1 = 0.6,
+                alp2 = 0.7,
+                alp3 = 0.8;
+        }
+        switch (num) {
+            case 1:
+                set_circle_style(ctx, 1, ccolor);
+                this.draw_circle(ctx, x, y, r1);
+                break;
+            case 2:
+                set_circle_style(ctx, 2, ccolor);
+                ctx.beginPath();
+                ctx.arc(x, y, r1 * pu.size, -0.34 * Math.PI, 0.73 * Math.PI, false);
+                ctx.arc(x - 0.12 * pu.size, y - 0.08 * pu.size, r2 * pu.size, 0.67 * Math.PI, -0.28 * Math.PI, true);
+                ctx.closePath();
+                ctx.fill();
+                break;
+            case 3:
+                set_font_style(ctx, alp1 * pu.size.toString(10), 10);
+                ctx.text("💡", x, y, alp2 * pu.size, this.size * alp3);
+                break;
+            case 4:
+                set_font_style(ctx, alp1 * pu.size.toString(10), 10);
+                ctx.text("💣", x, y, alp2 * pu.size, this.size * alp3);
+                break;
+        }
+    }
+
+    draw_sudokuetc(ctx, num, x, y, ccolor) {
+        switch (num) {
+            case 1:
+                var r = 0.14;
+                ctx.strokeStyle = Color.TRANSPARENTBLACK;
+                ctx.fillStyle = ccolor || Color.GREY_LIGHT;
+                this.draw_polygon(ctx, x - r * pu.size, y + r * pu.size, r * Math.sqrt(2), 4, 45);
+                this.draw_polygon(ctx, x + r * pu.size, y - r * pu.size, r * Math.sqrt(2), 4, 45);
+                ctx.fillStyle = Color.GREY_DARK;
+                this.draw_polygon(ctx, x - r * pu.size, y - r * pu.size, r * Math.sqrt(2), 4, 45);
+                this.draw_polygon(ctx, x + r * pu.size, y + r * pu.size, r * Math.sqrt(2), 4, 45);
+                break;
+            case 2:
+                ctx.setLineDash([]);
+                ctx.lineCap = "butt";
+                ctx.fillStyle = Color.TRANSPARENTBLACK;
+                ctx.strokeStyle = ccolor || Color.GREY_LIGHT;
+                ctx.lineWidth = 4;
+                this.draw_circle(ctx, x, y, 0.71);
+                break;
+            case 3:
+                var r = 0.99;
+                set_circle_style(ctx, 3, ccolor);
+                ctx.beginPath();
+                ctx.moveTo(x, y + r * pu.size);
+                ctx.lineTo(x + r * pu.size, y);
+                ctx.lineTo(x, y - r * pu.size);
+                ctx.lineTo(x - r * pu.size, y);
+                ctx.closePath();
+                ctx.fill();
+                break;
+            case 4:
+                var r = 0.2 * pu.size;
+                var w = 1.8 * pu.size;
+                var h = 0.8 * pu.size;
+                x = x - 0.40 * pu.size;
+                y = y - 0.40 * pu.size;
+                ctx.lineCap = "butt";
+                ctx.lineWidth = 2;
+                ctx.setLineDash([]);
+                ctx.fillStyle = Color.TRANSPARENTBLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
+                ctx.beginPath()
+                ctx.moveTo(x + r, y);
+                ctx.lineTo(x + w - r, y);
+                ctx.arcTo(x + w, y, x + w, y + r, r);
+                ctx.lineTo(x + w, y + h - r);
+                ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+                ctx.lineTo(x + r, y + h);
+                ctx.arcTo(x, y + h, x, y + h - r, r);
+                ctx.lineTo(x, y + r);
+                ctx.arcTo(x, y, x + r, y, r);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            case 5:
+                var r = 0.2 * pu.size;
+                var w = 0.8 * pu.size;
+                var h = 1.8 * pu.size;
+                x = x - 0.40 * pu.size;
+                y = y - 0.40 * pu.size;
+                ctx.lineCap = "butt";
+                ctx.lineWidth = 2;
+                ctx.setLineDash([]);
+                ctx.fillStyle = Color.TRANSPARENTBLACK;
+                ctx.strokeStyle = ccolor || Color.BLACK;
+                ctx.beginPath()
+                ctx.moveTo(x + r, y);
+                ctx.lineTo(x + w - r, y);
+                ctx.arcTo(x + w, y, x + w, y + r, r);
+                ctx.lineTo(x + w, y + h - r);
+                ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+                ctx.lineTo(x + r, y + h);
+                ctx.arcTo(x, y + h, x, y + h - r, r);
+                ctx.lineTo(x, y + r);
+                ctx.arcTo(x, y, x + r, y, r);
+                ctx.closePath();
+                ctx.stroke();
+                break;
+        }
+    }
+
+    draw_polyomino(ctx, num, x, y, ccolor) {
+        ctx.setLineDash([]);
+        ctx.fillStyle = ccolor || Color.GREY_LIGHT;
+        ctx.strokeStyle = Color.BLACK;
+        ctx.lineWidth = 1.2;
+        ctx.lineCap = "butt";
+        var r = 0.25;
+        for (var i = 0; i < 9; i++) {
+            if (num[i] === 1) {
+                this.draw_polygon(ctx, x + (i % 3 - 1) * r * pu.size, y + ((i / 3 | 0) - 1) * r * pu.size, r * 0.5 * Math.sqrt(2), 4, 45);
+            }
+        }
+    }
+
+    rotate_theta(th) {
+        th = (th + this.theta);
+        if (this.reflect[0] === -1) { th = (180 - th + 360) % 360; }
+        if (this.reflect[1] === -1) { th = (360 - th + 360) % 360; }
+        th = th / 180 * Math.PI;
+        return th;
+    }
+}

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -6784,7 +6784,7 @@ class Puzzle_penrose_P3 extends Puzzle {
         //盤面情報
         super('penrose_P3');
         this.nx = side;
-        this.ny = side;
+        this.ny = order;
         this.nx0 = this.nx + 2;
         this.ny0 = this.ny + 2;
         this.margin = -1; //for arrow of number pointing outside of the grid
@@ -6796,7 +6796,7 @@ class Puzzle_penrose_P3 extends Puzzle {
         // aperiodic tiling, the sum of all values should be an integer.
         this.grid_offset = Array(this.ngrids).fill(1/this.ngrids);
         this.width0 = this.nx;
-        this.height0 = this.ny;
+        this.height0 = this.nx;
         this.width_c = this.width0;
         this.height_c = this.height0;
         this.width = this.width_c;
@@ -6824,8 +6824,8 @@ class Puzzle_penrose_P3 extends Puzzle {
 
     create_point() {
 	const PI = Math.PI;
-	const pixel_sqradius = (this.nx*this.ny*this.size*this.size)
-	const pixel_sqradius0 = (this.nx0*this.ny0*this.size*this.size)
+	const pixel_sqradius = (this.nx*this.nx*this.size*this.size)
+	const pixel_sqradius0 = (this.nx0*this.nx0*this.size*this.size)
 
 	// Compute the identity of the next tile in the tiling,
 	// using a de Bruijn grid.
@@ -7074,7 +7074,7 @@ class Puzzle_penrose_P3 extends Puzzle {
 
         this.make_frameline();
         this.cursol = this.centerlist[0];
-        this.cursolS = 4 * (this.nx0) * (this.ny0) + 4 + 4 * (this.nx0);
+        this.cursolS = 4 * (this.nx0) * (this.nx0) + 4 + 4 * (this.nx0);
     }
 
     search_center() {
@@ -7289,12 +7289,12 @@ class Puzzle_penrose_P3 extends Puzzle {
 
     cursolcheck() {
         if (this.mode[this.mode.qa].edit_mode === "number" && this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
-            if (this.cursolS > 8 * (this.nx0) * (this.ny0)) {
-                this.cursolS -= 4 * (this.nx0) * (this.ny0);
+            if (this.cursolS > 8 * (this.nx0) * (this.nx0)) {
+                this.cursolS -= 4 * (this.nx0) * (this.nx0);
             }
         } else if (this.mode[this.mode.qa].edit_mode === "number" && this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
-            if (this.cursolS < 8 * (this.nx0) * (this.ny0)) {
-                this.cursolS += 4 * (this.nx0) * (this.ny0);
+            if (this.cursolS < 8 * (this.nx0) * (this.nx0)) {
+                this.cursolS += 4 * (this.nx0) * (this.nx0);
             }
         }
     }

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -251,7 +251,8 @@ function make_class(gridtype, loadtype = 'new') {
         'snub': 20,
         'cairo': 20,
         'rhombitrihex': 20,
-        'deltoidal': 20
+        'deltoidal': 20,
+        'penrose': 20
     }; // also defined in class_p.js
     switch (gridtype) {
         case "square":
@@ -542,6 +543,19 @@ function make_class(gridtype, loadtype = 'new') {
                 errorMsg(PenpaText.get('size_warning_generic', gridmax['deltoidal']));
             }
             break;
+        case "penrose_P3":
+            var n0 = parseInt(document.getElementById("nb_size1").value, 10);
+            var order = parseInt(document.getElementById("nb_size2").value, 10);
+            if (n0 <= gridmax['penrose'] && n0 > 0) {
+                if (order >= 4 && order <= 30) {
+                  pu = new Puzzle_penrose_P3(n0, order, size);
+                } else {
+                  errorMsg(PenpaText.get('order_warning_generic', 30));
+		}
+            } else {
+                errorMsg(PenpaText.get('size_warning_generic', gridmax['penrose']));
+            }
+            break;
     }
     return pu;
 }
@@ -577,6 +591,7 @@ function changetype() {
                 document.getElementById(i).style.display = "none";
             }
             document.getElementById("name_size1").innerHTML = PenpaText.get('columns');
+            document.getElementById("name_size2").innerHTML = PenpaText.get('rows');
             document.getElementById("name_space1").innerHTML = PenpaText.get('over');
             document.getElementById("nb_sudoku3_lb").style.display = "inline";
             document.getElementById("nb_sudoku3_lb").innerHTML = PenpaText.get('nb_sudoku3_lb_sqaure');
@@ -709,6 +724,7 @@ function changetype() {
                 document.getElementById(i).style.display = "inline";
             }
             document.getElementById("name_size1").innerHTML = PenpaText.get('columns');
+            document.getElementById("name_size2").innerHTML = PenpaText.get('rows');
             document.getElementById("nb_size1").value = 10;
             document.getElementById("nb_size2").value = 10;
             break;
@@ -770,6 +786,7 @@ function changetype() {
             document.getElementById("nb_sudoku3_lb").innerHTML = "<span style='color: red;'>" + PenpaText.get('alpha_warning') + "</span>";
             document.getElementById("nb_size1").value = 4;
             document.getElementById("nb_size3").value = 38;
+            break;
         case "cairo_pentagonal":
             for (var i of type) {
                 document.getElementById(i).style.display = "none";
@@ -789,6 +806,7 @@ function changetype() {
             document.getElementById("nb_sudoku3_lb").innerHTML = "<span style='color: red;'>" + PenpaText.get('alpha_warning') + "</span>";
             document.getElementById("nb_size1").value = 4;
             document.getElementById("nb_size3").value = 38;
+            break;
         case "rhombitrihexagonal":
             for (var i of type) {
                 document.getElementById(i).style.display = "none";
@@ -808,6 +826,7 @@ function changetype() {
             document.getElementById("nb_sudoku3_lb").innerHTML = "<span style='color: red;'>" + PenpaText.get('alpha_warning') + "</span>";
             document.getElementById("nb_size1").value = 4;
             document.getElementById("nb_size3").value = 38;
+            break;
         case "deltoidal_trihexagonal":
             for (var i of type) {
                 document.getElementById(i).style.display = "none";
@@ -827,6 +846,33 @@ function changetype() {
             document.getElementById("nb_sudoku3_lb").innerHTML = "<span style='color: red;'>" + PenpaText.get('alpha_warning') + "</span>";
             document.getElementById("nb_size1").value = 4;
             document.getElementById("nb_size3").value = 38;
+            break;
+        case "penrose_P3":
+            for (var i of type) {
+                document.getElementById(i).style.display = "none";
+            }
+            for (var i of type2) {
+                document.getElementById(i).style.display = "none";
+            }
+            for (var i of type3) {
+                document.getElementById(i).style.display = "none";
+            }
+            for (var i of type4) {
+                document.getElementById(i).style.display = "none";
+            }
+            for (var i of type5) {
+                document.getElementById(i).style.display = "inline";
+            }
+            document.getElementById("name_size1").innerHTML = PenpaText.get('side');
+            document.getElementById("name_size2").innerHTML = PenpaText.get('order');
+            document.getElementById("nb_space_lb").style.display = "none";
+            document.getElementById("nb_size1").value = 4;
+            document.getElementById("nb_size2").value = 5;
+            document.getElementById("nb_sudoku3_lb").style.display = "inline";
+            document.getElementById("nb_sudoku3_lb").innerHTML = "<span style='color: red;'>" + PenpaText.get('alpha_warning') + "</span>";
+            document.getElementById("nb_size1").value = 4;
+            document.getElementById("nb_size3").value = 38;
+            break;
     }
 }
 

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -741,4 +741,57 @@ const penpa_modes = {
         // unique IDs that doesn't follow regular id naming
         'exceptions': ['custom_color_lb']
     },
+    'penrose_P3': {
+        //modes
+        'mode': ['surface', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board', 'move'],
+        //submodes
+        'sub': ['line1', 'line3', 'line4',
+            'lineE1', 'lineE3', 'lineE4', 'lineE5',
+            'number1', 'number10', 'number6', 'number5', 'number7', 'number4', 'number2', 'number8',
+            'specialpolygon',
+            'cage2', 'move1', 'move2', 'move3',
+            'sudoku1', 'sudoku3'
+        ],
+        //composite modes
+        'combisub': ['blpo', 'blwh',
+            'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
+            'edgesub',
+            'star', 'tents', 'magnets', 'mines', 'akari',
+            'numfl', 'alfl'
+        ],
+        //composite mode headers
+        'subcombi': ['subc1', 'subc2', 'subc3', 'subc4'],
+        'shapemodes': ['ms1', 'ms2', 'ms3', 'ms5'],
+        // shapes
+        'ms': ['cross', 'line', 'frameline', 'inequality', 'degital_f', 'dice', 'pills',
+            'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight',
+            'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
+            'angleloop', 'firefly', 'sun_moon'
+        ],
+        'ms1': ['circle', 'square', 'triup', 'tridown', 'diamond', 'hexpoint', 'hexflat', 'ox'],
+        'ms3': ['math', 'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP'],
+        'ms4': [],
+        // styles
+        'st': ['surface1', 'surface8', 'surface3', 'surface4', 'surface2', 'surface5', 'surface6', 'surface7', 'surface9', 'surface10', 'surface11', 'surface12',
+            'line3', 'line2', 'line5', 'line8', 'line9', 'line80', 'line12', 'line13', 'line40', 'line30',
+            'lineE3', 'lineE2', 'lineE5', 'lineE8', 'lineE9', 'lineE21', 'lineE80', 'lineE12', 'lineE13', 'lineE30',
+            'wall3', 'wall2', 'wall5', 'wall8', 'wall9', 'wall1', 'wall12', 'wall17', 'wall14',
+            'number1', 'number2', 'number8', 'number3', 'number9', 'number10', 'number4', 'number0', 'number6', 'number7', 'number11', 'number5',
+            'symbol1', 'symbol2',
+            'cage10', 'cage7', 'cage15', 'cage16',
+            'sudoku1', 'sudoku2', 'sudoku8', 'sudoku3', 'sudoku9', 'sudoku10'
+        ],
+        'li': ['battleship', 'kakuro', 'tents', 'star', 'compass', 'sudokuetc', 'sudokumore', 'polyomino',
+            'linex', 'lineox', 'edgex', 'edgexoi', 'yajilin', 'hashi',
+            'circle', 'square', 'triup', 'tridown', 'triright', 'trileft', 'diamond', 'hexpoint', 'hexflat', 'ox', 'cross', 'line', 'frameline', 'bars', 'tri',
+            'circle_L', 'circle_M', 'circle_S', 'circle_SS', 'square_LL', 'square_L', 'square_M', 'square_S', 'square_SS',
+            'arrow_B', 'arrow_N', 'arrow_tri', 'arrow_GP', 'arrow_fouredge', 'arrow_Short', 'arrow_S', 'arrow_cross', 'arrow_eight', 'arrow_fourtip'
+        ],
+        'symmode': ['content'],
+        'combimode': ['content'],
+        'customcolor': ['line', 'lineE', 'surface', 'special', 'symbol'],
+        'top_buttons': ['rotation'],
+        // unique IDs that doesn't follow regular id naming
+        'exceptions': ['custom_color_lb']
+    },
 };

--- a/docs/js/translate.js
+++ b/docs/js/translate.js
@@ -435,6 +435,7 @@ const PenpaText = {
         'nb_gridtype11_lb',
         'nb_gridtype12_lb',
         'nb_gridtype13_lb',
+        'nb_gridtype14_lb',
         'nb_rules_lb',
         'nb_title_lb',
         'settings_modal_header',
@@ -517,6 +518,7 @@ const PenpaText = {
         sides: { EN: "Sides:", JP: '横：' },
         over: { EN: "Over:", JP: '上：' },
         border: { EN: "Border:", JP: '境界：' },
+        order: { EN: "Order:" },
 
         nb_gridtype8_lb: { EN: 'Tetrakis square' },
         nb_gridtype9_lb: { EN: 'Truncated square' },
@@ -524,6 +526,7 @@ const PenpaText = {
         nb_gridtype11_lb: { EN: 'Cairo pentagonal' },
         nb_gridtype12_lb: { EN: 'Rhombitrihexagonal' },
         nb_gridtype13_lb: { EN: 'Deltoidal trihexagonal' },
+        nb_gridtype14_lb: { EN: 'Penrose P3' },
 
         // Generic Terms
         on: { EN: "ON" },
@@ -827,6 +830,9 @@ const PenpaText = {
         size_warning_generic: {
             EN: 'Side Size must be in the range <h2 class="warn">1-$v</h2>',
             JP: '一辺の大きさは以下の範囲です <h2 class="warn">1-$v</h2>'
+        },
+        order_warning_generic: {
+            EN: 'Order must be in the range <h2 class="warn">4-$v</h2>',
         },
 
         alpha_warning: {


### PR DESCRIPTION
This adds basic support for Penrose rhombus tilings. You can change the default 5-fold symmetry to higher-order equivalent (e.g. 7-fold).

Like with the other tilings already marked as "alpha", some of the detailed support for specific puzzle types is lacking at the moment. But at least connectivity of cells/edges/vertices works. Cursor key navigation in number mode is also supported.