### PR TITLE
Number mode improvements

### DIFF
--- a/docs/css/base-structure.css
+++ b/docs/css/base-structure.css
@@ -590,6 +590,21 @@ hr.newgridhrline {
     font-size: 16px;
 }
 
+.rotate_up {
+    transform: rotate(-90deg);
+    display: inline-block;
+}
+
+.rotate_down {
+    transform: rotate(90deg);
+    display: inline-block;
+}
+
+.rotate_left {
+    transform: rotate(180deg);
+    display: inline-block;
+}
+
 #ms1_degital {
     font-size: 18px;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -795,7 +795,7 @@
                 <canvas id="float-canvas" class="float-canvas"></canvas>
             </div>
             <div id="float-key-text">
-                <textarea class="text_area" class="text_area" rows="1" cols="20" maxlength="100" id="inputtext"></textarea>
+                <textarea class="text_area" class="text_area" rows="1" cols="20" maxlength="1000" id="inputtext"></textarea>
                 <input type="button" id="closeBtn_input1" value="Insert" />
                 <input type="button" id="closeBtn_input2" value="Clear" />
                 <input type="button" id="closeBtn_input3" value="Load" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -712,6 +712,19 @@
                             <input type="text" name="style_special" id="colorpicker_special" />
                         </span>
                     </div>
+                    <div id="orientation_button" style="display:none;">
+                        <span>
+                            <label class="label_mode tooltip" id="style_txt">Orientation:</label>
+                        </span>
+                        <input type="radio" name="orientation_button" value="R" id="rot_R" checked="checked">
+                        <label for="rot_R" class="labelL" id="rot_R_lb">A</label>
+                        <input type="radio" name="orientation_button" value="U" id="rot_U">
+                        <label for="rot_U" class="labelL" id="rot_U_lb"><span class="rotate rotate_up">A</span></label>
+                        <input type="radio" name="orientation_button" value="D" id="rot_D">
+                        <label for="rot_D" class="labelL" id="rot_D_lb"><span class="rotate rotate_down">A</span></label>
+                        <input type="radio" name="orientation_button" value="L" id="rot_L">
+                        <label for="rot_L" class="labelL" id="rot_L_lb"><span class="rotate rotate_left">A</span></label>
+                    </div>
                 </div>
             </div>
             <div id="ruletext"></div>

--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -1343,14 +1343,23 @@ class Puzzle_hex extends Puzzle {
                     }
                     break;
                 case "8": //long
-                    if (this[pu].number[i][1] === 5) {
-                        set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                        set_circle_style(this.ctx, 7);
-                        this.ctx.fillRect(this.point[i].x - 0.2 * this.size, this.point[i].y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    {
+                        let number_data = this[pu].number[i];
+                        let lines = number_data[0].split('\n');
+                        let p_x = this.point[i].x;
+                        let p_y = this.point[i].y;
+                        for (let line of lines) {
+                            if (number_data[1] === 5) {
+                                set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                                set_circle_style(this.ctx, 7);
+                                this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(line).width, 0.5 * this.size);
+                            }
+                            set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                            this.ctx.textAlign = "left";
+                            this.ctx.text(line, p_x - 0.2 * this.size, p_y);
+                            p_y += this.size * 0.5;
+                        }
                     }
-                    set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                    this.ctx.textAlign = "left";
-                    this.ctx.text(this[pu].number[i][0], this.point[i].x - 0.2 * this.size, this.point[i].y);
                     break;
             }
         }

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -1330,6 +1330,9 @@ class Puzzle {
             this.subsymbolmode(submode, skipredraw);
         } else if (mode === "combi") {
             this.subcombimode(submode, skipredraw);
+        } else if (mode === "number") {
+            const dir = this.mode[this.mode.qa][mode][2] || 'R';
+            this.set_orientation(dir);
         }
         if (UserSettings.custom_colors_on && penpa_modes[this.gridtype].customcolor.includes(mode)) {
             let cc = this.mode[this.mode.qa][mode][2];
@@ -1350,6 +1353,7 @@ class Puzzle {
             let isNumberS = ["3", "9", "11"].includes(pu.mode[pu.mode.qa][pu.mode[pu.mode.qa].edit_mode][0])
             let enableLoadButton = (!isNumberS && pu[pu.mode.qa].number[pu.cursol]) || (isNumberS && pu[pu.mode.qa].numberS[pu.cursolS]);
             document.getElementById("closeBtn_input3").disabled = !enableLoadButton;
+            document.getElementById('orientation_button').style.display = 'block';
         }
 
         if (!skipredraw)
@@ -1404,6 +1408,14 @@ class Puzzle {
             panel_pu.draw_panel(); // Panel update
         }
         this.set_custom_color(name);
+    }
+
+    set_orientation(direction) {
+        let input_name = "rot_" + direction;
+        if (document.getElementById(input_name)) {
+            document.getElementById(input_name).checked = true;
+            this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][2] = direction;
+        }
     }
 
     subsymbolmode(mode, skipredraw = false) {
@@ -1494,6 +1506,8 @@ class Puzzle {
         document.getElementById('style_cage').style.display = 'none';
         document.getElementById('style_combi').style.display = 'none';
         document.getElementById('style_sudoku').style.display = 'none';
+        
+        document.getElementById('orientation_button').style.display = 'none';
     }
 
     reset_selectedmode() {
@@ -7390,6 +7404,7 @@ class Puzzle {
         var str_num = "1234567890";
         let edit_mode = this.mode[this.mode.qa].edit_mode;
         let submode = this.mode[this.mode.qa][edit_mode];
+        let orientation = submode[2] && submode[2] !== 'R' ? [submode[2]] : [];
 
         // If ZXCV is disabled
         if (!UserSettings.shortcuts_enabled || force_no_shortcut) {
@@ -7452,7 +7467,7 @@ class Puzzle {
                             number = key;
                         }
 
-                        this.set_value("number", k, [number, submode[1], submode[0]]);
+                        this.set_value("number", k, [number, submode[1], submode[0], ...orientation]);
                         break;
                     case "2": // Arrow
                         if (this[this.mode.qa].number[k] && this[this.mode.qa].number[k][2] != "7") {
@@ -7476,7 +7491,7 @@ class Puzzle {
                         } else {
                             number = key;
                         }
-                        this.set_value("number", k, [number + arrow, submode[1], submode[0]]);
+                        this.set_value("number", k, [number + arrow, submode[1], submode[0], ...orientation]);
                         break;
                     case "3": // 1/4, corner
                     case "9": // Sides
@@ -7486,7 +7501,7 @@ class Puzzle {
                             con = "";
                         }
                         number = con + key;
-                        this.set_value("numberS", k, [number, submode[1]]);
+                        this.set_value("numberS", k, [number, submode[1], ...orientation]);
                         break;
                     case "4": //tapa
                         if (key === ".") { key = " "; }
@@ -7507,7 +7522,7 @@ class Puzzle {
                         } else { // Overwrite if arrow
                             number = key;
                         }
-                        this.set_value("number", k, [number, submode[1], submode[0]]);
+                        this.set_value("number", k, [number, submode[1], submode[0], ...orientation]);
                         break;
                     case "5": // Small
                     case "6": // Medium
@@ -7522,7 +7537,7 @@ class Puzzle {
                         const limit = (submode[0] === "8") ? 1000 : 10;
                         if (con.length < limit) {
                             number = con + key;
-                            this.set_value("number", k, [number, submode[1], submode[0]]);
+                            this.set_value("number", k, [number, submode[1], submode[0], ...orientation]);
                         }
                         break;
                     case "7": // Candidates
@@ -7537,7 +7552,7 @@ class Puzzle {
                                 con = "";
                             }
                             number = this.onofftext(9, key, con);
-                            let value = [number, submode[1], submode[0]];
+                            let value = [number, submode[1], submode[0], ...orientation];
                             this[this.mode.qa][prop][k] = value;
                             this.record_replay(prop, k, this.undoredo_counter);
                         }
@@ -7550,7 +7565,7 @@ class Puzzle {
                             con = "";
                         }
                         number = con + key;
-                        this.set_value("numberS", corner_cursor, [number, submode[1]]);
+                        this.set_value("numberS", corner_cursor, [number, submode[1], ...orientation]);
                         break;
                 }
             }
@@ -9213,7 +9228,11 @@ class Puzzle {
                 } else {
                     number = con + "_" + arrowdirection;
                 }
-                this[this.mode.qa].number[this.cursol] = [number, this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1], "2"];
+                
+                let edit_mode = this.mode[this.mode.qa].edit_mode;
+                let submode = this.mode[this.mode.qa][edit_mode];
+                let orientation = submode[2] && submode[2] !== 'R' ? [submode[2]] : [];
+                this[this.mode.qa].number[this.cursol] = [number, submode[1], "2", ...orientation];
                 this.record_replay("number", this.cursol);
                 this.drawing = false;
                 this.last = -1;

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -7518,8 +7518,8 @@ class Puzzle {
                         } else {
                             con = "";
                         }
-                        // Length limit of 10 except for Long submode which has 50
-                        const limit = (submode[0] === "8") ? 50 : 10;
+                        // Length limit of 10 except for Long submode which has 1000
+                        const limit = (submode[0] === "8") ? 1000 : 10;
                         if (con.length < limit) {
                             number = con + key;
                             this.set_value("number", k, [number, submode[1], submode[0]]);

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -1059,14 +1059,23 @@ class Puzzle_pyramid extends Puzzle {
                     }
                     break;
                 case "8": //long
-                    if (this[pu].number[i][1] === 5) {
-                        set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                        set_circle_style(this.ctx, 7);
-                        this.ctx.fillRect(this.point[i].x - 0.2 * this.size, this.point[i].y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    {
+                        let number_data = this[pu].number[i];
+                        let lines = number_data[0].split('\n');
+                        let p_x = this.point[i].x;
+                        let p_y = this.point[i].y;
+                        for (let line of lines) {
+                            if (number_data[1] === 5) {
+                                set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                                set_circle_style(this.ctx, 7);
+                                this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(line).width, 0.5 * this.size);
+                            }
+                            set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                            this.ctx.textAlign = "left";
+                            this.ctx.text(line, p_x - 0.2 * this.size, p_y);
+                            p_y += this.size * 0.5;
+                        }
                     }
-                    set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                    this.ctx.textAlign = "left";
-                    this.ctx.text(this[pu].number[i][0], this.point[i].x - 0.2 * this.size, this.point[i].y);
                     break;
             }
         }

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -1461,6 +1461,23 @@ class Puzzle_square extends Puzzle {
             } else {
                 factor = 0;
             }
+
+            if (this[pu].number[i][3]) {
+                let dir = this[pu].number[i][3];
+                let angle = 0;
+                switch (dir) {
+                case 'U': angle = -Math.PI/2; break;
+                case 'D': angle = Math.PI/2; break;
+                case 'L': angle = Math.PI; break;
+                }
+                this.ctx.save();
+                this.ctx.translate(p_x, p_y);
+                this.ctx.rotate(angle);
+                this.ctx.translate(-p_x, -p_y);
+
+                // TODO: only rotate the number in arrow mode, not the arrow
+            }
+
             switch (this[pu].number[i][2]) {
                 case "1": //normal
                     set_font_style(this.ctx, 0.7 * this.size.toString(10), this[pu].number[i][1]);
@@ -1719,6 +1736,10 @@ class Puzzle_square extends Puzzle {
                     }
                     break;
             }
+
+            if (this[pu].number[i][3]) {
+                this.ctx.restore();
+            }
         }
 
         for (var i in this[pu].numberS) {
@@ -1737,6 +1758,21 @@ class Puzzle_square extends Puzzle {
             }
             if (true) { //(this[pu].numberS[i][0].length <= 2 ){
                 if (this.point[i]) {
+                    
+                    if (this[pu].numberS[i][2]) {
+                        let dir = this[pu].numberS[i][2];
+                        let angle = 0;
+                        switch (dir) {
+                        case 'U': angle = -Math.PI/2; break;
+                        case 'D': angle = Math.PI/2; break;
+                        case 'L': angle = Math.PI; break;
+                        }
+                        this.ctx.save();
+                        this.ctx.translate(this.point[i].x, this.point[i].y);
+                        this.ctx.rotate(angle);
+                        this.ctx.translate(-this.point[i].x, -this.point[i].y);
+                    }
+
                     var [_, _, j] = this.point[i].index;
                     set_font_style(this.ctx, 0.32 * this.size.toString(10), this[pu].numberS[i][1]);
                     var n = parseInt(this[pu].numberS[i][0]);
@@ -1747,6 +1783,10 @@ class Puzzle_square extends Puzzle {
                     this.ctx.textAlign = "center";
                     this.ctx.text(this[pu].numberS[i][0], this.point[i].x, this.point[i].y + 0.03 * this.size, this.size * 0.48);
                     this.ctx.fillStyle = style;
+
+                    if (this[pu].numberS[i][2]) {
+                        this.ctx.restore();
+                    }
                 }
                 //}else{
                 //  set_font_style(this.ctx,0.28*this.size.toString(10),this[pu].numberS[i][1]);

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -1702,14 +1702,21 @@ class Puzzle_square extends Puzzle {
                     }
                     break;
                 case "8": //long
-                    if (this[pu].number[i][1] === 5) {
-                        set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                        set_circle_style(this.ctx, 7);
-                        this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    {
+                        let number_data = this[pu].number[i];
+                        let lines = number_data[0].split('\n');
+                        for (let line of lines) {
+                            if (number_data[1] === 5) {
+                                set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                                set_circle_style(this.ctx, 7);
+                                this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(line).width, 0.5 * this.size);
+                            }
+                            set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                            this.ctx.textAlign = "left";
+                            this.ctx.text(line, p_x - 0.2 * this.size, p_y);
+                            p_y += this.size * 0.5;
+                        }
                     }
-                    set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                    this.ctx.textAlign = "left";
-                    this.ctx.text(this[pu].number[i][0], p_x - 0.2 * this.size, p_y);
                     break;
             }
         }

--- a/docs/js/class_tri.js
+++ b/docs/js/class_tri.js
@@ -1050,14 +1050,23 @@ class Puzzle_tri extends Puzzle {
                     }
                     break;
                 case "8": //long
-                    if (this[pu].number[i][1] === 5) {
-                        set_font_style(this.ctx, 0.4 * this.size.toString(10), this[pu].number[i][1]);
-                        set_circle_style(this.ctx, 7);
-                        this.ctx.fillRect(this.point[i].x - 0.2 * this.size, this.point[i].y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    {
+                        let number_data = this[pu].number[i];
+                        let lines = number_data[0].split('\n');
+                        let p_x = this.point[i].x;
+                        let p_y = this.point[i].y;
+                        for (let line of lines) {
+                            if (number_data[1] === 5) {
+                                set_font_style(this.ctx, 0.4 * this.size.toString(10), number_data[1]);
+                                set_circle_style(this.ctx, 7);
+                                this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(line).width, 0.4 * this.size);
+                            }
+                            set_font_style(this.ctx, 0.4 * this.size.toString(10), number_data[1]);
+                            this.ctx.textAlign = "left";
+                            this.ctx.text(line, p_x - 0.2 * this.size, p_y);
+                            p_y += this.size * 0.4;
+                        }
                     }
-                    set_font_style(this.ctx, 0.4 * this.size.toString(10), this[pu].number[i][1]);
-                    this.ctx.textAlign = "left";
-                    this.ctx.text(this[pu].number[i][0], this.point[i].x - 0.2 * this.size, this.point[i].y);
                     break;
             }
         }

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -1133,14 +1133,23 @@ class Puzzle_truncated_square extends Puzzle {
                     }
                     break;
                 case "8": //long
-                    if (this[pu].number[i][1] === 5) {
-                        set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                        set_circle_style(this.ctx, 7);
-                        this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    {
+                        let number_data = this[pu].number[i];
+                        let lines = number_data[0].split('\n');
+                        let p_x = this.point[i].x;
+                        let p_y = this.point[i].y;
+                        for (let line of lines) {
+                            if (number_data[1] === 5) {
+                                set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                                set_circle_style(this.ctx, 7);
+                                this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(line).width, 0.5 * this.size);
+                            }
+                            set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                            this.ctx.textAlign = "left";
+                            this.ctx.text(line, p_x - 0.2 * this.size, p_y);
+                            p_y += this.size * 0.5;
+                        }
                     }
-                    set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                    this.ctx.textAlign = "left";
-                    this.ctx.text(this[pu].number[i][0], p_x - 0.2 * this.size, p_y);
                     break;
             }
         }
@@ -5305,14 +5314,23 @@ class Puzzle_iso extends Puzzle_truncated_square {
                     }
                     break;
                 case "8": //long
-                    if (this[pu].number[i][1] === 5) {
-                        set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                        set_circle_style(this.ctx, 7);
-                        this.ctx.fillRect(this.point[i].x - 0.2 * this.size, this.point[i].y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    {
+                        let number_data = this[pu].number[i];
+                        let lines = number_data[0].split('\n');
+                        let p_x = this.point[i].x;
+                        let p_y = this.point[i].y;
+                        for (let line of lines) {
+                            if (number_data[1] === 5) {
+                                set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                                set_circle_style(this.ctx, 7);
+                                this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(line).width, 0.5 * this.size);
+                            }
+                            set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                            this.ctx.textAlign = "left";
+                            this.ctx.text(line, p_x - 0.2 * this.size, p_y);
+                            p_y += this.size * 0.5;
+                        }
                     }
-                    set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                    this.ctx.textAlign = "left";
-                    this.ctx.text(this[pu].number[i][0], this.point[i].x - 0.2 * this.size, this.point[i].y);
                     break;
             }
         }
@@ -8006,14 +8024,23 @@ class Puzzle_penrose_P3 extends Puzzle {
                     }
                     break;
                 case "8": //long
-                    if (this[pu].number[i][1] === 5) {
-                        set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                        set_circle_style(this.ctx, 7);
-                        this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(this[pu].number[i][0]).width, 0.5 * this.size);
+                    {
+                        let number_data = this[pu].number[i];
+                        let lines = number_data[0].split('\n');
+                        let p_x = this.point[i].x;
+                        let p_y = this.point[i].y;
+                        for (let line of lines) {
+                            if (number_data[1] === 5) {
+                                set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                                set_circle_style(this.ctx, 7);
+                                this.ctx.fillRect(p_x - 0.2 * this.size, p_y - 0.25 * this.size, this.ctx.measureText(line).width, 0.5 * this.size);
+                            }
+                            set_font_style(this.ctx, 0.5 * this.size.toString(10), number_data[1]);
+                            this.ctx.textAlign = "left";
+                            this.ctx.text(line, p_x - 0.2 * this.size, p_y);
+                            p_y += this.size * 0.5;
+                        }
                     }
-                    set_font_style(this.ctx, 0.5 * this.size.toString(10), this[pu].number[i][1]);
-                    this.ctx.textAlign = "left";
-                    this.ctx.text(this[pu].number[i][0], p_x - 0.2 * this.size, p_y);
                     break;
             }
         }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1068,7 +1068,7 @@ onload = function() {
 
     function window_click(e) {
         let eventTarget = e.target;
-        if (eventTarget.classList.contains('fa')) {
+        if (eventTarget.classList.contains('fa') || eventTarget.classList.contains('rotate')) {
             eventTarget = eventTarget.parentElement;
         }
 
@@ -1951,6 +1951,10 @@ onload = function() {
         } else if (e.target.id.slice(0, 3) === "st_") { // Style mode
             pu.stylemode_check(e.target.id.slice(0, -3));
             e.preventDefault();
+        }
+        // Number orientation
+        if (eventTarget.id.slice(0, 4) === "rot_") {
+            pu.set_orientation(eventTarget.id.slice(4, -3));
         }
         // Combination mode
         if (eventTarget.id.slice(0, 9) === "combisub_") {


### PR DESCRIPTION
This adds a few new features to number mode:

- Increase the length limit for long numbers. I don't feel strongly about the actual limit here, but I needed more than it currently supported. I also don't really see the benefit in having a limit at all.
- Line breaks are now preserved in long number submode. The line height looks a bit squished as is, but it fits nicely on two lines per grid row, which is kind of neat.
- All number submodes can now be rotated by multiples of 90 degrees.

TODOs:

- [ ] Arrow submode numbers are currently rotated in their entirety, but it would probably be better to rotate only the number and leave the arrow unchanged.
- [ ] Implement number rotation on non-square grids or hide the relevant UI.