### PR TITLE
allow deleting circle in number-in-a-circle mode

### DIFF
--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -8294,6 +8294,10 @@ class Puzzle {
                                 } else {
                                     delete this[this.mode.qa].number[k];
                                 }
+                            } else {
+                                // For modes where going down to an empty number doesn't automatically
+                                // delete the circle, you can still delete it by hitting backspace again
+                                delete this[this.mode.qa].number[k];
                             }
                             this.record_replay("number", k, this.undoredo_counter);
                         }


### PR DESCRIPTION
In the circle submode of number mode, pressing delete until all digits are gone gets you an empty circle. Previously this meant you couldn't delete the circle at all.

With this fix you can press delete one more time to get back the behaviour of deleting the circle.