### PR TITLE
Add new half-edge submode for square, hex, and triangle grids

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -235,6 +235,8 @@
                             <label for="sub_lineE2" class="labelL" id="sub_lineE2_lb">Diagonal</label>
                             <input type="radio" name="mode_lineE" value="3" id="sub_lineE3">
                             <label for="sub_lineE3" class="labelL" id="sub_lineE3_lb">Free</label>
+                            <input type="radio" name="mode_lineE" value="6" id="sub_lineE6">
+                            <label for="sub_lineE6" class="labelL" id="sub_lineE6_lb">Middle</label>
                             <input type="radio" name="mode_lineE" value="4" id="sub_lineE4">
                             <label for="sub_lineE4" class="labelL" id="sub_lineE4_lb">Helper (x)</label>
                             <input type="radio" name="mode_lineE" value="5" id="sub_lineE5">

--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -37,7 +37,7 @@ class Puzzle_hex extends Puzzle {
     create_point() {
         var k = 0;
         var n = this.nx * 3 + 1;
-        var adjacent, surround, type, use, neighbor;
+        var adjacent, surround, type, use, neighbor, edge_to_vertex;
         var point = [];
         const index = (x, y) => [x, y];
         //center
@@ -59,7 +59,8 @@ class Puzzle_hex extends Puzzle {
                 if (i === 0 || i === n - 1 || j === 0 || j === n - 1) { use = -1; } else { use = 1; }
                 adjacent = [k + n ** 2, k + n ** 2 + 1, k + n ** 2 + n + j % 2];
                 surround = [k - n ** 2, k - n ** 2 + n - 1 + j % 2, k - n ** 2 + n + j % 2];
-                point[k] = new Point(point[i + j * n].x, point[i + j * n].y + 2 / 3 * this.size * Math.sqrt(3) * 0.5, type, adjacent, surround, use);
+                edge_to_vertex = [k + 2 * n ** 2, k + 3 * n ** 2, k + 4 * n ** 2 + n - 1 + j % 2];
+                point[k] = new Point(point[i + j * n].x, point[i + j * n].y + 2 / 3 * this.size * Math.sqrt(3) * 0.5, type, adjacent, surround, use, [], [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -68,7 +69,8 @@ class Puzzle_hex extends Puzzle {
                 if (i === 0 || i === n - 1 || j === 0 || j === n - 1) { use = -1; } else { use = 1; }
                 adjacent = [k - n ** 2 - n - (j + 1) % 2, k - n ** 2 - 1, k - n ** 2];
                 surround = [k - 2 * n ** 2 - 1, k - 2 * n ** 2, k - 2 * n ** 2 + n - 1 + j % 2];
-                point[k] = new Point(point[i + j * n].x - 0.5 * this.size, point[i + j * n].y + 1 / 3 * this.size * Math.sqrt(3) * 0.5, type, adjacent, surround, use);
+                edge_to_vertex = [k + n ** 2, k + 2 * n ** 2 - 1, k + 3 * n ** 2 - 1];
+                point[k] = new Point(point[i + j * n].x - 0.5 * this.size, point[i + j * n].y + 1 / 3 * this.size * Math.sqrt(3) * 0.5, type, adjacent, surround, use, [], [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -80,7 +82,8 @@ class Puzzle_hex extends Puzzle {
                 adjacent = [k + n - 1 + j % 2, k - n + j % 2];
                 surround = [];
                 neighbor = [k - 3 * n ** 2, k - 3 * n ** 2 + n - 1 + j % 2];
-                point[k] = new Point(point[i + j * n].x - 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor);
+                edge_to_vertex = [k - n ** 2, k - 2 * n ** 2];
+                point[k] = new Point(point[i + j * n].x - 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor, [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -91,7 +94,8 @@ class Puzzle_hex extends Puzzle {
                 adjacent = [k + n + j % 2, k - n - 1 + j % 2];
                 surround = [];
                 neighbor = [k - 4 * n ** 2, k - 4 * n ** 2 + n + j % 2];
-                point[k] = new Point(point[i + j * n].x + 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor);
+                edge_to_vertex = [k - 2 * n ** 2 + 1, k - 3 * n ** 2];
+                point[k] = new Point(point[i + j * n].x + 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor, [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -102,7 +106,8 @@ class Puzzle_hex extends Puzzle {
                 adjacent = [k - 1, k + 1];
                 surround = [];
                 neighbor = [k - 5 * n ** 2, k - 5 * n ** 2 + 1];
-                point[k] = new Point(point[i + j * n].x + 0.5 * this.size, point[i + j * n].y, type, adjacent, surround, use, neighbor);
+                edge_to_vertex = [k - 3 * n ** 2 + 1, k - 4 * n ** 2 - n + j % 2];
+                point[k] = new Point(point[i + j * n].x + 0.5 * this.size, point[i + j * n].y, type, adjacent, surround, use, neighbor, [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -225,6 +230,8 @@ class Puzzle_hex extends Puzzle {
             case "lineE":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
                     type = [2, 3, 4];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "6") {
+                    type = [1, 2, 3, 4];
                 } else {
                     type = [1];
                 }

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -1,7 +1,7 @@
 const MAX_EXPORT_LENGTH = 7360;
 
 class Point {
-    constructor(x, y, type, adjacent, surround, use, neighbor = [], adjacent_dia = [], type2 = 0, index = null) {
+    constructor(x, y, type, adjacent, surround, use, neighbor = [], adjacent_dia = [], type2 = 0, index = null, edge_to_vertex = []) {
         this.x = x;
         this.y = y;
         this.type = type;
@@ -10,6 +10,7 @@ class Point {
         this.adjacent_dia = adjacent_dia;
         this.surround = surround;
         this.neighbor = neighbor;
+        this.edge_to_vertex = edge_to_vertex;
         this.use = use;
         this.index = index;
     }
@@ -8948,6 +8949,12 @@ class Puzzle {
                     array = "deletelineE";
                     var key = (Math.min(num, this.last)).toString() + "," + (Math.max(num, this.last)).toString();
                     this.re_line(array, key, 1);
+                }
+            } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "6") { // half edge
+                if (this.point[num].edge_to_vertex.indexOf(parseInt(this.last)) != -1) {
+                    array = "lineE";
+                    var key = (Math.min(num, this.last)).toString() + "," + (Math.max(num, this.last)).toString();
+                    this.re_line(array, key, line_style);
                 }
             }
             this.redraw();

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -48,7 +48,7 @@ class Puzzle_square extends Puzzle {
         var k = 0;
         var nx = this.nx0;
         var ny = this.ny0;
-        var adjacent, surround, type, use, neighbor, adjacent_dia;
+        var adjacent, surround, type, use, neighbor, adjacent_dia, edge_to_vertex;
         var point = [];
         const index = (x, y) => [x, y, this.nx0 * y + x];
         //center
@@ -72,7 +72,8 @@ class Puzzle_square extends Puzzle {
                 adjacent = [k - nx, k - 1, k + 1, k + nx];
                 adjacent_dia = [k - nx - 1, k - nx + 1, k + nx - 1, k + nx + 1];
                 surround = [];
-                point[k] = new Point(point[i + j * nx].x + 0.5 * this.size, point[i + j * nx].y + 0.5 * this.size, type, adjacent, surround, use, [], adjacent_dia, 0, index(i, j));
+                edge_to_vertex = [k + nx * ny, k + nx * ny + 1, k + 2 *nx * ny, k + 2 * nx * ny + nx];
+                point[k] = new Point(point[i + j * nx].x + 0.5 * this.size, point[i + j * nx].y + 0.5 * this.size, type, adjacent, surround, use, [], adjacent_dia, 0, index(i, j), edge_to_vertex);
                 k++;
             }
         }
@@ -86,7 +87,8 @@ class Puzzle_square extends Puzzle {
                 adjacent = [k + nx, k - nx];
                 surround = [];
                 neighbor = [k - 2 * nx * ny, k - 2 * nx * ny + nx];
-                point[k] = new Point(point[i + j * nx].x, point[i + j * nx].y + 0.5 * this.size, type, adjacent, surround, use, neighbor, [], 0, index(i, j));
+                edge_to_vertex = [k - nx * ny - 1, k - nx * ny];
+                point[k] = new Point(point[i + j * nx].x, point[i + j * nx].y + 0.5 * this.size, type, adjacent, surround, use, neighbor, [], 0, index(i, j), edge_to_vertex);
                 k++;
             }
         }
@@ -97,7 +99,8 @@ class Puzzle_square extends Puzzle {
                 adjacent = [k + 1, k - 1];
                 surround = [];
                 neighbor = [k - 3 * nx * ny, k - 3 * nx * ny + 1];
-                point[k] = new Point(point[i + j * nx].x + 0.5 * this.size, point[i + j * nx].y, type, adjacent, surround, use, neighbor, [], 0, index(i, j));
+                edge_to_vertex = [k - 2 * nx * ny - nx, k - 2 * nx * ny];
+                point[k] = new Point(point[i + j * nx].x + 0.5 * this.size, point[i + j * nx].y, type, adjacent, surround, use, neighbor, [], 0, index(i, j), edge_to_vertex);
                 k++;
             }
         }
@@ -228,6 +231,8 @@ class Puzzle_square extends Puzzle {
                     type = [2, 3];
                 } else if (submode === "2") {
                     type = [0, 1];
+                } else if (submode === "6") {
+                    type = [1, 2, 3];
                 } else {
                     type = [1];
                 }

--- a/docs/js/class_tri.js
+++ b/docs/js/class_tri.js
@@ -35,21 +35,22 @@ class Puzzle_tri extends Puzzle {
     create_point() {
         var k = 0;
         var n = this.n0;
-        var adjacent, surround, type, use, neighbor;
+        var adjacent, surround, type, use, neighbor, edge_to_vertex;
         var point = [];
         const index = (x, y, t) => [x, y, t];
-        //center
+        //vertex
         type = 1;
         for (var j = 0; j < n; j++) {
             for (var i = 0; i < n; i++) {
                 if (i === 0 || i === n - 1 || j === 0 || j === n - 1) { use = -1; } else { use = 1; }
                 adjacent = [k - n - 1 + j % 2, k - n + j % 2, k - 1, k + 1, k + n - 1 + j % 2, k + n + j % 2];
                 surround = [k + n ** 2 - n - 1 + j % 2, k + 2 * n ** 2 - n + j % 2, k + n ** 2 - n + j % 2, k + 2 * n ** 2 + 1, k + n ** 2, k + 2 * n ** 2];
-                point[k] = new Point((i + (j % 2) * 0.5 - (1 + 0.5 * ((this.nx + 1) % 2))) * this.size, (j - 1) * this.size * Math.sqrt(3) * 0.5, type, adjacent, surround, use);
+                edge_to_vertex = [k + 3 * n ** 2 - n + j % 2, k + 3 * n ** 2, k + 4 * n ** 2 - n - 1 + j % 2, k + 4 * n ** 2, k + 5 * n ** 2 - 1, k + 5 * n ** 2];
+                point[k] = new Point((i + (j % 2) * 0.5 - (1 + 0.5 * ((this.nx + 1) % 2))) * this.size, (j - 1) * this.size * Math.sqrt(3) * 0.5, type, adjacent, surround, use, [], [], 0, null, edge_to_vertex);
                 k++;
             }
         }
-        //vertex
+        //center
         type = 0;
         for (var j = 0; j < n; j++) {
             for (var i = 0; i < n; i++) {
@@ -79,7 +80,8 @@ class Puzzle_tri extends Puzzle {
                 adjacent = [k + n - 1 + j % 2, k - n + j % 2];
                 surround = [];
                 neighbor = [k - 2 * n ** 2, k - n ** 2];
-                point[k] = new Point(point[i + j * n].x - 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor);
+                edge_to_vertex = [k - 3 * n ** 2, k - 3 * n ** 2 + n - 1 + j % 2];
+                point[k] = new Point(point[i + j * n].x - 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor, [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -90,7 +92,8 @@ class Puzzle_tri extends Puzzle {
                 adjacent = [k + n + j % 2, k - n - 1 + j % 2];
                 surround = [];
                 neighbor = [k - 3 * n ** 2, k - 2 * n ** 2 + 1];
-                point[k] = new Point(point[i + j * n].x + 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor);
+                edge_to_vertex = [k - 4 * n ** 2, k - 4 * n ** 2 + n + j % 2];
+                point[k] = new Point(point[i + j * n].x + 0.25 * this.size, point[i + j * n].y + this.size * Math.sqrt(3) * 0.25, type, adjacent, surround, use, neighbor, [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -101,7 +104,8 @@ class Puzzle_tri extends Puzzle {
                 adjacent = [k - 1, k + 1];
                 surround = [];
                 neighbor = [k - 4 * n ** 2 - n + j % 2, k - 3 * n ** 2 + 1];
-                point[k] = new Point(point[i + j * n].x + 0.5 * this.size, point[i + j * n].y, type, adjacent, surround, use, neighbor);
+                edge_to_vertex = [k - 5 * n ** 2, k - 5 * n ** 2 + 1];
+                point[k] = new Point(point[i + j * n].x + 0.5 * this.size, point[i + j * n].y, type, adjacent, surround, use, neighbor, [], 0, null, edge_to_vertex);
                 k++;
             }
         }
@@ -229,6 +233,8 @@ class Puzzle_tri extends Puzzle {
             case "lineE":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
                     type = [2, 3, 4];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "6") {
+                    type = [1, 2, 3, 4];
                 } else {
                     type = [1];
                 }

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -45,7 +45,7 @@ const penpa_modes = {
         'mode': ['surface', 'multicolor', 'line', 'lineE', 'wall', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line2', 'line3', 'line5', 'line4',
-            'lineE1', 'lineE2', 'lineE3', 'lineE4', 'lineE5',
+            'lineE1', 'lineE2', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number9', 'number4', 'number2', 'number8', 'number11',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
             'cage1', 'cage2', 'move1', 'move2', 'move3',
@@ -102,7 +102,7 @@ const penpa_modes = {
         'mode': ['surface', 'multicolor', 'line', 'lineE', 'wall', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line2', 'line3', 'line5', 'line4',
-            'lineE1', 'lineE2', 'lineE3', 'lineE4', 'lineE5',
+            'lineE1', 'lineE2', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number9', 'number4', 'number2', 'number8', 'number11',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
             'cage1', 'cage2', 'move1', 'move2', 'move3',
@@ -159,7 +159,7 @@ const penpa_modes = {
         'mode': ['surface', 'multicolor', 'line', 'lineE', 'wall', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line2', 'line3', 'line5', 'line4',
-            'lineE1', 'lineE2', 'lineE3', 'lineE4', 'lineE5',
+            'lineE1', 'lineE2', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number9', 'number4', 'number2', 'number8', 'number11',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
             'cage1', 'cage2', 'move1', 'move2', 'move3',

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -216,7 +216,7 @@ const penpa_modes = {
         'mode': ['surface', 'multicolor', 'line', 'lineE', 'wall', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line3', 'line5', 'line4',
-            'lineE1', 'lineE3', 'lineE4', 'lineE5',
+            'lineE1', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number4', 'number2', 'number8',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
             'cage2', 'move1', 'move2', 'move3',

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -270,7 +270,7 @@ const penpa_modes = {
         'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line3', 'line5', 'line4',
-            'lineE1', 'lineE3', 'lineE4', 'lineE5',
+            'lineE1', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
             'number1', 'number6', 'number5', 'number7', 'number3', 'number4', 'number2', 'number8',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
             'cage2', 'move1', 'move2', 'move3',


### PR DESCRIPTION
This adds a new submode to Edge mode, similar to Line -> Middle. It is currently supported on square (+ sudoku + kakuro), hex and triangle grids, which are the grids that also support Line -> Middle.

I've called it Edge -> Middle for consistency, but I'm not a big fan tbh. I think Edge -> Half feels more appropriate, but then ideally we'd rename the Line submode as well.