### PR TITLE
In akari mode, don't forbid creating bulbs on coloured cells

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -11311,7 +11311,7 @@ class Puzzle {
 
     re_combi_akari_up_reduced(num) {
         if (this.point[num].type === 0 && this.last === num && this.first === num) {
-            if (!this[this.mode.qa].surface[num] && !this[this.mode.qa].symbol[num]) {
+            if (!this[this.mode.qa].symbol[num]) {
                 this.record("symbol", num);
                 this[this.mode.qa].symbol[num] = [3, "sun_moon", 2];
                 this.record_replay("symbol", num);


### PR DESCRIPTION
Clicking on a coloured empty cell on desktop in akari mode didn't create a bulb because the code was explicitly testing for a surface element.

I'm not sure what the intention was, but the result was an uncaught TypeError as it fell through to a case that assumed there was a symbol element at the cell.