### PR TITLE
Resize menu improvements

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1074,6 +1074,10 @@
                     <button class="addbottom" id="rt_addbottom">+ &#9660;</button>
                     <button class="subbottom" id="rt_subbottom">&ndash; &#9650;</button>
                 </div>
+                <p>
+                    <span id="resize_whitespace_button0" class="label_mode">Adjust only whitespace:</span>
+                    <span id="resize_whitespace_button" class="label toggle_btn">OFF</span>
+                </p>
             </div>
             <br>
             <div class="nb_button">

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -744,7 +744,7 @@ class Puzzle {
             } else {
                 if (this.space[spaceSide] > 0) {
                     this.space[spaceSide] = this.space[spaceSide] - 1;
-                } else if (pu.mode.qa === 'pu_a') {
+                } else {
                     return; // Protect board content
                 }
             }
@@ -834,7 +834,7 @@ class Puzzle {
                 this.centerlist.splice(index, 1);
             }
         }
-        
+
         // Add Box elements
         for (let n = 0; n < boxadd.length; n++) {
             let num = boxadd[n];

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -782,7 +782,7 @@ class Puzzle {
             }
         }
 
-        // Find the missing boxes
+        // Find the missing and added boxes
         let old_centerlist = this.centerlist;
         let old_idealcenterlist = []; // If no box was missing
         for (let j = 2 + originalspace[0]; j < originalny0 - 2 - originalspace[1]; j++) {
@@ -791,6 +791,7 @@ class Puzzle {
             }
         }
         let boxremove = old_idealcenterlist.filter(x => old_centerlist.indexOf(x) === -1);
+        let boxadd = old_centerlist.filter(x => old_idealcenterlist.indexOf(x) === -1);
 
         this.create_point();
         this.centerlist = [];
@@ -823,6 +824,7 @@ class Puzzle {
                 this.centerlist.push(i + j * (this.nx0));
             }
         }
+
         // Remove Box elements
         for (let n = 0; n < boxremove.length; n++) {
             let num = boxremove[n];
@@ -832,6 +834,17 @@ class Puzzle {
                 this.centerlist.splice(index, 1);
             }
         }
+        
+        // Add Box elements
+        for (let n = 0; n < boxadd.length; n++) {
+            let num = boxadd[n];
+            let m = translate_fn(num);
+            let index = this.centerlist.indexOf(m);
+            if (index === -1) {
+                this.centerlist.push(m);
+            }
+        }
+
         this.make_frameline();
         this.translate_puzzle_elements(translate_fn);
     }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1373,34 +1373,21 @@ onload = function() {
             case "rt_addtop":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('t');
-                if (pu.gridtype === "square") {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" || pu.gridtype === "kakuro" ? 'white' : 'black';
+                        
                     switch (orientation) {
                         case 0:
-                            pu.resize_bottom(1); // rotated by 180
+                            pu.resize_bottom(1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_left(1); // rotated by 90
+                            pu.resize_left(1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_top(1); // original
+                            pu.resize_top(1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_right(1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku" || (pu.gridtype === "kakuro")) {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_bottom(1, 'white');
-                            break;
-                        case 1:
-                            pu.resize_left(1, 'white');
-                            break;
-                        case 2:
-                            pu.resize_top(1, 'white');
-                            break;
-                        case 3:
-                            pu.resize_right(1, 'white');
+                            pu.resize_right(1, celltype); // rotated by 270
                             break;
                     }
                 }
@@ -1410,34 +1397,21 @@ onload = function() {
             case "rt_addbottom":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('b');
-                if (pu.gridtype === "square" || (pu.gridtype === "kakuro")) {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" ? 'white' : 'black';
+                        
                     switch (orientation) {
                         case 0:
-                            pu.resize_top(1); // rotated by 180
+                            pu.resize_top(1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_right(1); // rotated by 90
+                            pu.resize_right(1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_bottom(1); // original
+                            pu.resize_bottom(1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_left(1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku") {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_top(1, 'white'); // rotated by 180
-                            break;
-                        case 1:
-                            pu.resize_right(1, 'white'); // rotated by 90
-                            break;
-                        case 2:
-                            pu.resize_bottom(1, 'white'); // original
-                            break;
-                        case 3:
-                            pu.resize_left(1, 'white'); // rotated by 270
+                            pu.resize_left(1, celltype); // rotated by 270
                             break;
                     }
                 }
@@ -1447,34 +1421,21 @@ onload = function() {
             case "rt_addleft":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('l');
-                if (pu.gridtype === "square") {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" || pu.gridtype === "kakuro" ? 'white' : 'black';
+                        
                     switch (orientation) {
                         case 0:
-                            pu.resize_right(1); // rotated by 180
+                            pu.resize_right(1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_bottom(1); // rotated by 90
+                            pu.resize_bottom(1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_left(1); // original
+                            pu.resize_left(1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_top(1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku" || (pu.gridtype === "kakuro")) {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_right(1, 'white');
-                            break;
-                        case 1:
-                            pu.resize_bottom(1, 'white');
-                            break;
-                        case 2:
-                            pu.resize_left(1, 'white');
-                            break;
-                        case 3:
-                            pu.resize_top(1, 'white');
+                            pu.resize_top(1, celltype); // rotated by 270
                             break;
                     }
                 }
@@ -1484,34 +1445,21 @@ onload = function() {
             case "rt_addright":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('r');
-                if (pu.gridtype === "square" || (pu.gridtype === "kakuro")) {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" ? 'white' : 'black';
+                        
                     switch (orientation) {
                         case 0:
-                            pu.resize_left(1); // rotated by 180
+                            pu.resize_left(1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_top(1); // rotated by 90
+                            pu.resize_top(1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_right(1); // original
+                            pu.resize_right(1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_bottom(1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku") {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_left(1, 'white'); // rotated by 180
-                            break;
-                        case 1:
-                            pu.resize_top(1, 'white'); // rotated by 90
-                            break;
-                        case 2:
-                            pu.resize_right(1, 'white'); // original
-                            break;
-                        case 3:
-                            pu.resize_bottom(1, 'white'); // rotated by 270
+                            pu.resize_bottom(1, celltype); // rotated by 270
                             break;
                     }
                 }
@@ -1521,34 +1469,21 @@ onload = function() {
             case "rt_subtop":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('t');
-                if (pu.gridtype === "square") {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" || pu.gridtype === "kakuro" ? 'white' : 'black';
+                        
                     switch (orientation) {
                         case 0:
-                            pu.resize_bottom(-1); // rotated by 180
+                            pu.resize_bottom(-1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_left(-1); // rotated by 90
+                            pu.resize_left(-1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_top(-1); // original
+                            pu.resize_top(-1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_right(-1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku" || (pu.gridtype === "kakuro")) {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_bottom(-1, 'white');
-                            break;
-                        case 1:
-                            pu.resize_left(-1, 'white');
-                            break;
-                        case 2:
-                            pu.resize_top(-1, 'white');
-                            break;
-                        case 3:
-                            pu.resize_right(-1, 'white');
+                            pu.resize_right(-1, celltype); // rotated by 270
                             break;
                     }
                 }
@@ -1558,34 +1493,21 @@ onload = function() {
             case "rt_subbottom":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('b');
-                if (pu.gridtype === "square" || (pu.gridtype === "kakuro")) {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" ? 'white' : 'black';
+
                     switch (orientation) {
                         case 0:
-                            pu.resize_top(-1); // rotated by 180
+                            pu.resize_top(-1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_right(-1); // rotated by 90
+                            pu.resize_right(-1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_bottom(-1); // original
+                            pu.resize_bottom(-1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_left(-1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku") {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_top(-1, 'white'); // rotated by 180
-                            break;
-                        case 1:
-                            pu.resize_right(-1, 'white'); // rotated by 90
-                            break;
-                        case 2:
-                            pu.resize_bottom(-1, 'white'); // original
-                            break;
-                        case 3:
-                            pu.resize_left(-1, 'white'); // rotated by 270
+                            pu.resize_left(-1, celltype); // rotated by 270
                             break;
                     }
                 }
@@ -1595,34 +1517,21 @@ onload = function() {
             case "rt_subleft":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('l');
-                if (pu.gridtype === "square") {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" || pu.gridtype === "kakuro" ? 'white' : 'black';
+                        
                     switch (orientation) {
                         case 0:
-                            pu.resize_right(-1); // rotated by 180
+                            pu.resize_right(-1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_bottom(-1); // rotated by 90
+                            pu.resize_bottom(-1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_left(-1); // original
+                            pu.resize_left(-1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_top(-1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku" || (pu.gridtype === "kakuro")) {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_right(-1, 'white');
-                            break;
-                        case 1:
-                            pu.resize_bottom(-1, 'white');
-                            break;
-                        case 2:
-                            pu.resize_left(-1, 'white');
-                            break;
-                        case 3:
-                            pu.resize_top(-1, 'white');
+                            pu.resize_top(-1, celltype); // rotated by 270
                             break;
                     }
                 }
@@ -1632,70 +1541,61 @@ onload = function() {
             case "rt_subright":
                 // To handle Rotation and Reflection
                 orientation = pu.get_orientation('r');
-                if (pu.gridtype === "square" || (pu.gridtype === "kakuro")) {
+                if (pu.grid_is_square()) {
+                    let celltype = UserSettings.resize_whitespace || pu.gridtype === "sudoku" ? 'white' : 'black';
+                        
                     switch (orientation) {
                         case 0:
-                            pu.resize_left(-1); // rotated by 180
+                            pu.resize_left(-1, celltype); // rotated by 180
                             break;
                         case 1:
-                            pu.resize_top(-1); // rotated by 90
+                            pu.resize_top(-1, celltype); // rotated by 90
                             break;
                         case 2:
-                            pu.resize_right(-1); // original
+                            pu.resize_right(-1, celltype); // original
                             break;
                         case 3:
-                            pu.resize_bottom(-1); // rotated by 270
-                            break;
-                    }
-                } else if (pu.gridtype === "sudoku") {
-                    switch (orientation) {
-                        case 0:
-                            pu.resize_left(-1, 'white'); // rotated by 180
-                            break;
-                        case 1:
-                            pu.resize_top(-1, 'white'); // rotated by 90
-                            break;
-                        case 2:
-                            pu.resize_right(-1, 'white'); // original
-                            break;
-                        case 3:
-                            pu.resize_bottom(-1, 'white'); // rotated by 270
+                            pu.resize_bottom(-1, celltype); // rotated by 270
                             break;
                     }
                 }
                 // pu.rotate_size(); // fit board to window
                 e.preventDefault();
                 break;
+            case "resize_whitespace_button":
+                UserSettings.resize_whitespace = !UserSettings.resize_whitespace;
+                e.preventDefault();
+                break;
             case "rt_addtop_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_top(1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_top(1, 'white'); }
                 e.preventDefault();
                 break;
             case "rt_addbottom_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_bottom(1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_bottom(1, 'white'); }
                 e.preventDefault();
                 break;
             case "rt_addleft_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_left(1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_left(1, 'white'); }
                 e.preventDefault();
                 break;
             case "rt_addright_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_right(1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_right(1, 'white'); }
                 e.preventDefault();
                 break;
             case "rt_subtop_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_top(-1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_top(-1, 'white'); }
                 e.preventDefault();
                 break;
             case "rt_subbottom_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_bottom(-1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_bottom(-1, 'white'); }
                 e.preventDefault();
                 break;
             case "rt_subleft_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_left(-1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_left(-1, 'white'); }
                 e.preventDefault();
                 break;
             case "rt_subright_r":
-                if ((pu.gridtype === "square") || (pu.gridtype === "sudoku") || (pu.gridtype === "kakuro")) { pu.resize_right(-1, 'white'); }
+                if (pu.grid_is_square()) { pu.resize_right(-1, 'white'); }
                 e.preventDefault();
                 break;
             case "closeBtn_rotate1":

--- a/docs/js/settings.js
+++ b/docs/js/settings.js
@@ -453,6 +453,16 @@ const UserSettings = {
     get quick_panel_button() {
         return this._quick_panel_btn;
     },
+    
+    _resize_whitespace: false,
+    set resize_whitespace(newValue) {
+        const button = document.getElementById("resize_whitespace_button");
+        this._resize_whitespace = newValue;
+        button.textContent = PenpaText.get(newValue ? "on" : "off");
+    },
+    get resize_whitespace() {
+        return this._resize_whitespace;
+    },
 
     can_save: [
         'auto_save_history',


### PR DESCRIPTION
This PR contains two small improvements for the resize menu:

1. Resizing no longer resets boxed cells in the whitespace area of the grid.
2. There's a new toggle to make the transform buttons adjust only whitespace instead. The functionality was already there (for Sudoku/Kakuro grids and when resizing in Solver Mode), so this is mostly just new UI to expose it in Setter Mode.

Maybe the toggle should be hidden for Kakuro and Sudoku grids, because they have their own magic for deciding when to adjust whitespace and when not? Then again, the transform buttons don't get removed for non-square grid types either.