### PR TITLE
feat: optimize `Draw on edges` functionability

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12718,28 +12718,43 @@ class Puzzle {
                 set_line_style(this.ctx, 101);
                 if (factor < 1) {
                     this.ctx.beginPath();
-                    for (var j = 0; j < this.point[k].surround.length; j++) {
-                        switch (j) {
-                            case 0:
-                                this.ctx.moveTo(this.point[this.point[k].surround[a[0]]].x + offset, this.point[this.point[k].surround[a[0]]].y + offset);
-                                break;
-                            case 1:
-                                this.ctx.lineTo(this.point[this.point[k].surround[a[1]]].x - offset, this.point[this.point[k].surround[a[1]]].y + offset);
-                                break;
-                            case 2:
-                                this.ctx.lineTo(this.point[this.point[k].surround[a[2]]].x - offset, this.point[this.point[k].surround[a[2]]].y - offset);
-                                break;
-                            case 3:
-                                this.ctx.lineTo(this.point[this.point[k].surround[a[3]]].x + offset, this.point[this.point[k].surround[a[3]]].y - offset);
-                                break;
-                            case 4:
-                                // only useful and hard coded for cairo_pentagonal
-                                this.ctx.lineTo(this.point[this.point[k].surround[4]].x + offset, this.point[this.point[k].surround[4]].y - offset);
-                                break;
+                    if (this.point[k].type === 0 && this.point[k].surround.length > 0) {
+                        for (var j = 0; j < this.point[k].surround.length; j++) {
+                            switch (j) {
+                                case 0:
+                                    this.ctx.moveTo(this.point[this.point[k].surround[a[0]]].x + offset, this.point[this.point[k].surround[a[0]]].y + offset);
+                                    break;
+                                case 1:
+                                    this.ctx.lineTo(this.point[this.point[k].surround[a[1]]].x - offset, this.point[this.point[k].surround[a[1]]].y + offset);
+                                    break;
+                                case 2:
+                                    this.ctx.lineTo(this.point[this.point[k].surround[a[2]]].x - offset, this.point[this.point[k].surround[a[2]]].y - offset);
+                                    break;
+                                case 3:
+                                    this.ctx.lineTo(this.point[this.point[k].surround[a[3]]].x + offset, this.point[this.point[k].surround[a[3]]].y - offset);
+                                    break;
+                                case 4:
+                                    // only useful and hard coded for cairo_pentagonal
+                                    this.ctx.lineTo(this.point[this.point[k].surround[4]].x + offset, this.point[this.point[k].surround[4]].y - offset);
+                                    break;
+                            }
+                        }
+                    } else {
+                        // default: render rectangles on edges
+                        let r = 0.2;
+                        let n = 4;
+                        let th = 45;
+
+                        let x = this.point[k].x;
+                        let y = this.point[k].y
+
+                        this.ctx.moveTo(x - r * Math.cos(th * (Math.PI / 180)) * this.size, y - r * Math.sin(th * (Math.PI / 180)) * this.size);
+                        for (var i = 0; i < n - 1; i++) {
+                            th += 360 / n;
+                            this.ctx.lineTo(x - r * Math.cos(th * (Math.PI / 180)) * this.size, y - r * Math.sin(th * (Math.PI / 180)) * this.size);
                         }
                     }
                     this.ctx.closePath();
-                    // this.ctx.fill();
                     this.ctx.stroke();
                 } else {
                     let r, n, th;
@@ -12749,7 +12764,7 @@ class Puzzle {
                         n = 4;
                         th = 45;
                     } else if (this.gridtype === "hex") {
-                        r = 0.45;
+                        r = (this.point[k].surround.length === 6) ? 0.45 : 0.2;
                         n = 6;
                         th = 30 + this.theta;
                     } else if (this.gridtype === "tri") {
@@ -12759,18 +12774,22 @@ class Puzzle {
                             th = 90;
                         } else if (parseInt(k / (this.n0) ** 2) === 2) {
                             th = 150;
+                        } else {
+                            r = 0.2;
+                            n = 6;
+                            th = 30 + this.theta;
                         }
                     } else if (this.gridtype === "pyramid") {
-                        r = 0.6;
+                        r = (this.point[k].surround.length === 6) ? 0.6 : 0.2;
                         n = 4;
                         th = 45;
                     } else if (this.gridtype === "truncated_square") {
-                        if (parseInt(k % 2) === 0) { // Even numbers are octa shape, odd numbers are square shape
+                        if (this.point[k].surround.length === 8) { // Even numbers are octa shape, odd numbers are square shape
                             r = 0.65;
                             n = 8;
                             th = 22.5;
                         } else {
-                            r = 0.3;
+                            r = (this.point[k].surround.length === 4) ? 0.3 : 0.2;
                             n = 4;
                             th = 45;
                         }
@@ -12803,6 +12822,10 @@ class Puzzle {
                                 n = 4;
                                 th = 105;
                             }
+                        } else {
+                            r = 0.2;
+                            n = 4;
+                            th = 45;
                         }
                     }
                     let x = this.point[k].x;

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12734,9 +12734,12 @@ class Puzzle {
                                     this.ctx.lineTo(this.point[this.point[k].surround[a[3]]].x + offset, this.point[this.point[k].surround[a[3]]].y - offset);
                                     break;
                                 case 4:
-                                    // only useful and hard coded for cairo_pentagonal
+                                    // only useful and hard coded for cairo_pentagonal and rhombitrihexagonal
                                     this.ctx.lineTo(this.point[this.point[k].surround[4]].x + offset, this.point[this.point[k].surround[4]].y - offset);
                                     break;
+                                case 5:
+                                    // only useful and hard coded for rhombitrihexagonal
+                                    this.ctx.lineTo(this.point[this.point[k].surround[5]].x + offset, this.point[this.point[k].surround[5]].y - offset);
                             }
                         }
                     } else {

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -1956,6 +1956,10 @@ function load(urlParam, type = 'url', origurl = null) {
         if (rtext_para[19] === "ON" || rtext_para[19] === "1") {
             UserSettings.draw_edges = true;
         }
+        
+        if (rtext_para[19] === "OFF" || rtext_para[19] === "2") {
+            UserSettings.draw_edges = false;
+        }
     }
 
     // multisolution status


### PR DESCRIPTION
This PR will implement three features:

- fix the `Draw on Edges` box cannot be set to `OFF` on importing URLs when it is set to `ON` already. 
  - For example, the following [link](http://swaroopg92.github.io/penpa-edit/#m=edit&p=7VRdT+M6EH3vr1j5FUvEDS1pJB76BRKCXrqU7UIUVW7qkoAbQz4Auep/Z+ykapIGdPdhV6y0Sn3m5ExszyT1iZ9TGjFMDPUzLQwRriNi6dG02noY+TUJEs7sb7ibJr6IgGD83wgvKY8ZPr996A0eu6/D7s/D1p1p3oyWBw+D8c3DYvqDjI3gMDJG3AovrwY9fnAm7y797gsbsvZVLDyfM7qg8m56/sbDU+veX5L+ud+3ljQ04mdr0nnpjU9OGk5eh9tYy44tx1ie2Q4iCKMmDIJcLMf2Wl7a8hrLa0ghTFyMVilPAk9wEaGtJi+yiU2gwx2d6rxi/UwkBvBRzoHeAvWCyONsdpEpV7YjJxipvXt6tqJoJV6Y2kzVpu49sZoHSpjTBF5h7AdPCJuQiNOFeEzzR4m7wbL7ax3AItsOFM06UKymA9XY7+2g42428HG+Qw8z21Ht3OyotaPX9hq1DGQTjFpEh/aRDsetLFg6WB0dOk0diLGNZh6zOcTIJhHSzuNxHtUqsNvIXgMSjbcaTzU2NU6gJCxNjQONhsaWxgv9zFDjVGNf45HGtn7mWDX1P9v+Y+U4ZnaWy1fr79PchgMHHsWCz+I0WlKPzdgb9RJkZ8ZTzJS0MF3NGZyYgsSFeOJBWLfCNlUSg/tQRKw2pUS2uP9oKZWqWWouokWlplfKebkX7cklKTuxJSmJ4DgW7mkUideSsqKJXxIKR7e0EgsrLzOh5RLpI63sttq9jk0DvSE9HBM31ff6585f2J3VhzK+mll9tXL0f1xEnxjOLlmVa2wH1E+cp5Ct0z8wmUK2qu85iip231RArfEVUKvWAtK+u4C4ZzCgfeAxatWqzaiqqk6jttozG7VV0W8ct/EO) will switch the `Draw on Edges` to `ON`, but another [link](http://swaroopg92.github.io/penpa-edit/#m=edit&p=7VRbT+M8EH3vr1j5FUvECS1pJB56RULQjy5l+5UoqtzUJQE3hlwAuep/x5dUTdKAdh92xUqr1GfGZ+LxjFOf5DnDMYHIkD/LhsKK5wTZaph2Sw0jfyZhSonzDXayNGCxcCD8bziEK0wTAi9mD93+Y+d10Pn/uHlnWbej1dFDf3z7sJz+QGMjPI6NEbWjq+t+lx6d87uroPNCBqR1nTA/oAQvMb+bXrzRaGjfByvUuwh69gpHRvJsT9ov3fHZWcPNC/EaG952+Bjyc8cFCEBgioGAB/nY2fArh99AfiNCACIPgnVG09BnlMVgx/FLvdAU7mDvTlVcej1NIkP4o9wX7ky4fhj7lMwvNXPtuHwCgdy7q1ZLF6zZC5Gbydrk3GfrRSiJBU7FGSZB+ASgJQJJtmSPWf4q8raQd36tA5Fk14F0dQfSq+lANvZ7O2h72634ON9FD3PHle3c7l177944G9BEwEEQtExtLG2aypzmpqVNWxnb0EbP2ifKIEMvRIadWx1G6DS3OW/q1cjU2yJT74vMfL2Vz63dXOYXpY6cjUCkcKZwqNBUOBH9QG4p7Cs0FDYVXqp3BgqnCnsKTxS21Dun8kR+8sz+WDmupZWg/DT/Ps5ruEItQMLoPMniFfbJnLxhPwWOVq1ipMRF2XpBxHUrUJSxJxpGdRl2oRIZ3kcsJrUhSZLl/UepZKgm1YLFy0pNr5jSci9K0UuUvu4lKo3FXS7McRyz1xKzxmlQIgr3vpSJRJXDTHG5RPyIK7ut98exbYA3oIZrQVN+r3/S/oWlXX4o46uJ1VcrR/3HWfyJ4OyDVbpGdgT7ifIUonX8ByJTiFb5A0WRxR6KimBrdEWwVWkR1KG6CPJAYAT3gcbIrFWZkVVVlUZudSA2cqui3rhe4x0=) will not have the chance to swtich  the `Draw on Edges` to `OFF`.
- render/unify selections on edges:
  - fix that selections not rendered on edges in certain board types (#198),
  - hexagon/triangle -> hexagon borders with `r = 0.2` on edges,
  - other shapes -> square borders with r = 0.2 on edges.
- fix hexagons rendered incorrectly in rhombit-tri-hexagonal, since the edge case is not considered.
