### PR TITLE
fix: PenpaText not called correctly and issues with constraints in minesweeper and akari

### DIFF
--- a/docs/js/constraints.js
+++ b/docs/js/constraints.js
@@ -224,7 +224,7 @@ const penpa_constraints = {
             "show": ["mo_surface_lb",
                 "mo_number_lb", "sub_number1_lb",
                 "mo_combi_lb", "subc4", "combisub_mines", "combili_mines",
-                "mo_symbol_lb", "ms5", "li_sun_moon", "ms_sun_moon"
+                "mo_symbol_lb", "ms5", "ms_sun_moon"
             ],
             "modeset": ["number", "symbol", "combi"],
             "submodeset": ["1", "sun_moon", "mines"],
@@ -234,7 +234,7 @@ const penpa_constraints = {
             "show": ["mo_surface_lb",
                 "mo_lineE_lb", "sub_lineE1_lb", "sub_lineE2_lb", "sub_lineE5_lb",
                 "mo_combi_lb", "subc4", "combisub_akari", "combili_akari",
-                "mo_symbol_lb", "ms5", "li_sun_moon", "ms_sun_moon"
+                "mo_symbol_lb", "ms5", "ms_sun_moon"
             ],
             "modeset": ["symbol", "combi"],
             "submodeset": ["sun_moon", "akari"],

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -1601,7 +1601,7 @@ function savetext_copy() {
     }
 
     // This needs to go after the copy takes place or else some browsers will not allow the copy.
-    infoMsg('<h2 class="info">' + PenpaText('copied_success') + '</h2>');
+    infoMsg('<h2 class="info">' + PenpaText.get('copied_success') + '</h2>');
 }
 
 function savetext_download() {


### PR DESCRIPTION
In this PR, two tiny issues are fixed:

- PenpaText in copying URLs: `PenpaText('copied_success')` is changed to `PenpaText.get('copied_success')`
- Constraints in minesweeper and akari: the unexisted `li_sun_moon` id is removed to make these constraints work
