### PR TITLE
Faster create_point() for the grids in class_uniform.js (that is, the semiregular/Archimedean ones)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## History
+* unreleased
+    * Faster grid generation for tetrakis square, truncated square, snub square, Cairo pentagonal, rhombitrihexagonal and deltoidal trihexagonal grids.
 * 2024/07/16 ver 3.1.4
 	* Code refactoring.
 	* Added non-alphanumeric genre tag to allow answer check on non-alphanumeric characters.

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -101,21 +101,32 @@ class Puzzle_truncated_square extends Puzzle {
             }
         }
         // 重複判定
+        var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
             if (!point[i]) { continue; };
+            if (typeof renumber[i] !== "undefined") { continue; };
+            renumber[i] = i;
             for (var j = i + 1; j < point.length; j++) {
                 if (!point[j]) { continue; };
                 if ((point[i].x - point[j].x) ** 2 + (point[i].y - point[j].y) ** 2 < 0.01) {
+                    renumber[j] = i;
+                }
+            }
+        }
                     //surround,neighbor置換
                     for (var k = 0; k < point.length; k++) {
                         if (!point[k]) { continue; };
                         for (var n = 0; n < point[k].surround.length; n++) {
-                            if (point[k].surround[n] === j) {
+                            let j = point[k].surround[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 point[k].surround.splice(n, 1, i);
                             }
                         }
                         for (var n = 0; n < point[k].neighbor.length; n++) {
-                            if (point[k].neighbor[n] === j) {
+                            let j = point[k].neighbor[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 if (point[k].neighbor.indexOf(i) === -1) {
                                     point[k].neighbor.splice(n, 1, i); //無ければ置き換え
                                 } else {
@@ -124,16 +135,19 @@ class Puzzle_truncated_square extends Puzzle {
                             }
                         }
                     }
-                    for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
-                        if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
-                            point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
-                        }
-                    }
-                    if (point[i].use === -1 && point[j].use === 1) { point[i].use = 1; };
-                    delete point[j];
-                    //置換ここまで
+        for (var j = 0; j < point.length; j++) {
+            if (!point[j]) { continue; };
+            let i = renumber[j];
+            if (i == j) { continue; };
+            if (typeof i === "undefined") { continue; };
+            for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
+                if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
+                    point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
                 }
             }
+            if (point[i].use === -1 && point[j].use === 1) { point[i].use = 1; };
+            delete point[j];
+            //置換ここまで
         }
         // adjacent作成
         for (var i = 0; i < point.length; i++) {
@@ -2714,21 +2728,32 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
             }
         }
         // 重複判定
+        var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
             if (!point[i]) { continue; };
+            if (typeof renumber[i] !== "undefined") { continue; };
+            renumber[i] = i;
             for (var j = i + 1; j < point.length; j++) {
                 if (!point[j]) { continue; };
                 if ((point[i].x - point[j].x) ** 2 + (point[i].y - point[j].y) ** 2 < 0.01) {
+                    renumber[j] = i;
+                }
+            }
+        }
                     //surround,neighbor置換
                     for (var k = 0; k < point.length; k++) {
                         if (!point[k]) { continue; };
                         for (var n = 0; n < point[k].surround.length; n++) {
-                            if (point[k].surround[n] === j) {
+                            let j = point[k].surround[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 point[k].surround.splice(n, 1, i);
                             }
                         }
                         for (var n = 0; n < point[k].neighbor.length; n++) {
-                            if (point[k].neighbor[n] === j) {
+                            let j = point[k].neighbor[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 if (point[k].neighbor.indexOf(i) === -1) {
                                     point[k].neighbor.splice(n, 1, i); //無ければ置き換え
                                 } else {
@@ -2737,20 +2762,23 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                             }
                         }
                     }
-                    for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
-                        if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
-                            point[i].surround = point[i].surround.concat([point[j].surround[n]]);
-                        }
-                    }
-                    for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
-                        if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
-                            point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
-                        }
-                    }
-                    delete point[j];
-                    //置換ここまで
+        for (var j = 0; j < point.length; j++) {
+            if (!point[j]) { continue; };
+            let i = renumber[j];
+            if (i == j) { continue; };
+            if (typeof i === "undefined") { continue; };
+            for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
+                if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
+                    point[i].surround = point[i].surround.concat([point[j].surround[n]]);
                 }
             }
+            for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
+                if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
+                    point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
+                }
+            }
+            delete point[j];
+            //置換ここまで
         }
         // adjacent作成
         for (var i = 0; i < point.length; i++) {
@@ -3360,21 +3388,32 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
             }
         }
         // 重複判定
+        var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
             if (!point[i]) { continue; };
+            if (typeof renumber[i] !== "undefined") { continue; };
+            renumber[i] = i;
             for (var j = i + 1; j < point.length; j++) {
                 if (!point[j]) { continue; };
                 if ((point[i].x - point[j].x) ** 2 + (point[i].y - point[j].y) ** 2 < 0.01) {
+                    renumber[j] = i;
+                }
+            }
+        }
                     //surround,neighbor置換
                     for (var k = 0; k < point.length; k++) {
                         if (!point[k]) { continue; };
                         for (var n = 0; n < point[k].surround.length; n++) {
-                            if (point[k].surround[n] === j) {
+                            let j = point[k].surround[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 point[k].surround.splice(n, 1, i);
                             }
                         }
                         for (var n = 0; n < point[k].neighbor.length; n++) {
-                            if (point[k].neighbor[n] === j) {
+                            let j = point[k].neighbor[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 if (point[k].neighbor.indexOf(i) === -1) {
                                     point[k].neighbor.splice(n, 1, i); //無ければ置き換え
                                 } else {
@@ -3383,20 +3422,23 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
                             }
                         }
                     }
-                    for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
-                        if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
-                            point[i].surround = point[i].surround.concat([point[j].surround[n]]);
-                        }
-                    }
-                    for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
-                        if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
-                            point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
-                        }
-                    }
-                    delete point[j];
-                    //置換ここまで
+        for (var j = 0; j < point.length; j++) {
+            if (!point[j]) { continue; };
+            let i = renumber[j];
+            if (i == j) { continue; };
+            if (typeof i === "undefined") { continue; };
+            for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
+                if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
+                    point[i].surround = point[i].surround.concat([point[j].surround[n]]);
                 }
             }
+            for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
+                if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
+                    point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
+                }
+            }
+            delete point[j];
+            //置換ここまで
         }
         // adjacent作成
         for (var i = 0; i < point.length; i++) {
@@ -3972,21 +4014,32 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
             }
         }
         // 重複判定
+        var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
             if (!point[i]) { continue; };
+            if (typeof renumber[i] !== "undefined") { continue; };
+            renumber[i] = i;
             for (var j = i + 1; j < point.length; j++) {
                 if (!point[j]) { continue; };
                 if ((point[i].x - point[j].x) ** 2 + (point[i].y - point[j].y) ** 2 < 0.01) {
+                    renumber[j] = i;
+                }
+            }
+        }
                     //surround,neighbor置換
                     for (var k = 0; k < point.length; k++) {
                         if (!point[k]) { continue; };
                         for (var n = 0; n < point[k].surround.length; n++) {
-                            if (point[k].surround[n] === j) {
+                            let j = point[k].surround[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 point[k].surround.splice(n, 1, i);
                             }
                         }
                         for (var n = 0; n < point[k].neighbor.length; n++) {
-                            if (point[k].neighbor[n] === j) {
+                            let j = point[k].neighbor[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 if (point[k].neighbor.indexOf(i) === -1) {
                                     point[k].neighbor.splice(n, 1, i); //無ければ置き換え
                                 } else {
@@ -3995,20 +4048,23 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
                             }
                         }
                     }
-                    for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
-                        if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
-                            point[i].surround = point[i].surround.concat([point[j].surround[n]]);
-                        }
-                    }
-                    for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
-                        if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
-                            point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
-                        }
-                    }
-                    delete point[j];
-                    //置換ここまで
+        for (var j = 0; j < point.length; j++) {
+            if (!point[j]) { continue; };
+            let i = renumber[j];
+            if (i == j) { continue; };
+            if (typeof i === "undefined") { continue; };
+            for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
+                if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
+                    point[i].surround = point[i].surround.concat([point[j].surround[n]]);
                 }
             }
+            for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
+                if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
+                    point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
+                }
+            }
+            delete point[j];
+            //置換ここまで
         }
         // adjacent作成
         for (var i = 0; i < point.length; i++) {
@@ -4549,21 +4605,32 @@ class Puzzle_iso extends Puzzle_truncated_square {
         }
 
         // 重複判定
+        var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
             if (!point[i]) { continue; };
+            if (typeof renumber[i] !== "undefined") { continue; };
+            renumber[i] = i;
             for (var j = i + 1; j < point.length; j++) {
                 if (!point[j]) { continue; };
                 if ((point[i].x - point[j].x) ** 2 + (point[i].y - point[j].y) ** 2 < 0.01) {
+                    renumber[j] = i;
+                }
+            }
+        }
                     //surround,neighbor置換
                     for (var k = 0; k < point.length; k++) {
                         if (!point[k]) { continue; };
                         for (var n = 0; n < point[k].surround.length; n++) {
-                            if (point[k].surround[n] === j) {
+                            let j = point[k].surround[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 point[k].surround.splice(n, 1, i);
                             }
                         }
                         for (var n = 0; n < point[k].neighbor.length; n++) {
-                            if (point[k].neighbor[n] === j) {
+                            let j = point[k].neighbor[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 if (point[k].neighbor.indexOf(i) === -1) {
                                     point[k].neighbor.splice(n, 1, i); //無ければ置き換え
                                 } else {
@@ -4577,25 +4644,28 @@ class Puzzle_iso extends Puzzle_truncated_square {
                             }
                         }
                     }
-                    for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
-                        if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
-                            point[i].surround = point[i].surround.concat([point[j].surround[n]]);
-                        }
-                    }
-                    for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
-                        if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
-                            point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
-                        }
-                    }
-                    for (var n = 0; n < point[j].adjacent_dia.length; n++) { //削除された点のadjacent_diaを移し替え
-                        if (point[i].adjacent_dia.indexOf(point[j].adjacent_dia[n]) === -1) {
-                            point[i].adjacent_dia = point[i].adjacent_dia.concat([point[j].adjacent_dia[n]]);
-                        }
-                    }
-                    delete point[j];
-                    //置換ここまで
+        for (var j = 0; j < point.length; j++) {
+            if (!point[j]) { continue; };
+            let i = renumber[j];
+            if (i == j) { continue; };
+            if (typeof i === "undefined") { continue; };
+            for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
+                if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
+                    point[i].surround = point[i].surround.concat([point[j].surround[n]]);
                 }
             }
+            for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
+                if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
+                    point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
+                }
+            }
+            for (var n = 0; n < point[j].adjacent_dia.length; n++) { //削除された点のadjacent_diaを移し替え
+                if (point[i].adjacent_dia.indexOf(point[j].adjacent_dia[n]) === -1) {
+                    point[i].adjacent_dia = point[i].adjacent_dia.concat([point[j].adjacent_dia[n]]);
+                }
+            }
+            delete point[j];
+            //置換ここまで
         }
         // adjacent作成
         for (var i = 0; i < point.length; i++) {
@@ -5713,21 +5783,32 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
 
 
         // 重複判定
+        var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
             if (!point[i]) { continue; };
+            if (typeof renumber[i] !== "undefined") { continue; };
+            renumber[i] = i;
             for (var j = i + 1; j < point.length; j++) {
                 if (!point[j]) { continue; };
                 if ((point[i].x - point[j].x) ** 2 + (point[i].y - point[j].y) ** 2 < 0.01) {
+                    renumber[j] = i;
+                }
+            }
+        }
                     //surround,neighbor置換
                     for (var k = 0; k < point.length; k++) {
                         if (!point[k]) { continue; };
                         for (var n = 0; n < point[k].surround.length; n++) {
-                            if (point[k].surround[n] === j) {
+                            let j = point[k].surround[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 point[k].surround.splice(n, 1, i);
                             }
                         }
                         for (var n = 0; n < point[k].neighbor.length; n++) {
-                            if (point[k].neighbor[n] === j) {
+                            let j = point[k].neighbor[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 if (point[k].neighbor.indexOf(i) === -1) {
                                     point[k].neighbor.splice(n, 1, i); //無ければ置き換え
                                 } else {
@@ -5736,20 +5817,23 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
                             }
                         }
                     }
-                    for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
-                        if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
-                            point[i].surround = point[i].surround.concat([point[j].surround[n]]);
-                        }
-                    }
-                    for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
-                        if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
-                            point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
-                        }
-                    }
-                    delete point[j];
-                    //置換ここまで
+        for (var j = 0; j < point.length; j++) {
+            if (!point[j]) { continue; };
+            let i = renumber[j];
+            if (i == j) { continue; };
+            if (typeof i === "undefined") { continue; };
+            for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
+                if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
+                    point[i].surround = point[i].surround.concat([point[j].surround[n]]);
                 }
             }
+            for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
+                if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
+                    point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
+                }
+            }
+            delete point[j];
+            //置換ここまで
         }
 
         // adjacent作成
@@ -6342,21 +6426,32 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
 
 
         // 重複判定
+        var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
             if (!point[i]) { continue; };
+            if (typeof renumber[i] !== "undefined") { continue; };
+            renumber[i] = i;
             for (var j = i + 1; j < point.length; j++) {
                 if (!point[j]) { continue; };
                 if ((point[i].x - point[j].x) ** 2 + (point[i].y - point[j].y) ** 2 < 0.01) {
+                    renumber[j] = i;
+                }
+            }
+        }
                     //surround,neighbor置換
                     for (var k = 0; k < point.length; k++) {
                         if (!point[k]) { continue; };
                         for (var n = 0; n < point[k].surround.length; n++) {
-                            if (point[k].surround[n] === j) {
+                            let j = point[k].surround[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 point[k].surround.splice(n, 1, i);
                             }
                         }
                         for (var n = 0; n < point[k].neighbor.length; n++) {
-                            if (point[k].neighbor[n] === j) {
+                            let j = point[k].neighbor[n];
+                            let i = renumber[j];
+                            if (i != j) {
                                 if (point[k].neighbor.indexOf(i) === -1) {
                                     point[k].neighbor.splice(n, 1, i); //無ければ置き換え
                                 } else {
@@ -6365,20 +6460,23 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
                             }
                         }
                     }
-                    for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
-                        if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
-                            point[i].surround = point[i].surround.concat([point[j].surround[n]]);
-                        }
-                    }
-                    for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
-                        if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
-                            point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
-                        }
-                    }
-                    delete point[j];
-                    //置換ここまで
+        for (var j = 0; j < point.length; j++) {
+            if (!point[j]) { continue; };
+            let i = renumber[j];
+            if (i == j) { continue; };
+            if (typeof i === "undefined") { continue; };
+            for (var n = 0; n < point[j].surround.length; n++) { //削除された点のsurroundを移し替え
+                if (point[i].surround.indexOf(point[j].surround[n]) === -1) {
+                    point[i].surround = point[i].surround.concat([point[j].surround[n]]);
                 }
             }
+            for (var n = 0; n < point[j].neighbor.length; n++) { //削除された点のneighborを移し替え
+                if (point[i].neighbor.indexOf(point[j].neighbor[n]) === -1) {
+                    point[i].neighbor = point[i].neighbor.concat([point[j].neighbor[n]]);
+                }
+            }
+            delete point[j];
+            //置換ここまで
         }
 
         // adjacent作成


### PR DESCRIPTION
The class_uniform.js grids are generated using an extremely slow algorithm that creates a lot of duplicate points and then tries to merge them. The slowest part of this for large grids is the merge algorithm, which was O(N^3) in the number of points. This PR replaces it with an O(N^2) algorithm. On my setup it speeds up the generation of the largest grids (20x20 setting) by a factor of about 3.

In reality, generation of these grids should be possible in linear or quasilinear time; however, to achieve that, all of the grid generation code has to be rewritten while retaining the exact numbering of all points to maintain compatibility with pre-existing puzzles. That might be complicated, especially to test and review; so I thought it was worth making this relatively simple change to improve the worst performance.

