### PR TITLE
Fix yajilin mode responsivity

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -939,7 +939,7 @@ onload = function() {
         if (fittype === 'flex') {
             if ((edit_mode === "combi" && improve_modes.includes(pu.mode[pu.mode.qa][edit_mode][0])) ||
                 edit_mode === "sudoku" || edit_mode === "number")
-                pu.type = [0];
+                type = [0];
         }
 
         for (var i = 0; i < pu.point.length; i++) {
@@ -950,13 +950,6 @@ onload = function() {
                     num = i;
                 }
             }
-        }
-
-        // resetting the type for starbattle composite mode
-        if (fittype === 'flex') {
-            if ((edit_mode === "combi" && improve_modes.includes(pu.mode[pu.mode.qa][edit_mode][0])) ||
-                edit_mode === "sudoku" || edit_mode === "number")
-                pu.type = type;
         }
 
         //const endTime = performance.now();


### PR DESCRIPTION
This commit essentially reverts two changes from 2a33112 and 2272c9a which together seem to have broken a piece of code responsible for making yajilin mode (and some others) feel better. I don't know if there was a reason for the change in the first of these commits but it looks like an accidental partial reverting of a refactoring done in dd779c7.