### PR TITLE
Make the translation process more robust

### DIFF
--- a/docs/js/translate.js
+++ b/docs/js/translate.js
@@ -34,8 +34,14 @@ function trans_text(button_text, label_text, placeholder) {
         }
     }
 
-    PenpaText._innerText.forEach(el => document.getElementById(el).textContent = PenpaText.get(el));
-    PenpaText._placeholder.forEach(el => document.getElementById(el).placeholder = PenpaText.get(el));
+    PenpaText._innerText.forEach(el => {
+        const element = document.getElementById(el);
+        if (element) element.textContent = PenpaText.get(el);
+    });
+    PenpaText._placeholder.forEach(el => {
+        const element = document.getElementById(el);
+        if (element) element.placeholder = PenpaText.get(el);
+    });
     document.querySelectorAll('.lb_generic_yes').forEach(el => el.textContent = PenpaText.get('yes'));
     document.querySelectorAll('.lb_generic_no').forEach(el => el.textContent = PenpaText.get('no'));
     document.querySelectorAll('.lb_generic_on').forEach(el => el.textContent = PenpaText.get('on'));
@@ -116,7 +122,7 @@ function trans() {
         "edit_bg_image": {JP: "背景を編集", EN: "Edit Background", ZH: "编辑背景"},
         "input_sudoku": {JP: "数独入出力", EN: "I/O Sudoku", ZH: "数独导入/导出"},
         "input_url": {JP: "入力", EN: "Load", ZH: "加载"},
-        "page_settings": {JP: "設定", EN: "", ZH: "设置"},
+        "page_settings": {JP: "設定", EN: "Settings", ZH: "设置"},
         "tb_undo": {JP: "戻", EN: "Undo", ZH: "撤销"},
         "tb_redo": {JP: "進", EN: "Redo", ZH: "重做"},
         "tb_reset": {JP: "選択消去", EN: "Erase selected mode", ZH: "清除所选模式"},


### PR DESCRIPTION
When I switch the language to others, an exception appears:
```
translate.js?v=3.2.3:37 Uncaught TypeError: Cannot set properties of null (setting 'textContent')
    at translate.js?v=3.2.3:37:80
    at Array.forEach (<anonymous>)
    at trans_text (translate.js?v=3.2.3:37:26)
    at trans (translate.js?v=3.2.3:574:5)
    at set app_language (settings.js?v=3.2.3:97:9)
    at document.getElementById.onchange (main.js?v=3.2.3:2079:35)
```

This is probably that some element in the PenpaText._innerText does not exist. So we add a pre-check for the existence of the element.