### PR TITLE
fix: penpalite buttons are misaligned after new board creation

### DIFF
--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -196,6 +196,9 @@ function create_newboard() {
         pu = make_class(gridtype);
         pu.mode = mode;
 
+        // reset the penpa lite states
+        advancecontrol_toggle("off");
+
         // update mode defaults for special grids
         if (!(gridtype === "square" || gridtype === "sudoku" || gridtype === "kakuro")) {
             pu.mode["pu_q"]["combi"] = ["linex", ""];


### PR DESCRIPTION
This PR will fix an issue where the penpalite buttons are misaligned after new board creation by invoking `advancecontrol_toggle("off")`.