### PR TITLE
Merge the freeline array to the regular array

### DIFF
--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -620,8 +620,6 @@ class Puzzle_hex extends Puzzle {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_direction("pu_q");
@@ -647,7 +645,6 @@ class Puzzle_hex extends Puzzle {
             this.draw_wall("pu_q");
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_direction("pu_q");
             this.draw_lattice();
@@ -942,58 +939,6 @@ class Puzzle_hex extends Puzzle {
                 }
                 this.ctx.stroke();
             }
-        }
-    }
-
-    draw_freeline(pu) {
-        /*freeline*/
-        for (var i in this[pu].freeline) {
-            set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freeline[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-        for (var i in this[pu].freelineE) {
-            set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freelineE[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
         }
     }
 

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -74,6 +74,8 @@ COMPRESS_SUB = [
     ["\"command_undo\"", "zU"],
     ["\"command_replay\"", "z8"],
     ["\"numberS\"", "z1"],
+    ["\"freeline\"", "zF"],
+    ["\"freelineE\"", "z2"],
     ["\"thermo\"", "zT"],
     ["\"arrows\"", "z3"],
     ["\"direction\"", "zD"],
@@ -359,6 +361,37 @@ class Puzzle {
             // Add multicolor data
             if (this.mode[mode].multicolor === undefined)
                 this.mode[mode].multicolor = ["", 1];
+        }
+        
+        for (let mode of ['pu_q', 'pu_q_col', 'pu_a', 'pu_a_col']) {
+            // Put freeline with the regular array since they are now using the same one
+            if (this[mode].freeline !== undefined){    
+                if (this[mode].freeline.constructor.length !== 0) {
+                    for (var line in this[mode].freeline) {
+                        let split = this.split_line("line", line);
+                        for (var subline of split) {
+                            if (this[mode]["line"][subline] === undefined) {
+                                this[mode]["line"][subline] = this[mode].freeline[line];
+                            }
+                        }
+                    }
+                    this[mode].freeline = {};
+                }
+            }
+
+            if (this[mode].freelineE !== undefined){    
+                if (this[mode].freelineE.constructor.length !== 0) {
+                    for (var line in this[mode].freelineE) {
+                        let split = this.split_line("lineE", line);
+                        for (var subline of split) {
+                            if (this[mode]["lineE"][subline] === undefined) {
+                                this[mode]["lineE"][subline] = this[mode].freelineE[line];
+                            }
+                        }
+                    }
+                    this[mode].freelineE = {};
+                }
+            }
         }
     }
 
@@ -8665,6 +8698,24 @@ class Puzzle {
         return (Math.min(a, b)).toString() + "," + (Math.max(a, b)).toString();
     }
 
+    // For freelines, split into smaller pieces. Intended to be overriden by the specific class
+    split_line(array, num) { 
+        var ret = [num];
+        return  ret;
+    }
+
+    // For freelines, check how many sublines will need updated so that lines are completed instead of being inverted
+    line_change(array, lines, line_style){ 
+        var ret = [];
+        for (let i = 0; i < lines.length; i++){
+            if (this[this.mode.qa][array][lines[i]] === line_style) {
+                continue;
+            }
+            ret.push(lines[i])
+        }
+        return ret;
+    }
+
     mouse_line(x, y, num) {
         if (this.mouse_mode === "down_left") {
             this.drawing = true;
@@ -8721,7 +8772,11 @@ class Puzzle {
                         delete this[this.mode.qa + "_col"][array][num];
                     }
                 }
-                this.record_replay(array, num);
+                if (group_counter > 0) {
+                    this.record_replay(array, num, group_counter);
+                } else {
+                    this.record_replay(array, num);
+                }
             }
         } else {
             if (this.drawing_mode === 100) { // single line, edge
@@ -8752,7 +8807,11 @@ class Puzzle {
                     this.drawing_mode = line_style;
                 }
             } else if (this.drawing_mode === line_style) { // to draw in a stretch
-                this.record(array, num);
+                if (group_counter > 0) {
+                    this.record(array, num, group_counter);
+                } else {
+                    this.record(array, num);
+                }
                 if (array === "deletelineE") {
                     this["pu_q"][array][num] = line_style;
                 } else {
@@ -8766,7 +8825,11 @@ class Puzzle {
                         }
                     }
                 }
-                this.record_replay(array, num);
+                if (group_counter > 0) {
+                    this.record_replay(array, num, group_counter);
+                } else {
+                    this.record_replay(array, num);
+                }
             }
         }
     }
@@ -8829,25 +8892,24 @@ class Puzzle {
     re_lineup_free(num) {
         if (num != this.last && this.last != -1) {
             var key = (Math.min(num, this.last)).toString() + "," + (Math.max(num, this.last)).toString();
-            this.record("line", key);
-            if (this[this.mode.qa].line[key]) {
-                delete this[this.mode.qa].line[key];
-                if (UserSettings.custom_colors_on) {
-                    delete this[this.mode.qa + "_col"].line[key];
-                }
-            } else {
-                this[this.mode.qa].line[key] = this.drawing_mode;
-                if (UserSettings.custom_colors_on) {
-                    let cc = this.get_customcolor();
-                    if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(this.drawing_mode))) {
-                        delete this[this.mode.qa + "_col"].line[key];
-                    } else {
-                        this[this.mode.qa + "_col"].line[key] = cc;
-                    }
-                }
+            var lines = this.split_line("line", key);
+            var update = this.line_change("line", lines, this.drawing_mode);
+            var style = this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1];
+
+            if (!((update.length === 0 && lines.length === 1) || update.length === 1)) {
+                this.undoredo_counter = this.undoredo_counter + 1;
             }
-            this.record_replay("line", key);
+
+            if (update.length === 0) {
+                this.drawing_mode = 0;
+                update = lines;
+            }
+
+            for (let i = 0; i < update.length; i++){
+                this.re_line("line", update[i], style, this.undoredo_counter);
+            }
         }
+
     }
 
     mouse_lineX(x, y, num) {
@@ -8963,25 +9025,20 @@ class Puzzle {
     re_lineEup_free(num) {
         if (num != this.last && this.last != -1) {
             var key = (Math.min(num, this.last)).toString() + "," + (Math.max(num, this.last)).toString();
-            this.record("lineE", key);
-            if (this[this.mode.qa].lineE[key]) {
-                delete this[this.mode.qa].lineE[key];
-                if (UserSettings.custom_colors_on) {
-                    delete this[this.mode.qa + "_col"].lineE[key];
-                }
-            } else {
-                this[this.mode.qa].lineE[key] = this.drawing_mode;
-                if (UserSettings.custom_colors_on) {
-                    let cc = this.get_customcolor();
-                    if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(this.drawing_mode))) {
-                        delete this[this.mode.qa + "_col"].lineE[key];
-                    } else {
-                        this[this.mode.qa + "_col"].lineE[key] = cc;
-                    }
-
-                }
+            var lines = this.split_line("lineE", key);
+            var update = this.line_change("lineE", lines, this.drawing_mode);
+            var style = this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1];
+            if (!((update.length === 0 && lines.length === 1) || update.length === 1)) {
+                this.undoredo_counter = this.undoredo_counter + 1;
             }
-            this.record_replay("lineE", key);
+
+            if (update.length === 0) {
+                this.drawing_mode = 0;
+                update = lines;
+            }
+            for (let i = 0; i < update.length; i++){
+                this.re_line("lineE", update[i], style, this.undoredo_counter);
+            }
         }
     }
 

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -74,8 +74,6 @@ COMPRESS_SUB = [
     ["\"command_undo\"", "zU"],
     ["\"command_replay\"", "z8"],
     ["\"numberS\"", "z1"],
-    ["\"freeline\"", "zF"],
-    ["\"freelineE\"", "z2"],
     ["\"thermo\"", "zT"],
     ["\"arrows\"", "z3"],
     ["\"direction\"", "zD"],
@@ -235,8 +233,6 @@ class Puzzle {
         this[p].number = {};
         this[p].numberS = {};
         this[p].symbol = {};
-        this[p].freeline = {};
-        this[p].freelineE = {};
         this[p].thermo = [];
         this[p].arrows = [];
         this[p].direction = [];
@@ -278,9 +274,7 @@ class Puzzle {
             case "line":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] != "4") {
                     this[this.mode.qa].line = {};
-                    this[this.mode.qa].freeline = {};
                     this[this.mode.qa + "_col"].line = {};
-                    this[this.mode.qa + "_col"].freeline = {};
                 } else {
                     for (var i in this[this.mode.qa].line) {
                         if (this[this.mode.qa].line[i] === 98) {
@@ -311,9 +305,7 @@ class Puzzle {
                     this[this.mode.qa + "_col"].deletelineE = {};
                 } else {
                     this[this.mode.qa].lineE = {};
-                    this[this.mode.qa].freelineE = {};
                     this[this.mode.qa + "_col"].lineE = {};
-                    this[this.mode.qa + "_col"].freelineE = {};
                 }
                 break;
             case "wall":
@@ -892,7 +884,7 @@ class Puzzle {
             }
 
             // Translate point-pair features
-            for (let feature of ['line', 'lineE', 'deletelineE', 'freeline', 'freelineE', 'wall', 'cage']) {
+            for (let feature of ['line', 'lineE', 'deletelineE', 'wall', 'cage']) {
                 if (this[i][feature]) {
                     let temp = this[i][feature];
                     this[i][feature] = {};
@@ -1515,10 +1507,6 @@ class Puzzle {
                             }
                         }
                     }
-                    this[this.mode.qa].freeline = {};
-                    if (UserSettings.custom_colors_on) {
-                        this[this.mode.qa + "_col"].freeline = {};
-                    }
                 } else {
                     for (var i in this[this.mode.qa].line) {
                         if (this[this.mode.qa].line[i] === 98) {
@@ -1553,10 +1541,6 @@ class Puzzle {
                                 delete this[this.mode.qa + "_col"].lineE[i];
                             }
                         }
-                    }
-                    this[this.mode.qa].freelineE = {};
-                    if (UserSettings.custom_colors_on) {
-                        this[this.mode.qa + "_col"].freelineE = {};
                     }
                 }
                 break;
@@ -2190,9 +2174,6 @@ class Puzzle {
             check_line(i, 'line');
         }
 
-        for (var i in pu.freeline)
-            check_line(i, 'freeline');
-
         return solution;
     }
 
@@ -2228,9 +2209,6 @@ class Puzzle {
 
         for (var i in pu.lineE)
             check_edge(i, 'lineE');
-
-        for (var i in pu.freelineE)
-            check_edge(i, 'freelineE');
 
         let found = $('#genre_tags_opt').select2("val").some(r => this.surface_2_edge_types.includes(r));
         if (found && this.gridtype === 'square') {
@@ -8851,24 +8829,24 @@ class Puzzle {
     re_lineup_free(num) {
         if (num != this.last && this.last != -1) {
             var key = (Math.min(num, this.last)).toString() + "," + (Math.max(num, this.last)).toString();
-            this.record("freeline", key);
-            if (this[this.mode.qa].freeline[key]) {
-                delete this[this.mode.qa].freeline[key];
+            this.record("line", key);
+            if (this[this.mode.qa].line[key]) {
+                delete this[this.mode.qa].line[key];
                 if (UserSettings.custom_colors_on) {
-                    delete this[this.mode.qa + "_col"].freeline[key];
+                    delete this[this.mode.qa + "_col"].line[key];
                 }
             } else {
-                this[this.mode.qa].freeline[key] = this.drawing_mode;
+                this[this.mode.qa].line[key] = this.drawing_mode;
                 if (UserSettings.custom_colors_on) {
                     let cc = this.get_customcolor();
                     if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(this.drawing_mode))) {
-                        delete this[this.mode.qa + "_col"].freeline[key];
+                        delete this[this.mode.qa + "_col"].line[key];
                     } else {
-                        this[this.mode.qa + "_col"].freeline[key] = cc;
+                        this[this.mode.qa + "_col"].line[key] = cc;
                     }
                 }
             }
-            this.record_replay("freeline", key);
+            this.record_replay("line", key);
         }
     }
 
@@ -8985,25 +8963,25 @@ class Puzzle {
     re_lineEup_free(num) {
         if (num != this.last && this.last != -1) {
             var key = (Math.min(num, this.last)).toString() + "," + (Math.max(num, this.last)).toString();
-            this.record("freelineE", key);
-            if (this[this.mode.qa].freelineE[key]) {
-                delete this[this.mode.qa].freelineE[key];
+            this.record("lineE", key);
+            if (this[this.mode.qa].lineE[key]) {
+                delete this[this.mode.qa].lineE[key];
                 if (UserSettings.custom_colors_on) {
-                    delete this[this.mode.qa + "_col"].freelineE[key];
+                    delete this[this.mode.qa + "_col"].lineE[key];
                 }
             } else {
-                this[this.mode.qa].freelineE[key] = this.drawing_mode;
+                this[this.mode.qa].lineE[key] = this.drawing_mode;
                 if (UserSettings.custom_colors_on) {
                     let cc = this.get_customcolor();
                     if (!cc || tinycolor.equals(cc, CustomColor.default_line_style_color(this.drawing_mode))) {
-                        delete this[this.mode.qa + "_col"].freelineE[key];
+                        delete this[this.mode.qa + "_col"].lineE[key];
                     } else {
-                        this[this.mode.qa + "_col"].freelineE[key] = cc;
+                        this[this.mode.qa + "_col"].lineE[key] = cc;
                     }
 
                 }
             }
-            this.record_replay("freelineE", key);
+            this.record_replay("lineE", key);
         }
     }
 

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -393,6 +393,8 @@ class Puzzle {
                 }
             }
         }
+
+        this.redraw(); // We updated the line and lineE arrays, so we need to display them again. Otherwise it starts blank
     }
 
     reset_pause_layer() {

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -465,8 +465,6 @@ class Puzzle_pyramid extends Puzzle {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_direction("pu_q");
@@ -490,7 +488,6 @@ class Puzzle_pyramid extends Puzzle {
             this.draw_wall("pu_q");
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_direction("pu_q");
             this.draw_lattice();
@@ -782,57 +779,6 @@ class Puzzle_pyramid extends Puzzle {
         }
     }
 
-    draw_freeline(pu) {
-        /*freeline*/
-        for (var i in this[pu].freeline) {
-            set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freeline[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-        for (var i in this[pu].freelineE) {
-            set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freelineE[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-    }
 
     draw_wall(pu) {
         for (var i in this[pu].wall) {

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -698,8 +698,6 @@ class Puzzle_square extends Puzzle {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -725,7 +723,6 @@ class Puzzle_square extends Puzzle {
             this.draw_wall("pu_q");
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_direction("pu_q");
             this.draw_lattice();
@@ -1185,6 +1182,91 @@ class Puzzle_square extends Puzzle {
         }
     }
 
+    findGCD(num1, num2) { // For usage below
+        while (num2 !== 0) {
+            let temp = num2;
+            num2 = num1 % num2;
+            num1 = temp;
+        }
+        return Math.abs(num1);
+    }
+
+    split_line(array, num) { 
+        var ret = [];
+        var points = [];
+        switch (array) {
+            case 'line':
+                var i1 = num.split(",")[0];
+                var i2 = num.split(",")[1];
+
+                var x1 = this.point[i1].index[0];
+                var x2 = this.point[i2].index[0];
+                var y1 = this.point[i1].index[1];
+                var y2 = this.point[i2].index[1];
+
+                var dx = x2 - x1;
+                var dy = y2 - y1;
+
+                if (dx === 0) {
+                    for (let i = 0; i <= dy; i++) {
+                        points.push(x1 + (y1 + i) * this.nx0);
+                    }
+                }
+                else if (dy === 0) {
+                    for (let i = 0; i <= dx; i++) {
+                        points.push(x1 + i + y1 * this.nx0);
+                    }
+                }
+                else {
+                    var gcd = this.findGCD(dx, dy);
+                    var sx = dx / gcd;
+                    var sy = dy / gcd;
+                    for (let i = 0; i <= gcd; i++) {
+                        points.push(x1 + i * sx + (y1 + i * sy) * this.nx0);
+                    }
+                }
+                
+                break;
+
+            case 'lineE':
+                var i1 = num.split(",")[0];
+                var i2 = num.split(",")[1];
+
+                var x1 = this.point[i1].index[0];
+                var x2 = this.point[i2].index[0];
+                var y1 = this.point[i1].index[1];
+                var y2 = this.point[i2].index[1];
+
+                var dx = x2 - x1;
+                var dy = y2 - y1;
+
+                if (dx === 0) {
+                    for (let i = 0; i <= dy; i++) {
+                        points.push(x1 + (y1 + i) * this.nx0 + this.nx0*this.ny0);
+                    }
+                }
+                else if (dy === 0) {
+                    for (let i = 0; i <= dx; i++) {
+                        points.push(x1 + i + y1 * this.nx0 + this.nx0*this.ny0);
+                    }
+                }
+                else {
+                    var gcd = this.findGCD(dx, dy);
+                    var sx = dx / gcd;
+                    var sy = dy / gcd;
+                    for (let i = 0; i <= gcd; i++) {
+                        points.push(x1 + i * sx + (y1 + i * sy) * this.nx0 + this.nx0*this.ny0);
+                    }
+                }
+
+                break;
+        }
+        for (let i = 0; i < points.length - 1; i++) {
+            ret.push(points[i] + "," + points[i+1]);
+        }
+        return  ret;
+    }
+
     draw_line(pu) {
         for (var i in this[pu].line) {
             if (this[pu].line[i] === 98) {
@@ -1291,57 +1373,6 @@ class Puzzle_square extends Puzzle {
         }
     }
 
-    draw_freeline(pu) {
-        /*freeline*/
-        for (var i in this[pu].freeline) {
-            set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freeline[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-        for (var i in this[pu].freelineE) {
-            set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freelineE[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-    }
 
     draw_wall(pu) {
         for (var i in this[pu].wall) {

--- a/docs/js/class_tri.js
+++ b/docs/js/class_tri.js
@@ -468,8 +468,6 @@ class Puzzle_tri extends Puzzle {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_direction("pu_q");
@@ -492,7 +490,6 @@ class Puzzle_tri extends Puzzle {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_direction("pu_q");
             this.draw_lattice();
@@ -786,58 +783,6 @@ class Puzzle_tri extends Puzzle {
                 }
                 this.ctx.stroke();
             }
-        }
-    }
-
-    draw_freeline(pu) {
-        /*freeline*/
-        for (var i in this[pu].freeline) {
-            set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freeline[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-        for (var i in this[pu].freelineE) {
-            set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freelineE[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
         }
     }
 

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -698,8 +698,6 @@ class Puzzle_truncated_square extends Puzzle {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -716,7 +714,6 @@ class Puzzle_truncated_square extends Puzzle {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -891,58 +888,6 @@ class Puzzle_truncated_square extends Puzzle {
                 }
                 this.ctx.stroke();
             }
-        }
-    }
-
-    draw_freeline(pu) {
-        /*freeline*/
-        for (var i in this[pu].freeline) {
-            set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freeline[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-        for (var i in this[pu].freelineE) {
-            set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freelineE[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
         }
     }
 
@@ -3037,8 +2982,6 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -3055,7 +2998,6 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -3697,8 +3639,6 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -3715,7 +3655,6 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -4339,8 +4278,6 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -4357,7 +4294,6 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -4940,8 +4876,6 @@ class Puzzle_iso extends Puzzle_truncated_square {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -4958,7 +4892,6 @@ class Puzzle_iso extends Puzzle_truncated_square {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -6096,8 +6029,6 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -6114,7 +6045,6 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -6750,8 +6680,6 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -6768,7 +6696,6 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -7571,8 +7498,6 @@ class Puzzle_penrose_P3 extends Puzzle {
             this.draw_frame();
             this.draw_polygonsp("pu_q");
             this.draw_polygonsp("pu_a");
-            this.draw_freeline("pu_q");
-            this.draw_freeline("pu_a");
             this.draw_line("pu_q");
             this.draw_line("pu_a");
             this.draw_lattice();
@@ -7589,7 +7514,6 @@ class Puzzle_penrose_P3 extends Puzzle {
             this.draw_symbol("pu_q", 1);
             this.draw_frame();
             this.draw_polygonsp("pu_q");
-            this.draw_freeline("pu_q");
             this.draw_line("pu_q");
             this.draw_lattice();
             this.draw_selection();
@@ -7767,58 +7691,7 @@ class Puzzle_penrose_P3 extends Puzzle {
         }
     }
 
-    draw_freeline(pu) {
-        /*freeline*/
-        for (var i in this[pu].freeline) {
-            set_line_style(this.ctx, this[pu].freeline[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freeline[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freeline[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freeline[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-        for (var i in this[pu].freelineE) {
-            set_line_style(this.ctx, this[pu].freelineE[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].freelineE[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].freelineE[i];
-            }
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            this.ctx.beginPath();
-            if (this[pu].freelineE[i] === 30) {
-                var r = 0.15 * this.size;
-                var dx = this.point[i1].x - this.point[i2].x;
-                var dy = this.point[i1].y - this.point[i2].y;
-                var d = Math.sqrt(dx ** 2 + dy ** 2);
-                this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                this.ctx.stroke();
-                this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-            } else {
-                this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            }
-            this.ctx.stroke();
-        }
-    }
-
+ 
     draw_symbol(pu, layer) {
         /*symbol_layer*/
         var p_x, p_y;

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -2910,7 +2910,7 @@ function loadqa_arrayver1(qa, rtext_qa) {
             pu[qa].symbol[i1][0] = dif_symbol[pu[qa].symbol[i1][0]];
         }
     }
-    for (var i in rtext_qa[qa][18]) { //freeline
+    /*for (var i in rtext_qa[qa][18]) { //freeline
         i1 = i.split(",")[0];
         i2 = i.split(",")[1];
         key = pu.centerlist[i1] + "," + pu.centerlist[i2];
@@ -2938,7 +2938,7 @@ function loadqa_arrayver1(qa, rtext_qa) {
         }
         key = pu.point[i1].surround[0] + "," + pu.point[i2].surround[0];
         pu[qa].lineE[key] = rtext_qa[qa][19][i];
-    }
+    }*/
     for (var i of rtext_qa[qa][20]) { //thermo
         pu[qa].thermo.push([]);
         for (j of i) {

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -2910,7 +2910,7 @@ function loadqa_arrayver1(qa, rtext_qa) {
             pu[qa].symbol[i1][0] = dif_symbol[pu[qa].symbol[i1][0]];
         }
     }
-    /*for (var i in rtext_qa[qa][18]) { //freeline
+    for (var i in rtext_qa[qa][18]) { //freeline
         i1 = i.split(",")[0];
         i2 = i.split(",")[1];
         key = pu.centerlist[i1] + "," + pu.centerlist[i2];
@@ -2938,7 +2938,7 @@ function loadqa_arrayver1(qa, rtext_qa) {
         }
         key = pu.point[i1].surround[0] + "," + pu.point[i2].surround[0];
         pu[qa].lineE[key] = rtext_qa[qa][19][i];
-    }*/
+    }
     for (var i of rtext_qa[qa][20]) { //thermo
         pu[qa].thermo.push([]);
         for (j of i) {


### PR DESCRIPTION
This is a draft PR to combine freeline to line. Here is a todo list of required items needed for this to work:

- [x] Add backwards compatibility support so that old puzzle using the freeline array can still have them displayed
- [x] Add helper function to split a line into a list of smaller lines
- [x] Modify the freeline up function to use aforementioned helper function 

Possibly more items to come if I haven't considered things