### PR TITLE
Fix fit-to-window on some platforms

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -1244,12 +1244,13 @@ class Puzzle {
         var textHeight = 0;
         var currentRow = -1
 
+        let iswhite = function(r,g,b) { return (r>250)&&(g>250)&&(b>250); }
         for (var i = 0, len = data.length; i < len; i += 4) {
             var r = data[i],
                 g = data[i + 1],
                 b = data[i + 2],
                 alpha = data[i + 3];
-            if (r != 255 || g != 255 || b != 255) {
+            if (!iswhite(r,g,b)) {
                 var yu = (Math.floor((i / 4) / this.canvas.width)) / this.resol;
                 break;
             }
@@ -1259,7 +1260,7 @@ class Puzzle {
                 g = data[i + 1],
                 b = data[i + 2],
                 alpha = data[i + 3];
-            if (r != 255 || g != 255 || b != 255) {
+            if (!iswhite(r,g,b)) {
                 var yd = (Math.floor((i / 4) / this.canvas.width) + 1) / this.resol;
                 break;
             }
@@ -1270,7 +1271,7 @@ class Puzzle {
                 g = data[j + 1],
                 b = data[j + 2],
                 alpha = data[j + 3];
-            if (r != 255 || g != 255 || b != 255) {
+            if (!iswhite(r,g,b)) {
                 var xl = (((j / 4) % this.canvas.width)) / this.resol;
                 break;
             }
@@ -1281,7 +1282,7 @@ class Puzzle {
                 g = data[j + 1],
                 b = data[j + 2],
                 alpha = data[j + 3];
-            if (r != 255 || g != 255 || b != 255) {
+            if (!iswhite(r,g,b)) {
                 var xr = (((j / 4) % this.canvas.width) + 1) / this.resol;
                 break;
             }


### PR DESCRIPTION
Fit-to-window and other options that rely on it (such as rotate) were not working properly on some platforms (I can reproduce both on Firefox/Linux and on Firefox/Android, although it may be dependent on specific hardware too).

The reason seems to be that some renderers unexpectedly produce not-perfectly-white pixels throughout white areas, and the fit code was interpreting these as not trimmable, resulting in a fitted area that was much larger than desired.