### PR TITLE
fix: avoid loading the theme css repeatedly

### DIFF
--- a/docs/js/settings.js
+++ b/docs/js/settings.js
@@ -275,6 +275,9 @@ const UserSettings = {
     },
     set color_theme(newValue) {
         const valueInt = newValue ? parseInt(newValue, 10) : THEME_LIGHT;
+        if (this._color_theme === valueInt)
+            return;  // avoid loading the theme css repeatedly
+
         this._color_theme = valueInt;
 
         let themeStylesheet = this._theme_urls[valueInt];


### PR DESCRIPTION
The `color_theme` css is fetched from the Internet every time when the user loads a URL, and this may degrade the performance when someone needs to load lots of URLs. A workaround is to avoid the process in `set color_theme` (in `settings.js`):

```js
    set color_theme(newValue) {
        const valueInt = newValue ? parseInt(newValue, 10) : THEME_LIGHT;
        if (this._color_theme === valueInt)
            return;  // this will avoid loading the theme css repeatedly

        ...

        document.getElementById("theme_mode_opt").value = valueInt;
        if (style_tag_cache['color_theme']) {
            style_tag_cache['color_theme'].href = themeStylesheet;  // this line will fetch the css
        } else {
            console.error('Could not find color theme stylesheet to change.');
        }

        ...
    }
```

In most cases, the user will not switch the theme constantly, so many fetches will be saved.

