### PR TITLE
Fix connectivity of snub-square and Cairo grids; fixes #84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## History
+* unreleased
+	* Fix for right edge of Cairo pentagonal grids.
 * 2024/07/16 ver 3.1.4
 	* Code refactoring.
 	* Added non-alphanumeric genre tag to allow answer check on non-alphanumeric characters.

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -3293,7 +3293,7 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
                         point[k - 17].neighbor = point[k - 17].neighbor.concat([k]);
                         point[k - 20].neighbor = point[k - 20].neighbor.concat([k]);
                     } else {
-                        point[k - 11].neighbor = point[k - 11].neighbor.concat([k]);
+                        point[k - 21].neighbor = point[k - 21].neighbor.concat([k]);
                         point[k - 20].neighbor = point[k - 20].neighbor.concat([k]);
                     }
                     k++;
@@ -3905,7 +3905,7 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
                         point[k - 17].neighbor = point[k - 17].neighbor.concat([k]);
                         point[k - 20].neighbor = point[k - 20].neighbor.concat([k]);
                     } else {
-                        point[k - 11].neighbor = point[k - 11].neighbor.concat([k]);
+                        point[k - 21].neighbor = point[k - 21].neighbor.concat([k]);
                         point[k - 20].neighbor = point[k - 20].neighbor.concat([k]);
                     }
                     k++;


### PR DESCRIPTION
The grid generation `create_point()` methods should ideally be rewritten in future as they're slow (making it impractical to generate very large grids on small devices) as well as hard to understand.

But in the interest of making small, testable PRs, I contented myself with directly fixing the bug :)