### PR TITLE
Fix bug in plotting vertex 0 in polygons

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12417,7 +12417,7 @@ class Puzzle {
 
     draw_polygonsp(pu) {
         for (var i = 0; i < this[pu].polygon.length; i++) {
-            if (this[pu].polygon[i][0]) {
+            if (this[pu].polygon[i][0] != null) {
                 this.ctx.setLineDash([]);
                 this.ctx.lineCap = "square";
                 if (UserSettings.custom_colors_on && this[pu + "_col"].polygon[i]) {


### PR DESCRIPTION
Free polygons were not being plotted if their first vertex was vertex 0, due to an incorrect test.