### PR TITLE
Added universal* killer cage support

### DIFF
--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -135,7 +135,7 @@ class Puzzle_hex extends Puzzle {
                 k++;
             }
         }
-        //  1/6
+        //  compass
         var r = 1 / 6;
         type = 5;
         for (var j = 0; j < n; j++) {
@@ -162,7 +162,7 @@ class Puzzle_hex extends Puzzle {
             }
         }
 
-        //  1/6
+        //  corner
         var r = 1 / 6;
         type = 6;
         for (var j = 0; j < n; j++) {
@@ -172,28 +172,37 @@ class Puzzle_hex extends Puzzle {
                 } else {
                     use = 1;
                 }
+                neighbor = [i + j * n];
+                this.corner_table[i + j * n] = [];
+                this.corner_table[i + j * n][point[i + j * n].surround[0]] = k;
+                this.corner_table[i + j * n][point[i + j * n].surround[1]] = k+1;
+                this.corner_table[i + j * n][point[i + j * n].surround[2]] = k+2;
+                this.corner_table[i + j * n][point[i + j * n].surround[5]] = k+3;
+                this.corner_table[i + j * n][point[i + j * n].surround[4]] = k+4;
+                this.corner_table[i + j * n][point[i + j * n].surround[3]] = k+5;
                 surround = [];
                 adjacent = [k - 6 * (n + 1) + 4 + 6 * (j % 2), k - 4, k + 1, k + 3];
-                point[k] = new Point(point[i + j * n].x - r * this.size * Math.sqrt(3), point[i + j * n].y - r * this.size, type, adjacent, surround, use);
+                point[k] = new Point(point[i + j * n].x - r * this.size * Math.sqrt(3), point[i + j * n].y - r * this.size, type, adjacent, [point[i + j * n].surround[0]], use, neighbor);
                 k++;
                 adjacent = [k - 6 * (n + 1) + 4 + 6 * (j % 2), k - 6 * (n + 1) + 8 + 6 * (j % 2), k - 1, k + 1];
-                point[k] = new Point(point[i + j * n].x, point[i + j * n].y - 2 * r * this.size, type, adjacent, surround, use);
+                point[k] = new Point(point[i + j * n].x, point[i + j * n].y - 2 * r * this.size, type, adjacent, [point[i + j * n].surround[1]], use, neighbor);
                 k++;
                 adjacent = [k - 6 * (n + 1) + 8 + 6 * (j % 2), k - 1, k + 3, k + 4];
-                point[k] = new Point(point[i + j * n].x + r * this.size * Math.sqrt(3), point[i + j * n].y - r * this.size, type, adjacent, surround, use);
+                point[k] = new Point(point[i + j * n].x + r * this.size * Math.sqrt(3), point[i + j * n].y - r * this.size, type, adjacent, [point[i + j * n].surround[2]], use, neighbor);
                 k++;
                 adjacent = [k - 4, k - 3, k + 1, k + 6 * (n - 1) - 2 + 6 * (j % 2)];
-                point[k] = new Point(point[i + j * n].x - r * this.size * Math.sqrt(3), point[i + j * n].y + r * this.size, type, adjacent, surround, use);
+                point[k] = new Point(point[i + j * n].x - r * this.size * Math.sqrt(3), point[i + j * n].y + r * this.size, type, adjacent, [point[i + j * n].surround[5]], use, neighbor);
                 k++;
                 adjacent = [k - 1, k + 1, k + 6 * (n - 1) - 2 + 6 * (j % 2), k + 6 * (n - 1) + 2 + 6 * (j % 2)];
-                point[k] = new Point(point[i + j * n].x, point[i + j * n].y + 2 * r * this.size, type, adjacent, surround, use);
+                point[k] = new Point(point[i + j * n].x, point[i + j * n].y + 2 * r * this.size, type, adjacent, [point[i + j * n].surround[4]], use, neighbor);
                 k++;
                 adjacent = [k - 3, k - 1, k + 4, k + 6 * (n - 1) + 2 + 6 * (j % 2)];
-                point[k] = new Point(point[i + j * n].x + r * this.size * Math.sqrt(3), point[i + j * n].y + r * this.size, type, adjacent, surround, use);
+                point[k] = new Point(point[i + j * n].x + r * this.size * Math.sqrt(3), point[i + j * n].y + r * this.size, type, adjacent, [point[i + j * n].surround[3]], use, neighbor);
                 k++;
             }
         }
-        this.point = point;
+        this.types = [[0], [1], [2, 3, 4], [6], [5]];
+        this.point = this.fill_neighbors(point);
     }
 
     listappend(centerlist) {
@@ -225,7 +234,9 @@ class Puzzle_hex extends Puzzle {
 
     type_set() {
         var type;
-        switch (this.mode[this.mode.qa].edit_mode) {
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -240,7 +251,7 @@ class Puzzle_hex extends Puzzle {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                if (submode === "3") {
                     type = [5];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -251,18 +262,18 @@ class Puzzle_hex extends Puzzle {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2, 3, 4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2, 3, 4];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2, 3, 4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "6") {
+                } else if (submode === "6") {
                     type = [1, 2, 3, 4];
                 } else {
                     type = [1];
@@ -276,17 +287,22 @@ class Puzzle_hex extends Puzzle {
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0];
                 }
                 break;
             case "cage":
-                type = [6];
+                case "cage":
+                if (submode === "1") {
+                    type = [0];
+                } else if (submode === "2") {
+                    type = [6];
+                }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -1022,130 +1038,6 @@ class Puzzle_hex extends Puzzle {
             this.ctx.beginPath();
             this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
             this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-            this.ctx.stroke();
-        }
-    }
-
-    draw_cage(pu) {
-        var r = 0.16; //space between grid
-        var r0 = Math.sqrt(3) / 3 - 1 / 3 - r;
-
-        for (var i in this[pu].cage) {
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            var x1, y1, x2, y2, x3 = -1,
-                y3 = -1,
-                th;
-
-            if (i1 % 6 === 0) {
-                th = this.rotate_theta_cage(150);
-                x1 = this.point[i1].x + r * Math.cos(th) * this.size;
-                y1 = this.point[i1].y - r * Math.sin(th) * this.size;
-                if (i2 % 6 === 1) {
-                    th = this.rotate_theta_cage(90);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                } else if (i2 % 6 === 3) {
-                    th = this.rotate_theta_cage(210);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                }
-            } else if (i1 % 6 === 1) {
-                th = this.rotate_theta_cage(90);
-                x1 = this.point[i1].x + r * Math.cos(th) * this.size;
-                y1 = this.point[i1].y - r * Math.sin(th) * this.size;
-                if (i2 % 6 === 2) {
-                    th = this.rotate_theta_cage(30);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                }
-            } else if (i1 % 6 === 2) {
-                th = this.rotate_theta_cage(30);
-                x1 = this.point[i1].x + r * Math.cos(th) * this.size;
-                y1 = this.point[i1].y - r * Math.sin(th) * this.size;
-                if (i2 % 6 === 0) {
-                    th = this.rotate_theta_cage(150);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                    th = this.rotate_theta_cage(330);
-                    x3 = x1 + r0 * Math.cos(th) * this.size;
-                    y3 = y1 - r0 * Math.sin(th) * this.size;
-                } else if (i2 % 6 === 5) {
-                    th = this.rotate_theta_cage(330);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                }
-            } else if (i1 % 6 === 3) {
-                th = this.rotate_theta_cage(210);
-                x1 = this.point[i1].x + r * Math.cos(th) * this.size;
-                y1 = this.point[i1].y - r * Math.sin(th) * this.size;
-                if (i2 % 6 === 1) {
-                    th = this.rotate_theta_cage(90);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                    th = this.rotate_theta_cage(270);
-                    x3 = x1 + r0 * Math.cos(th) * this.size;
-                    y3 = y1 - r0 * Math.sin(th) * this.size;
-                } else if (i2 % 6 === 4) {
-                    th = this.rotate_theta_cage(270);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                }
-            } else if (i1 % 6 === 4) {
-                th = this.rotate_theta_cage(270);
-                x1 = this.point[i1].x + r * Math.cos(th) * this.size;
-                y1 = this.point[i1].y - r * Math.sin(th) * this.size;
-                if (i2 % 6 === 0) {
-                    th = this.rotate_theta_cage(150);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                    th = this.rotate_theta_cage(330);
-                    x3 = x1 + r0 * Math.cos(th) * this.size;
-                    y3 = y1 - r0 * Math.sin(th) * this.size;
-                } else if (i2 % 6 === 2) {
-                    th = this.rotate_theta_cage(30);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                    th = this.rotate_theta_cage(210);
-                    x3 = x1 + r0 * Math.cos(th) * this.size;
-                    y3 = y1 - r0 * Math.sin(th) * this.size;
-                } else if (i2 % 6 === 5) {
-                    th = this.rotate_theta_cage(330);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                }
-            } else if (i1 % 6 === 5) {
-                th = this.rotate_theta_cage(330);
-                x1 = this.point[i1].x + r * Math.cos(th) * this.size;
-                y1 = this.point[i1].y - r * Math.sin(th) * this.size;
-                if (i2 % 6 === 1) {
-                    th = this.rotate_theta_cage(90);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                    th = this.rotate_theta_cage(270);
-                    x3 = x1 + r0 * Math.cos(th) * this.size;
-                    y3 = y1 - r0 * Math.sin(th) * this.size;
-                } else if (i2 % 6 === 3) {
-                    th = this.rotate_theta_cage(210);
-                    x2 = this.point[i2].x + r * Math.cos(th) * this.size;
-                    y2 = this.point[i2].y - r * Math.sin(th) * this.size;
-                    th = this.rotate_theta_cage(30);
-                    x3 = x1 + r0 * Math.cos(th) * this.size;
-                    y3 = y1 - r0 * Math.sin(th) * this.size;
-                }
-            }
-
-            set_line_style(this.ctx, this[pu].cage[i]);
-            if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].cage[i];
-            }
-
-            this.ctx.beginPath();
-            this.ctx.moveTo(x1, y1);
-            if (x3 != -1) {
-                this.ctx.lineTo(x3, y3);
-            }
-            this.ctx.lineTo(x2, y2);
             this.ctx.stroke();
         }
     }

--- a/docs/js/class_hex.js
+++ b/docs/js/class_hex.js
@@ -252,6 +252,8 @@ class Puzzle_hex extends Puzzle {
                 break;
             case "number":
                 if (submode === "3") {
+                    type = [6];
+                } else if (submode === "9") {
                     type = [5];
                 } else {
                     if (!UserSettings.draw_edges) {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -142,7 +142,7 @@ class Puzzle {
         this.surface_remove = false;
         this.panelflag = false;
         this.corner_table = []; // Table for quick lookup for cage drawing. First coordinate is cell, second is vertex
-        this.types = [];
+        this.types = [[0], [1], [2, 3, 4], [6], [5]]; // In order: cells, vertices, edges, corners, compass
         this.custom_colors = {};
         // Drawing mode
         this.mmode = ""; // Problem mode
@@ -524,21 +524,11 @@ class Puzzle {
         }))]
     }
 
-    // Returns an array grouping the types in center, vertex, edge, corner and compass
-    get_grouped_types() {
-        let output = [[],[],[],[],[]];
-        for (let i = 0; i < this.types.length; i++) {
-            let type = this.types[i];
-            output[type%10].push(type);
-        }
-        return output;
-    }
-
     // Fill the neighbor array for edges and vertices
 
     fill_neighbors(point) {
         for (var i in point) {
-            if (point[i].type%10 == 0) {
+            if (this.types[0].indexOf(point[i].type) !== -1) {
                 for (let j = 0; j < point[i].neighbor.length; j++) {
                     point[point[i].neighbor[j]].neighbor.push(parseInt(i));
                 }
@@ -548,7 +538,7 @@ class Puzzle {
             }
         }
         for (var i in point) {
-            if (point[i].type%10 == 1 || point[i].type%10 == 2) {
+            if (this.types[1].indexOf(point[i].type) !== -1 || this.types[2].indexOf(point[i].type) !== -1) {
                 point[i].neighbor = [...new Set(point[i].neighbor)];
             }    
         }
@@ -558,18 +548,18 @@ class Puzzle {
     // For this function to work correctly, cells need to have their surrond to be exact and their neighbor to contain all correct edges (there may be more edges than the correct ones)
     // This function fills in the rest of the fields, and modify incorrect fields if needed
 
-    fix_points(point) {
+    fix_points(point, fix_adjacent = true) {
         // First pass - reset fields
         for (var i in point) {
-            if (point[i].type%10 == 0) {
+            if (this.types[0].indexOf(point[i].type) !== -1 && fix_adjacent) {
                 point[i].adjacent = [];
             }
-            if (point[i].type%10 == 1) {
+            if (this.types[1].indexOf(point[i].type) !== -1) {
                 point[i].adjacent = [];
                 point[i].neighbor = [];
                 point[i].edge_to_vertex = [];
             }
-            if (point[i].type%10 == 2) {
+            if (this.types[2].indexOf(point[i].type) !== -1) {
                 point[i].adjacent = [];
                 point[i].neighbor = [];
                 point[i].edge_to_vertex = [];
@@ -579,43 +569,72 @@ class Puzzle {
         // Second pass - correctly link edges with their incident vertices, and vice versa
         for (var i in point) {
             // For all cells
-            if (point[i].type%10 == 0) {
+            if (this.types[0].indexOf(point[i].type) !== -1 && point[i].use !== -1) {
                 let deltas = [];
                 let vertices = point[i].surround;
                 let edge_bank = point[i].neighbor;
+                vertices = [...new Set(vertices)]
+                edge_bank = [...new Set(edge_bank)];
                 // Find all possible pairs of vertices
                 for (let j = 0; j < vertices.length; j++) {
-                    if (point[j].neighbor.length > 0) {
-                        point[j].neighbor = [];
-                    }
-                    point[j].neighbor.push(i);
+                    point[vertices[j]].neighbor.push(parseInt(i));
                     for (let k = j + 1; k < vertices.length; k++) {
-                        // Store how far the midpoints of these pairs lie from the edge coordinates.
-                        // If an edge is incident to two vertices, its coordinate should be roughly
-                        // at the midpoint of the two vertices
-                        let midpoint = [0.5 * point[vertices[j]].x + 0.5 * point[vertices[k]].x, 0.5 * point[vertices[j]].y + 0.5 * point[vertices[k]].y];
-                        for (let l = 0; l < edge_bank.length; l++) {
-                            deltas.push({diff: (Math.abs(point[edge_bank[l]].x - midpoint[0]) +  Math.abs(point[edge_bank[l]].y - midpoint[1])), 
-                                         v1: Math.min(vertices[j], vertices[k]), 
-                                         v2: Math.max(vertices[j], vertices[k]),
-                                         edge: edge_bank[l]});
+                        let vertex1 = point[vertices[j]];
+                        let vertex2 = point[vertices[k]];
+                        if (Math.abs(vertex1.x - vertex2.x) < 0.001) {
+                            for (let l = 0; l < edge_bank.length; l++) {
+                                if (Math.abs(point[edge_bank[l]].x - vertex1.x) < 0.001) {
+                                    if (Math.abs(vertex1.y + vertex2.y - 2*point[edge_bank[l]].y) < 0.001) {
+                                        deltas.push({diff: 0,
+                                                     v1: Math.min(vertices[j], vertices[k]),
+                                                     v2: Math.max(vertices[j], vertices[k]),
+                                                     edge: edge_bank[l]});
+                                    }
+                                }
+                            }
+                        } else if (Math.abs(vertex1.y - vertex2.y) < 0.001) {
+                            for (let l = 0; l < edge_bank.length; l++) {
+                                if (Math.abs(point[edge_bank[l]].y - vertex1.y) < 0.001) {
+                                    if (Math.abs(vertex1.x + vertex2.x - 2*point[edge_bank[l]].x) < 0.001) {
+                                        deltas.push({diff: 0,
+                                                     v1: Math.min(vertices[j], vertices[k]),
+                                                     v2: Math.max(vertices[j], vertices[k]),
+                                                     edge: edge_bank[l]});
+                                    }
+                                }
+                            }
+                        } else {
+                            for (let l = 0; l < edge_bank.length; l++) {
+                                let delta = Math.abs(((vertex1.y - point[edge_bank[l]].y)*(vertex2.x - point[edge_bank[l]].x)) -
+                                                    ((vertex1.x - point[edge_bank[l]].x)*(vertex2.y - point[edge_bank[l]].y)));
+                                if ((vertex1.x > point[edge_bank[l]].x === point[edge_bank[l]].x > vertex2.x) && (vertex1.y > point[edge_bank[l]].y === point[edge_bank[l]].y > vertex2.y)) {
+                                    deltas.push({diff: delta,
+                                                 v1: Math.min(vertices[j], vertices[k]),
+                                                 v2: Math.max(vertices[j], vertices[k]),
+                                                 edge: edge_bank[l]});
+                                }
+                            }
                         }
                     }
                 }
                 // Sort the distance, and find the best matches
                 deltas.sort((a, b) => a.diff - b.diff);
                 let edges = [];
-                for (let j = 0; j < vertices.length; j++) {
-                    // Fill in the edge_to_vertex data, and add the cell to the edge's neighbour
-                    point[deltas[j].edge].edge_to_vertex = [deltas[j].v1, deltas[j].v2];
-                    if (point[deltas[j].v1].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
-                        point[deltas[j].v1].edge_to_vertex.push(deltas[j].edge);
+                while (edges.length < vertices.length) {
+                    for (let j = 0; j < deltas.length; j++) {
+                        if (edges.indexOf(deltas[j].edge) === -1) {
+                            // Fill in the edge_to_vertex data, and add the cell to the edge's neighbour
+                            point[deltas[j].edge].edge_to_vertex = [deltas[j].v1, deltas[j].v2];
+                            if (point[deltas[j].v1].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
+                                point[deltas[j].v1].edge_to_vertex.push(deltas[j].edge);
+                            }
+                            if (point[deltas[j].v2].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
+                                point[deltas[j].v2].edge_to_vertex.push(deltas[j].edge);
+                            }
+                            point[deltas[j].edge].neighbor.push(parseInt(i));
+                            edges.push(deltas[j].edge);
+                        }
                     }
-                    if (point[deltas[j].v2].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
-                        point[deltas[j].v2].edge_to_vertex.push(deltas[j].edge);
-                    }
-                    point[deltas[j].edge].neighbor.push(parseInt(i));
-                    edges.push(deltas[j].edge);
                 }
                 point[i].neighbor = edges;
             }
@@ -623,7 +642,7 @@ class Puzzle {
         // Third pass - fix cells and vertices' adjacent fields
         for (var i in point) {
             // For all edges, which now have correct edge_to_vertex and neighbor data
-            if (point[i].type%10 == 2) {
+            if (this.types[2].indexOf(point[i].type) !== -1) {
                 let edge = point[i];
                 for (let j = 0; j < 2; j++) {
                     // Fix vertices adjacent
@@ -633,13 +652,112 @@ class Puzzle {
                         }
                     }
                     // Fix cells adjacent
-                    if (edge.neighbor.length == 2) {
+                    if (edge.neighbor.length == 2 && fix_adjacent) {
                         point[edge.neighbor[j]].adjacent.push(parseInt(edge.neighbor[(j + 1) % 2]));
                     }     
                 }
             }
         }
         return point;
+    }
+
+    // Create connections for all corners
+    point_connect_corners(point) {
+        for (var i in point) {
+            if (this.types[2].indexOf(point[i].type) !== -1) {
+                let edge = point[i];
+                let cells = edge.neighbor;
+                let vertices = edge.edge_to_vertex;
+                if (vertices.length == 2) {
+                    for (let j = 0; j < cells.length; j++) {
+                        point[this.corner_table[cells[j]][vertices[0]]].adjacent.push(parseInt(this.corner_table[cells[j]][vertices[1]]));
+                        point[this.corner_table[cells[j]][vertices[1]]].adjacent.push(parseInt(this.corner_table[cells[j]][vertices[0]]));
+                    }
+                }
+                if (cells.length == 2) {
+                    for (let j = 0; j < 2; j++) {
+                        point[this.corner_table[cells[1]][vertices[j]]].adjacent.push(parseInt(this.corner_table[cells[0]][vertices[j]]));
+                        point[this.corner_table[cells[0]][vertices[j]]].adjacent.push(parseInt(this.corner_table[cells[1]][vertices[j]]));
+                    }
+                }
+            }
+        }
+        return point;
+    }
+
+    // Add neighbor and surround to each of the corners
+    point_fillin_corners(point) {
+        let cells = [];
+        let corners = [];
+        for (var i in point) {
+            if (this.types[0].indexOf(point[i].type) !== -1 && point[i].use !== -1) {
+                cells.push(parseInt(i));
+            }
+            if (this.types[3].indexOf(point[i].type) !== -1) {
+                corners.push(parseInt(i));
+                point[i].adjacent = [];
+                point[i].neighbor = [];
+                point[i].surround = [];
+            }
+        }
+        for (let i = 0; i < cells.length; i++) {
+            this.corner_table[cells[i]] = [];
+            let cell = point[cells[i]];
+            for (let j = 0; j < cell.surround.length; j++) {
+                let vertex = point[cell.surround[j]];
+                let min = Number.MAX_VALUE;
+                let corner = 0;
+                if (Math.abs(vertex.x - cell.x) < 0.001) {
+                    for (let k = 0; k < corners.length; k++) {
+                        if (Math.abs(point[corners[k]].x - vertex.x) < 0.001) {
+                            if (vertex.y > point[corners[k]].y === point[corners[k]].y > cell.y) {
+                                corner = corners[k];
+                            }
+                        }
+                    }
+                } else if (Math.abs(vertex.y - cell.y) < 0.001) {
+                    for (let k = 0; k < corners.length; k++) {
+                        if (Math.abs(point[corners[k]].y - vertex.y) < 0.001) {
+                            if (vertex.x > point[corners[k]].x === point[corners[k]].x > cell.x) {
+                                corner = corners[k];
+                            }
+                        }
+                    }
+                } else {
+                    for (let k = 0; k < corners.length; k++) {
+                        let diff = Math.abs(((vertex.y - point[corners[k]].y)*(cell.x - point[corners[k]].x)) -
+                                            ((vertex.x - point[corners[k]].x)*(cell.y - point[corners[k]].y)));
+                        if (min > diff && (vertex.x > point[corners[k]].x === point[corners[k]].x > cell.x) && (vertex.y > point[corners[k]].y === point[corners[k]].y > cell.y)) {
+                            min = diff;
+                            corner = corners[k];
+                        }
+                    }
+                }
+                if (corner !== 0) {
+                    point[corner].surround.push(parseInt(cell.surround[j]));
+                    point[corner].neighbor.push(parseInt(cells[i]));
+                    this.corner_table[cells[i]][cell.surround[j]] = corner;
+                    this.remove_from_array(corners, corner);
+                }
+            }
+        }
+        return point;
+    }
+
+    // Create corners to be used by the puzzle
+    create_corners(point, radius, k) {
+        for (var i in point) {
+            if (this.types[0].indexOf(point[i].type) !== -1 && point[i].use !== -1) {
+                this.corner_table[i] = [];
+                let cell = point[i];
+                for (let j = 0; j < cell.surround.length; j++) {
+                    point[k] = new Point(cell.x * radius + point[cell.surround[j]].x * (1 - radius), cell.y * radius + point[cell.surround[j]].y * (1 - radius), 6, [], [parseInt(cell.surround[j])], 1, [parseInt(i)]);
+                    this.corner_table[i][cell.surround[j]] = parseInt(k);
+                    k = k + 1;
+                }
+            }
+        }
+        return [point, k];
     }
 
     point_move(x, y, theta) {
@@ -8892,7 +9010,7 @@ class Puzzle {
             this.drawing_mode = 100;
             this.last = num;
         } else if (this.mouse_mode === "move") {
-            if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] != "2" || this.point[num].type === 0) { // Not diagonal or diagonally inside
+            if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] != "2" || this.types[0].indexOf(this.point[num].type) !== -1) { // Not diagonal or diagonally inside
                 this.re_linemove(num);
                 this.last = num;
             }
@@ -9122,7 +9240,7 @@ class Puzzle {
             this.drawing_mode = 100;
             this.last = num;
         } else if (this.mouse_mode === "move") {
-            if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] != "2" || this.point[num].type === 1) { //対角線でないor対角線で内側
+            if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] != "2" || this.types[1].indexOf(this.point[num].type) !== -1) { //対角線でないor対角線で内側
                 this.re_linemoveE(num);
                 this.last = num;
             }
@@ -9386,7 +9504,7 @@ class Puzzle {
                     this.selection.splice(i, 1);
             } else if (!this.selection.includes(num) && this.drawing) {
                 // Add to selection only if the num is type 0
-                if (this.point[num].type === 0)
+                if (this.types[0].indexOf(this.point[num].type) !== -1)
                     this.selection.push(num);
             }
             this.redraw();
@@ -9470,7 +9588,7 @@ class Puzzle {
     //////////////////////////
 
     mouse_cage(x, y, num) {
-        if (document.getElementById('sub_cage1').checked) {
+        if (document.getElementById('sub_cage1').checked) /* Killer */{
             if (this.mouse_mode === "down_left") {
                 this.drawing = true;
                 // find if num already exist
@@ -9495,294 +9613,141 @@ class Puzzle {
                 } else {
                     this.cageselection = [];
                 }
-            } else if (this.mouse_mode === "up") {
+            } else if (this.mouse_mode === "up") /* Releasing the mouse with a cage selection */ {
                 this.drawing = false;
                 let cageexist_status = false;
                 let skip_cages = false;
                 let array = "cage";
-                let arraykill = "killercages";
-                let grid_matrix = [];
-                let cageexist_loc;
                 let key;
 
-                // Grid Size
-                let row_size = parseInt(this.ny0 - 4);
-                let col_size = parseInt(this.nx0 - 4);
-
-                // sort cage
-                let sortedcages = this.cageselection.sort((a, b) => a - b);
 
                 let line_style = this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1];
-
-                // Find if any cell of the new cage already has a cage
-                for (let j = 0; j < this[this.mode.qa][arraykill].length; j++) {
-                    let killercages_cells = [].concat.apply([], this[this.mode.qa][arraykill][j]);
-                    for (let i = 0; i < sortedcages.length; i++) {
-                        if (killercages_cells.includes(sortedcages[i])) {
-                            cageexist_status = true;
-                            cageexist_loc = j;
-                            break;
-                        }
-                    }
-                    if (cageexist_status) { // to exit from outermost for loop
-                        break;
-                    }
-                }
-
-                // Find if any cell of the new cage has outside half grid cells then skip
-                for (let i = 0; i < sortedcages.length; i++) {
-                    let col_num = (sortedcages[i] % (this.nx0)) - 2;
-                    let row_num = parseInt(sortedcages[i] / this.nx0) - 2;
-
-                    // If cage selection has outisde half grid cells then skip
-                    if ((row_num < 0) || (row_num >= row_size) || (col_num < 0) || (col_num >= col_size)) {
+                // Find if any cell of the new cage (if square grid) has outside half grid cells then skip
+                for (let i = 0; i < this.cageselection.length; i++) {
+                    if (this.cell_outside_for_square(this.cageselection[i])) {
                         cageexist_status = true;
                         skip_cages = true;
                         break;
                     }
                 }
 
-                if (!cageexist_status) {
 
-                    // undo redo group counter
+                if (this.cageselection.length > 1) {
+                    for (let i = 0; i < this.cageselection.length; i++) {
+                        let context = this.get_cage_context(this.cageselection[i], array);
+                        if (!this.flood_cage(this.cageselection[i], context[1], context[0], array)[0]) {
+                            cageexist_status = true;
+                        }
+                    }
+
+                    if (!cageexist_status) {
+                        // undo redo group counter
+                        this.undoredo_counter = this.undoredo_counter + 1;
+                        // remember drawing_mode
+                        let draw_mode = this.drawing_mode;
+                        this.drawing_mode = 100;
+                        let segments = this.cage_for_selection(this.cageselection);
+                        for (let i = 0; i < 2; i++) {
+                            for (let j = 0; j < segments[i].length; j++) {
+                                if (this[this.mode.qa][array][segments[i][j]] !== line_style) {
+                                    this.re_line(array, segments[i][j], line_style, this.undoredo_counter);
+                                }
+                            }
+                        }
+                        this.drawing_mode = draw_mode;
+                    }
+                } else if (!skip_cages) {
+                    let context = this.get_cage_context(this.cageselection[0], array);
+                    let result = this.flood_cage(this.cageselection[0], context[1], context[0], array);
+                    let not_in_cage = result[0];
+                    let found_cage = result[1];
                     this.undoredo_counter = this.undoredo_counter + 1;
-
-                    // if cage does not exist, then add to killer cages.
-                    this.record(arraykill, -1, this.undoredo_counter);
-                    this[this.mode.qa][arraykill].push(sortedcages);
-                    // let min_cell = Math.min(...this.cageselection);
-                    // let max_cell = Math.max(...this.cageselection);
                     // remember drawing_mode
                     let draw_mode = this.drawing_mode;
                     this.drawing_mode = 100;
+                    if (not_in_cage) /* Draw a 1x1 Cage */ {
+                        let segments = this.cage_for_selection(this.cageselection);
+                        for (let i = 0; i < 2; i++) {
+                            for (let j = 0; j < segments[i].length; j++) {
+                                if (this[this.mode.qa][array][segments[i][j]] !== line_style) {
+                                    this.re_line(array, segments[i][j], line_style, this.undoredo_counter);
+                                }
 
-                    let cage_vertices = [];
-                    let cage_edges = [];
-                    let inside_vertices = [];
-                    for (let i = 0; i < this.cageselection.length; i++) {
-                        cage_edges = cage_edges.concat(this.point[this.cageselection[i]].neighbor);
-                        cage_vertices = cage_vertices.concat(this.point[this.cageselection[i]].surround);
-                    }
-                    cage_edges = [...new Set(cage_edges)];
-                    cage_vertices = [...new Set(cage_vertices)];
-
-                    for (let i = 0; i < cage_vertices.length; i++) {
-                        if (this.point[cage_vertices[i]].neighbor.every(val => this.cageselection.includes(val))) {
-                            inside_vertices.push(cage_vertices[i]);
-                        }
-                    }
-
-                    for (let i = 0; i < cage_edges.length; i++) {
-                        let edge = this.point[cage_edges[i]];
-                        let cell_0_in = this.cageselection.includes(edge.neighbor[0]);
-                        let cell_1_in = this.cageselection.includes(edge.neighbor[1]);
-                        if (cell_0_in !== cell_1_in) {
-                            let p0 = this.corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[0]];
-                            let p1 = this.corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[1]];
-                            key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
-                            if (this[this.mode.qa][array][key] !== line_style) {
-                                this.re_line(array, key, line_style, this.undoredo_counter);
                             }
                         }
-                        else if (cell_0_in && cell_1_in) {
-                            for (let j = 0; j < 2; j++) {
-                                if (!inside_vertices.includes(edge.edge_to_vertex[j])) {
-                                    let p0 = this.corner_table[edge.neighbor[0]][edge.edge_to_vertex[j]];
-                                    let p1 = this.corner_table[edge.neighbor[1]][edge.edge_to_vertex[j]];
-                                    key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
+                    } else {
+                        let need_erase = true;
+                        let segments = this.cage_for_selection(found_cage);
+                        for (let i = 0; i < segments[0].length; i++) /* Try to restyle the cage */ {
+                            if (this[this.mode.qa][array][segments[0][i]] !== line_style) {
+                                this.re_line(array, segments[0][i], line_style, this.undoredo_counter);
+                                need_erase = false;
+                            }
+                        }
+
+                        if (need_erase) /* Same style */ {
+                            let perimeter = [];
+                            let outside = [];
+                            for (let i = 0; i < found_cage.length; i++) {
+                                let cell = found_cage[i];
+                                for (let j = 0; j < this.point[cell].adjacent.length; j++) {
+                                    if (found_cage.indexOf(this.point[cell].adjacent[j]) === -1) {
+                                        perimeter.push(cell);
+                                        outside.push(this.point[cell].adjacent[j]);
                                     }
+                                }
+                            }
+                            perimeter = [...new Set(perimeter)];
+                            outside = [...new Set(outside)];
+
+                            let sub_cages = perimeter.map((x) => this.flood_cage(x, [], true, array)).map((x) => x[0] ? [] : x[1]);
+                            let sup_cages = outside.map((x) => this.flood_cage(x, this.get_cage_context(x, array)[1], this.get_cage_context(x, array)[0], array)).map((x) => x[0] ? [] : x[1]);
+
+                            let sub_result = new Set([]);
+                            let has_been_filled = false;
+                            let sup_result = new Set([]);
+                            for (let i = 0; i < sub_cages.length; i++) {
+                                let cage = sub_cages[i];
+                                if (cage.length < found_cage.length) {
+                                    let cage_segments = this.cage_for_selection(cage);
+                                    sub_result = sub_result.union(new Set(cage_segments[0].concat(cage_segments[1])));
+                                }
+                            }
+                            for (let i = 0; i < sup_cages.length; i++) {
+                                let cage = sup_cages[i];
+                                if (cage.length > 0) {
+                                    let cage_segments = this.cage_for_selection(cage);
+                                    let segments_as_set = new Set(cage_segments[0].concat(cage_segments[1]))
+                                    if (!has_been_filled) {
+                                        sup_result = segments_as_set;
+                                    } else {
+                                        sup_result = sup_result.intersection(segments_as_set);
+                                    }
+                                }
+                            }
+                            // When removing a cage, we want to make sure that other cages do not become invalid as a result. By taking
+                            // The intersection of all supercages and the union of all subcages, we ensure that this is the case
+                            let exclude = sub_result.union(sup_result);
+                            for (let i = 0; i < 2; i++) {
+                                for (let j = 0; j < segments[i].length; j++) {
+                                    if (this[this.mode.qa][array][segments[i][j]] !== [] && !exclude.has(segments[i][j])) {
+                                        this.re_line(array, segments[i][j], this[this.mode.qa][array][segments[i][j]], this.undoredo_counter);
+                                    }
+
+                                }
+                            }
+                        } else {
+                            for (let i = 0; i < segments[1].length; i++) {
+                                if (this[this.mode.qa][array][segments[1][i]] !== line_style) {
+                                    this.re_line(array, segments[1][i], line_style, this.undoredo_counter);
                                 }
                             }
                         }
+                        this.drawing_mode = draw_mode;
                     }
-                
-                    // reset variables
-                    this.record_replay(arraykill, -1, this.undoredo_counter);
-                    this.cageselection = [];
-                    this.selection = [];
-                    this.drawing_mode = draw_mode;
-                } else {
-                    // length 1 then delete
-                    if (sortedcages.length === 1 && !skip_cages) {
-
-                        // check which style cage exist, if same style then delete or else do nothing
-                        let top_left = 4 * (this[this.mode.qa][arraykill][cageexist_loc][0] + this.nx0 * this.ny0);
-                        let top_right = top_left + 1;
-                        let bottom_left = top_left + 2;
-                        let key1 = (top_left.toString() + "," + top_right.toString());
-                        let key2 = (top_left.toString() + "," + bottom_left.toString());
-
-                        // caveat - if both of these lines are manually removed from the cage then it won't detect the cage.
-                        if (this[this.mode.qa][array][key1] === line_style || this[this.mode.qa][array][key2] === line_style) {
-
-                            // undo redo group counter
-                            this.undoredo_counter = this.undoredo_counter + 1;
-
-                            // remember drawing_mode
-                            let draw_mode = this.drawing_mode;
-                            this.drawing_mode = 100;
-
-                            // cage cell locations
-                            for (let i = 0; i < row_size; i++) {
-                                grid_matrix[i] = new Array(parseInt(col_size)).fill(0);
-                            }
-                            for (let i = 0; i < this[this.mode.qa][arraykill][cageexist_loc].length; i++) {
-                                let col_num = (this[this.mode.qa][arraykill][cageexist_loc][i] % (this.nx0)) - 2;
-                                let row_num = parseInt(this[this.mode.qa][arraykill][cageexist_loc][i] / this.nx0) - 2;
-                                grid_matrix[row_num][col_num] = 1;
-                            }
-
-
-                            for (let i = 0; i < this[this.mode.qa][arraykill][cageexist_loc].length; i++) {
-                                let col_num = (this[this.mode.qa][arraykill][cageexist_loc][i] % (this.nx0)) - 2;
-                                let row_num = parseInt(this[this.mode.qa][arraykill][cageexist_loc][i] / this.nx0) - 2;
-
-                                // current cell
-                                let top_left = 4 * (this[this.mode.qa][arraykill][cageexist_loc][i] + this.nx0 * this.ny0);
-                                let top_right = top_left + 1;
-                                let bottom_left = top_left + 2;
-                                let bottom_right = top_left + 3;
-
-                                // check if left cell is shared
-                                if (col_num !== 0) {
-                                    if (grid_matrix[row_num][col_num - 1]) {
-
-                                        // left shared cell
-                                        let top_left_left = 4 * (this[this.mode.qa][arraykill][cageexist_loc][i] - 1 + this.nx0 * this.ny0);
-                                        let top_right_left = top_left_left + 1;
-                                        let bottom_left_left = top_left_left + 2;
-                                        let bottom_right_left = top_left_left + 3;
-                                        key = (top_right_left.toString() + "," + top_left.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                        key = (bottom_right_left.toString() + "," + bottom_left.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                    } else {
-                                        key = (top_left.toString() + "," + bottom_left.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter); // left line
-                                        }
-                                    }
-                                } else {
-                                    key = (top_left.toString() + "," + bottom_left.toString());
-                                    if (this[this.mode.qa][array][key] === line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter); // left line
-                                    }
-                                }
-
-                                // check if top cell is shared
-                                if (row_num !== 0) {
-                                    if (grid_matrix[row_num - 1][col_num]) {
-
-                                        // top shared cell
-                                        let top_left_top = 4 * (this[this.mode.qa][arraykill][cageexist_loc][i] - this.nx0 + this.nx0 * this.ny0);
-                                        let top_right_top = top_left_top + 1;
-                                        let bottom_left_top = top_left_top + 2;
-                                        let bottom_right_top = top_left_top + 3;
-                                        key = (bottom_left_top.toString() + "," + top_left.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                        key = (bottom_right_top.toString() + "," + top_right.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                    } else {
-                                        key = (top_left.toString() + "," + top_right.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter); // top line
-                                        }
-                                    }
-                                } else {
-                                    key = (top_left.toString() + "," + top_right.toString());
-                                    if (this[this.mode.qa][array][key] === line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter); // top line
-                                    }
-                                }
-
-                                // check if right cell is shared
-                                if (col_num !== col_size - 1) {
-                                    if (grid_matrix[row_num][col_num + 1]) {
-
-                                        // top shared cell
-                                        let top_left_right = 4 * (this[this.mode.qa][arraykill][cageexist_loc][i] + 1 + this.nx0 * this.ny0);
-                                        let top_right_right = top_left_right + 1;
-                                        let bottom_left_right = top_left_right + 2;
-                                        let bottom_right_right = top_left_right + 3;
-                                        key = (top_right.toString() + "," + top_left_right.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                        key = (bottom_right.toString() + "," + bottom_left_right.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                    } else {
-                                        key = (top_right.toString() + "," + bottom_right.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter); // right line
-                                        }
-                                    }
-                                } else {
-                                    key = (top_right.toString() + "," + bottom_right.toString());
-                                    if (this[this.mode.qa][array][key] === line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter); // right line
-                                    }
-                                }
-
-                                // check if bottom cell is shared
-                                if (row_num !== row_size - 1) {
-                                    if (grid_matrix[row_num + 1][col_num]) {
-
-                                        // top shared cell
-                                        let top_left_bottom = 4 * (this[this.mode.qa][arraykill][cageexist_loc][i] + this.nx0 + this.nx0 * this.ny0);
-                                        let top_right_bottom = top_left_bottom + 1;
-                                        let bottom_left_bottom = top_left_bottom + 2;
-                                        let bottom_right_bottom = top_left_bottom + 3;
-                                        key = (bottom_left.toString() + "," + top_left_bottom.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                        key = (bottom_right.toString() + "," + top_right_bottom.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter);
-                                        }
-                                    } else {
-                                        key = (bottom_left.toString() + "," + bottom_right.toString());
-                                        if (this[this.mode.qa][array][key] === line_style) {
-                                            this.re_line(array, key, line_style, this.undoredo_counter); // bottom line
-                                        }
-                                    }
-                                } else {
-                                    key = (bottom_left.toString() + "," + bottom_right.toString());
-                                    if (this[this.mode.qa][array][key] === line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter); // bottom line
-                                    }
-                                }
-                            }
-
-                            // Save the current killercage and then delete
-                            this.record(arraykill, cageexist_loc, this.undoredo_counter);
-                            this[this.mode.qa][arraykill][cageexist_loc] = [];
-                            if (UserSettings.custom_colors_on) {
-                                this[this.mode.qa + "_col"][arraykill][cageexist_loc] = [];
-                            }
-                            this.record_replay(arraykill, cageexist_loc, this.undoredo_counter);
-                            this.drawing_mode = draw_mode;
-                        }
-                    }
-                    // length > 1 do not do anything
-                    // reset variables
-                    this.cageselection = [];
-                    this.selection = [];
                 }
-
                 // reset variables
+                this.cageselection = [];
                 this.selection = [];
 
                 // Draw up cages
@@ -9794,7 +9759,7 @@ class Puzzle {
 
                 this.drawing = false;
             }
-        } else if (document.getElementById('sub_cage2').checked) {
+        } else if (document.getElementById('sub_cage2').checked) /* Free */ {
             if (this.mouse_mode === "down_left") {
                 this.drawing = true;
                 this.drawing_mode = 100;
@@ -9810,6 +9775,204 @@ class Puzzle {
                 this.last = -1;
             }
         }
+    }
+
+    // Return the cage segments given a selection
+    cage_for_selection(selection) {
+        let key;
+        let output = [[],[]];
+        let cage_vertices = [];
+        let cage_edges = [];
+        let inside_vertices = [];
+        for (let i = 0; i < selection.length; i++) {
+            cage_edges = cage_edges.concat(this.point[selection[i]].neighbor);
+            cage_vertices = cage_vertices.concat(this.point[selection[i]].surround);
+        }
+        cage_edges = [...new Set(cage_edges)];
+        cage_vertices = [...new Set(cage_vertices)];
+
+        for (let i = 0; i < cage_vertices.length; i++) /* check what are the vertices that are fully contained in the cage */ {
+            if (this.point[cage_vertices[i]].neighbor.filter(val => selection.includes(val)).length == this.point[cage_vertices[i]].edge_to_vertex.length) {
+                inside_vertices.push(cage_vertices[i]);
+            }
+        }
+
+        for (let i = 0; i < cage_edges.length; i++) {
+            let edge = this.point[cage_edges[i]];
+            let cell_0_in = selection.includes(edge.neighbor[0]);
+            let cell_1_in = selection.includes(edge.neighbor[1]);
+            if (cell_0_in !== cell_1_in) {
+                let p0 = this.corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[0]];
+                let p1 = this.corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[1]];
+                key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
+                output[0].push(key);
+            }
+            else if (cell_0_in && cell_1_in) {
+                for (let j = 0; j < 2; j++) {
+                    if (!inside_vertices.includes(edge.edge_to_vertex[j])) {
+                        let p0 = this.corner_table[edge.neighbor[0]][edge.edge_to_vertex[j]];
+                        let p1 = this.corner_table[edge.neighbor[1]][edge.edge_to_vertex[j]];
+                        key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
+                        output[1].push(key);
+                    }
+                }
+            }
+        }
+
+        return output;
+    }
+
+    // From a given cell and context, returns [not_in_cage, cage], where not_in_cage is a boolean
+    // That is true if the cell is not in a cage, and cage is the array of all cells of the found
+    // Cage otherwise
+    flood_cage(cell, context, full, array) {
+        let found_cage = [];
+        let cage_queue = [cell];
+        let not_in_cage = false;
+        while (cage_queue.length > 0) {
+            let cell = cage_queue.shift();
+            found_cage.push(cell);
+            if (this.cell_outside_for_square(cell) || !this.corner_table[cell]) {
+                not_in_cage = true;
+                break;
+            }
+            if (!!this.point[cell].neighbor) {
+                for (let i = 0; i < this.point[cell].neighbor.length; i++) {
+                    let edge = this.point[cell].neighbor[i];
+                    let p0 = this.corner_table[cell][this.point[edge].edge_to_vertex[0]];
+                    let p1 = this.corner_table[cell][this.point[edge].edge_to_vertex[1]];
+                    let inner_cage_edge = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
+                    if (!this[this.mode.qa][array][inner_cage_edge]) {
+                        if (this.point[edge].neighbor.length === 2) {
+                            let outer_cell = this.point[edge].neighbor[0] == cell ? this.point[edge].neighbor[1] : this.point[edge].neighbor[0];
+                            if ((full || context.indexOf(outer_cell) !== -1)) {
+                                if (cage_queue.indexOf(outer_cell) === -1 && found_cage.indexOf(outer_cell) === -1) {
+                                    cage_queue.push(outer_cell);
+                                }
+                            } else {
+                                not_in_cage = true;
+                                break;
+                            }
+                        } else {
+                            not_in_cage = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        let output = [not_in_cage, found_cage];
+        return output;
+    }
+
+    get_cage_context(cell, array) {
+        // Find the "context" of the cell. That is, the smallest region that is fully defined
+        // by cage segments on the outside of it. As an example:
+        // AAAA
+        // A-xA
+        // A-AA
+        // AAA-
+        // If A is a cage, the context of x is the two - cells fully surrounded by As, plus x
+        let full = false;
+        let context = [];
+        let flood_queue = [];
+        let outsides = [];
+        flood_queue.push(cell);
+        while (flood_queue.length > 0) {
+            let cell = flood_queue.shift();
+            context.push(cell);
+            if (this.cell_outside_for_square(cell)) {
+                full = true;
+                break;
+            }
+            if (!!this.point[cell]) {
+                for (let i = 0; i < this.point[cell].neighbor.length; i++) {
+                    let edge = this.point[cell].neighbor[i];
+                    if (this.point[edge].neighbor.length === 1) /* Reached the outside */{
+                        full = true;
+                        break;
+                    } else {
+                        let outer_cell = this.point[edge].neighbor[0] == cell ? this.point[edge].neighbor[1] : this.point[edge].neighbor[0];
+                        if (flood_queue.indexOf(outer_cell) === -1 && context.indexOf(outer_cell) === -1) {
+                            if (!this.corner_table[outer_cell]) {
+                                full = true;
+                                break;
+                            }
+                            let p0 = this.corner_table[outer_cell][this.point[edge].edge_to_vertex[0]];
+                            let p1 = this.corner_table[outer_cell][this.point[edge].edge_to_vertex[1]];
+                            let outer_cage_edge = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
+                            if (!this[this.mode.qa][array][outer_cage_edge]) {
+                                this.remove_from_array(outsides, outer_cell);
+                                flood_queue.push(outer_cell);
+                            }
+                            else {
+                                outsides.push(outer_cell);
+                            }
+                        }
+                    }
+                }
+                if (full) {
+                    break;
+                }
+            }
+        }
+        if (!full) {
+            // The context should not contain any holes. For every cell in outsides, we check if we can reach
+            // the outside of the grid. If we cannot, we add the hole defined by that cell to the context
+            while (outsides.length > 0) {
+                let temp_queue = [outsides.shift()];
+                let temp_area = [];
+                let reached_outside = false;
+                while (temp_queue.length > 0) {
+                    let cell = temp_queue.shift();
+                    temp_area.push(cell);
+                    if (this.cell_outside_for_square(cell) || !this.corner_table[cell]) {
+                        reached_outside = true;
+                        break;
+                    }
+                    if (!!this.point[cell].neighbor) {
+                        for (let i = 0; i < this.point[cell].neighbor.length; i++) {
+                            let edge = this.point[cell].neighbor[i];
+                            if (this.point[edge].neighbor.length === 1) /* Reached the outside */{
+                                reached_outside = true;
+                                break;
+                            } else {
+                                let outer_cell = this.point[edge].neighbor[0] == cell ? this.point[edge].neighbor[1] : this.point[edge].neighbor[0];
+                                if (context.indexOf(outer_cell) === -1) {
+                                    if (temp_queue.indexOf(outer_cell) === -1 && temp_area.indexOf(outer_cell) === -1) {
+                                        temp_queue.push(outer_cell);
+                                    }
+                                    this.remove_from_array(outsides, outer_cell);
+                                }
+                            }
+                        }
+                        if (reached_outside) {
+                            break;
+                        }
+                    }
+                }
+                if (!reached_outside) {
+                    context = context.concat(temp_area);
+                }
+            }
+        }
+        let output = [full, context];
+        return output;
+    }
+
+    // Returns true if a cell is partly outside on a square grid
+    cell_outside_for_square(cell) {
+        if (this.grid_is_square()) {
+            let row_size = parseInt(this.ny0 - 4);
+            let col_size = parseInt(this.nx0 - 4);
+            let col_num = (cell % (this.nx0)) - 2;
+            let row_num = parseInt(cell / this.nx0) - 2;
+
+            if ((row_num < 0) || (row_num >= row_size) || (col_num < 0) || (col_num >= col_size)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     re_linecage(num) {
@@ -9833,19 +9996,19 @@ class Puzzle {
         if (this.mouse_mode === "down_left") {
             if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
                 this.re_polygondown(num);
-            } else if (this.point[num].type === 0) {
+            } else if (this.types[0].indexOf(this.point[num].type) !== -1) {
                 this.re_specialdown(num, this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]);
             }
         } else if (this.mouse_mode === "move") {
             if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
                 this.re_polygonmove(num);
-            } else if (this.drawing && this.point[num].type === 0 && num != this.last) {
+            } else if (this.drawing && this.types[0].indexOf(this.point[num].type) !== -1 && num != this.last) {
                 this.re_special(num, this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]);
             }
         } else if (this.mouse_mode === "up") {
             if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] != "polygon") {
                 if (this.point[num].use === 1) {
-                    if (this.point[num].type === 0) {
+                    if (this.types[0].indexOf(this.point[num].type) !== -1) {
                         this.re_specialup(num, this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]);
                     }
                 }
@@ -10563,7 +10726,7 @@ class Puzzle {
     }
 
     re_combi_shaka(x, y, num) {
-        if (this.point[num].type === 0) {
+        if (this.types[0].indexOf(this.point[num].type) !== -1) {
             this.last = num;
             this.lastx = x;
             this.lasty = y;
@@ -10593,7 +10756,7 @@ class Puzzle {
     }
 
     re_combi_shaka_up(num) {
-        if (this.point[num].type === 0 && this.last === num) {
+        if (this.types[0].indexOf(this.point[num].type) !== -1 && this.last === num) {
             if (!this[this.mode.qa].symbol[num] || (this[this.mode.qa].symbol[num] && this[this.mode.qa].symbol[num][1] === "tri")) {
                 this.record("symbol", num);
                 this[this.mode.qa].symbol[num] = [8, "ox_B", 2];
@@ -10619,7 +10782,7 @@ class Puzzle {
     re_combi_linex_move(num) {
         if (this.drawing_mode != -1 &&
             this.mouse_click !== 2 &&
-            this.point[num].type === 0) {
+            this.types[0].indexOf(this.point[num].type) !== -1) {
             let line_style = this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1];
             var array;
             if (this.point[num].adjacent.indexOf(parseInt(this.last)) != -1) {
@@ -10629,7 +10792,7 @@ class Puzzle {
             }
             this.last = num;
             this.redraw();
-        } else if ((this.point[num].type === 2 || this.point[num].type === 3) && (this.ondown_key === "mousedown")) {
+        } else if ((this.types[2].indexOf(this.point[num].type) !== -1) && (this.ondown_key === "mousedown")) {
             if (this.drawing_mode == 52) {
                 if (!this[this.mode.qa].line[num]) { // Insert cross
                     this.record("line", num);
@@ -10654,7 +10817,7 @@ class Puzzle {
     }
 
     re_combi_lineox_move(num) {
-        if (this.drawing_mode != -1 && this.point[num].type === 0) {
+        if (this.drawing_mode != -1 && this.types[0].indexOf(this.point[num].type) !== -1) {
             let line_style = this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1];
             var array;
             if (this.point[num].adjacent.indexOf(parseInt(this.last)) != -1) {
@@ -10680,7 +10843,7 @@ class Puzzle {
             secondsymbol = [1, "ox_E", 2];
         }
 
-        if (this.point[num].type === 0 && this.last === num && this.first === num && !this.linedrawing) {
+        if (this.types[0].indexOf(this.point[num].type) !== -1 && this.last === num && this.first === num && !this.linedrawing) {
             if (!this[this.mode.qa].symbol[num]) {
                 this.record("symbol", num);
                 this[this.mode.qa].symbol[num] = firstsymbol;
@@ -12755,13 +12918,19 @@ class Puzzle {
             let total_radius, radius;
             let offset = 3.7;
 
-            let regulars = ["square", "hex", "tri", "pyramid", "cube", "cairo_pentagonal", "sudoku", "kakuro", "tetrakis_square", "deltaoidal_trihexagonal"];
+            let regulars = ["square", "hex", "tri", "pyramid", "iso", "cairo_pentagonal", "sudoku", "kakuro", "tetrakis_square", "deltaoidal_trihexagonal"];
             set_line_style(this.ctx, 101);
 
-            if (this.gridtype in regulars && !!this.selection[0]) { // If all cells are the same shape, no need to recompute
-                total_radius = Math.sqrt((this.point[this.selection[0]].x - ((this.point[this.point[this.selection[0]].surround[0]].x) + (this.point[this.point[this.selection[0]].surround[1]].x)) * 0.5) ** 2 +
-                    (this.point[this.selection[0]].y - ((this.point[this.point[this.selection[0]].surround[0]].y) + (this.point[this.point[this.selection[0]].surround[1]].y)) * 0.5) ** 2);
-                radius = (total_radius - offset) / total_radius;
+            if (regulars.indexOf(this.gridtype) !== -1 && !!this.selection[0]) { // If all cells are the same shape, no need to recompute
+                let stop = false;
+                for (var k of this.selection) {
+                    if (this.point[k].type == 0 && !stop) {
+                        total_radius = Math.sqrt((this.point[k].x - ((this.point[this.point[k].surround[0]].x) + (this.point[this.point[k].surround[1]].x)) * 0.5) ** 2 +
+                            (this.point[k].y - ((this.point[this.point[k].surround[0]].y) + (this.point[this.point[k].surround[1]].y)) * 0.5) ** 2);
+                        radius = (total_radius - offset) / total_radius;
+                        stop = true;
+                    }
+                }
             } else {
                 irregular = true;
             }
@@ -12773,19 +12942,20 @@ class Puzzle {
 
                     this.draw_circle(this.ctx, this.point[k].x, this.point[k].y, 0.15);
                 } else { // Standard Cell
+                    let cell = this.point[k];
                     if (irregular) {
-                        total_radius = Math.sqrt((this.point[k].x - ((this.point[this.point[k].surround[0]].x) + (this.point[this.point[k].surround[1]].x)) * 0.5) ** 2 +
-                            (this.point[k].y - ((this.point[this.point[k].surround[0]].y) + (this.point[this.point[k].surround[1]].y)) * 0.5) ** 2);
+                        total_radius = Math.sqrt((cell.x - ((this.point[cell.surround[0]].x) + (this.point[cell.surround[1]].x)) * 0.5) ** 2 +
+                            (cell.y - ((this.point[cell.surround[0]].y) + (this.point[cell.surround[1]].y)) * 0.5) ** 2);
                         radius = (total_radius - offset) / total_radius;
                     }
 
                     this.ctx.beginPath();
-                    this.ctx.moveTo(this.point[k].x * (1 - radius) + this.point[this.point[k].surround[0]].x * radius,
-                        this.point[k].y * (1 - radius) + this.point[this.point[k].surround[0]].y * radius);
+                    this.ctx.moveTo(cell.x * (1 - radius) + this.point[cell.surround[0]].x * radius,
+                        cell.y * (1 - radius) + this.point[cell.surround[0]].y * radius);
 
-                    for (var j = 0; j < this.point[k].surround.length - 1; j++) {
-                        this.ctx.lineTo(this.point[k].x * (1 - radius) + this.point[this.point[k].surround[j + 1]].x * radius,
-                            this.point[k].y * (1 - radius) + this.point[this.point[k].surround[j + 1]].y * radius);
+                    for (var j = 0; j < cell.surround.length - 1; j++) {
+                        this.ctx.lineTo(cell.x * (1 - radius) + this.point[cell.surround[j + 1]].x * radius,
+                            cell.y * (1 - radius) + this.point[cell.surround[j + 1]].y * radius);
                     }
                     this.ctx.closePath();
                     this.ctx.stroke();
@@ -12797,17 +12967,99 @@ class Puzzle {
         }
     }
 
-    // Need more detail to properly draw stuff so it looks centered
     draw_cage(pu) {
-        let r = 0.16;
-        for (var i in this[pu].cage) {
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            // Corners in same cell, simply connect them with a line
-            if (this.point[i1].neighbor[0] == this.point[i2].neighbor[0]) {
-                set_line_style(this.ctx, this[pu].cage[i]);
-                if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
-                    this.ctx.strokeStyle = this[pu + "_col"].cage[i];
+        let r = 0.17;
+        // Below are the list of grids that will "smartly" combine corners to draw
+        let smarts = ["tri", "tetrakis_square", "deltoidal_trihexagonal", "penrose_P3", "rhombitrihexagonal"];
+        if (smarts.indexOf(this.gridtype) === -1) {
+            for (var i in this[pu].cage) {
+                var i1 = i.split(",")[0];
+                var i2 = i.split(",")[1];
+                // Corners in same cell, simply connect them with a line
+                if (this.point[i1].neighbor[0] == this.point[i2].neighbor[0]) {
+                    set_line_style(this.ctx, this[pu].cage[i]);
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
+                        this.ctx.strokeStyle = this[pu + "_col"].cage[i];
+                    }
+                    let p1 = this.get_cage_coordinates(i1, r);
+                    let p2 = this.get_cage_coordinates(i2, r);
+                    let intersect = [(p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2];
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(intersect[0], intersect[1]);
+                    this.ctx.lineTo(p1[0], p1[1]);
+                    this.ctx.stroke();
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(intersect[0], intersect[1]);
+                    this.ctx.lineTo(p2[0], p2[1]);
+                    this.ctx.stroke();
+                }
+                // Corners in adjacent cells, find intersection of the side lines and connect corners to intersection
+                else {
+                    if (this.point[i1].surround[0] != this.point[i2].surround[0]) {
+                        // If this is printed, something has gone wrong
+                        console.log("Cage corners that should not be connected are connected");
+                        continue;
+                    }
+                    let vertex = this.point[i1].surround[0];
+                    // The corners are next to a pair of edges within their cell. If two corners are connected and are in different cells, the line should pass
+                    // through one of these edge (same for both corners). Find the other edge of the pair (different for both corners), find the other vertex
+                    // that is incident to that edge and find the corner that corresponds to that other vertex and face combination
+                    let k1 = 0;
+                    let k2 = 0;
+                    for (let j = 0; j < this.point[vertex].edge_to_vertex.length; j++) {
+                        if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0]) &&
+                        !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0])) {
+                            k1 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
+                        }
+                        if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0]) &&
+                        !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0])) {
+                            k2 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
+                        }
+                    }
+                    let j1 = this.corner_table[this.point[i1].neighbor[0]][k1];
+                    let j2 = this.corner_table[this.point[i2].neighbor[0]][k2];
+                    // i1-j1 and i2-j2 can define lines. Find the intersection of both lines, and connect the intersection to i1, then the intersection to i2
+                    let pi1 = this.get_cage_coordinates(i1, r);
+                    let pi2 = this.get_cage_coordinates(i2, r);
+                    let pj1 = this.get_cage_coordinates(j1, r);
+                    let pj2 = this.get_cage_coordinates(j2, r);
+                    let intersect = [];
+
+                    let denom = ((pj2[1] - pi2[1]) * (pj1[0] - pi1[0])) - ((pj2[0] - pi2[0]) * (pj1[1] - pi1[1]));
+                    if (Math.abs(denom) < 0.0001 ) {
+                        // Undefined intersection, just take midpoint
+                        intersect = [(pi1[0] + pi2[0]) / 2, (pi1[1] + pi2[1]) / 2];
+                    }
+                    else {
+                        let deltY = pi1[1] - pi2[1];
+                        let deltX = pi1[0] - pi2[0];
+                        let numer = ((pj2[0] - pi2[0]) * deltY) - ((pj2[1] - pi2[1]) * deltX);
+                        let coeff = numer/denom;
+                        intersect = [pi1[0] + (coeff * (pj1[0] - pi1[0])), pi1[1] + (coeff * (pj1[1] - pi1[1]))];
+                    }
+                    set_line_style(this.ctx, this[pu].cage[i] + 100);
+                    if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
+                        this.ctx.strokeStyle = this[pu + "_col"].cage[i];
+                    }
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(pi1[0], pi1[1]);
+                    this.ctx.lineTo(intersect[0], intersect[1]);
+                    this.ctx.stroke();
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(pi2[0], pi2[1]);
+                    this.ctx.lineTo(intersect[0], intersect[1]);
+                    this.ctx.stroke();
+                }
+            }
+        } else {
+            let cages = this.process_for_drawing(this.preprocess_cage(this[pu].cage), pu);
+            for (let i = 0; i < cages[0].length; i++) {
+                let i1 = cages[0][i][0];
+                let i2 = cages[0][i][1];
+                let key = (Math.min(i1, i2).toString() + "," + Math.max(i1, i2).toString());
+                set_line_style(this.ctx, this[pu].cage[key]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].cage[key]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].cage[key];
                 }
                 let p1 = this.get_cage_coordinates(i1, r);
                 let p2 = this.get_cage_coordinates(i2, r);
@@ -12820,72 +13072,121 @@ class Puzzle {
                 this.ctx.moveTo(intersect[0], intersect[1]);
                 this.ctx.lineTo(p2[0], p2[1]);
                 this.ctx.stroke();
-            }
-            // Corners in adjacent cells, find intersection of the side lines and connect corners to intersection
-            else {
-                if (this.point[i1].surround[0] != this.point[i2].surround[0]) {
-                    // If this is printed, something has gone wrong
-                    console.log("Cage corners that should not be connected are connected");
-                    continue;
-                }
-                let vertex = this.point[i1].surround[0];
-                // The corners are next to a pair of edges within their cell. If two corners are connected and are in different cells, the line should pass
-                // through one of these edge (same for both corners). Find the other edge of the pair (different for both corners), find the other vertex
-                // that is incident to that edge and find the corner that corresponds to that other vertex and face combination
-                let k1 = 0;
-                let k2 = 0;
-                for (let j = 0; j < this.point[vertex].edge_to_vertex.length; j++) {
-                    if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0]) &&
-                       !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0])) {
-                        k1 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
+            } 
+            for (let i = 0; i < cages[1].length; i++) {
+                let s1 = cages[1][i][0];
+                let s2 = cages[1][i][1];
+                let points = [];
+                let key = (Math.min(s1, s2).toString() + "," + Math.max(s1, s2).toString());
+                set_line_style(this.ctx, this[pu].cage[key]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].cage[key]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].cage[key];
+                } 
+                for (let j = 0; j < cages[1][i].length - 1; j++) {
+                    let i1 = cages[1][i][j];
+                    let i2 = cages[1][i][j + 1];
+                    if (this.point[i1].surround[0] != this.point[i2].surround[0]) {
+                        // If this is printed, something has gone wrong
+                        console.log("Cage corners that should not be connected are connected");
+                        continue;
                     }
-                    if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0]) &&
-                       !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0])) {
-                        k2 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
+                    let vertex = this.point[i1].surround[0];
+                    // The corners are next to a pair of edges within their cell. If two corners are connected and are in different cells, the line should pass
+                    // through one of these edge (same for both corners). Find the other edge of the pair (different for both corners), find the other vertex
+                    // that is incident to that edge and find the corner that corresponds to that other vertex and face combination
+                    let k1 = 0;
+                    let k2 = 0;
+                    for (let j = 0; j < this.point[vertex].edge_to_vertex.length; j++) {
+                        if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0]) &&
+                        !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0])) {
+                            k1 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
+                        }
+                        if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0]) &&
+                        !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0])) {
+                            k2 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
+                        }
                     }
-                }
-                let j1 = this.corner_table[this.point[i1].neighbor[0]][k1];
-                let j2 = this.corner_table[this.point[i2].neighbor[0]][k2];
-                // i1-j1 and i2-j2 can define lines. Find the intersection of both lines, and connect the intersection to i1, then the intersection to i2
-                let pi1 = this.get_cage_coordinates(i1, r);
-                let pi2 = this.get_cage_coordinates(i2, r);
-                let pj1 = this.get_cage_coordinates(j1, r);
-                let pj2 = this.get_cage_coordinates(j2, r);
-                let intersect = [];
+                    let j1 = this.corner_table[this.point[i1].neighbor[0]][k1];
+                    let j2 = this.corner_table[this.point[i2].neighbor[0]][k2];
+                    // i1-j1 and i2-j2 can define lines. Find the intersection of both lines, and connect the intersection to i1, then the intersection to i2
+                    let pi1 = this.get_cage_coordinates(i1, r);
+                    let pi2 = this.get_cage_coordinates(i2, r);
+                    let pj1 = this.get_cage_coordinates(j1, r);
+                    let pj2 = this.get_cage_coordinates(j2, r);
+                    let intersect = [];
 
-                let denom = ((pj2[1] - pi2[1]) * (pj1[0] - pi1[0])) - ((pj2[0] - pi2[0]) * (pj1[1] - pi1[1]));
-                if (denom == 0) {
-                    // Undefined intersection, just take midpoint
-                    intersect = [(pi1[0] + pi2[0]) / 2, (pi1[1] + pi2[1]) / 2];
+                    let denom = ((pj2[1] - pi2[1]) * (pj1[0] - pi1[0])) - ((pj2[0] - pi2[0]) * (pj1[1] - pi1[1]));
+                    if (Math.abs(denom) < 0.0001 ) {
+                        // Undefined intersection, just take midpoint
+                        intersect = [(pi1[0] + pi2[0]) / 2, (pi1[1] + pi2[1]) / 2];
+                    }
+                    else {
+                        let deltY = pi1[1] - pi2[1];
+                        let deltX = pi1[0] - pi2[0];
+                        let numer = ((pj2[0] - pi2[0]) * deltY) - ((pj2[1] - pi2[1]) * deltX);
+                        let coeff = numer/denom;
+                        intersect = [pi1[0] + (coeff * (pj1[0] - pi1[0])), pi1[1] + (coeff * (pj1[1] - pi1[1]))];
+                    }
+                    if (j === 0) {
+                        points.push(pi1);
+                    }  
+                    points.push(intersect);
+                    if (j === cages[1][i].length - 2) {
+                        points.push(pi2);
+                    }   
                 }
-                else {
-                    let deltY = pi1[1] - pi2[1];
-                    let deltX = pi1[0] - pi2[0];
-                    let numer = ((pj2[0] - pi2[0]) * deltY) - ((pj2[1] - pi2[1]) * deltX);
-                    let coeff = numer/denom;
-                    intersect = [pi1[0] + (coeff * (pj1[0] - pi1[0])), pi1[1] + (coeff * (pj1[1] - pi1[1]))];
+                if (points.length == 3) {
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(points[1][0], points[1][1]);
+                    this.ctx.lineTo(points[0][0], points[0][1]);
+                    this.ctx.stroke();  
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(points[1][0], points[1][1]);
+                    this.ctx.lineTo(points[2][0], points[2][1]);
+                    this.ctx.stroke();  
+                } else {
+                    for (let j = 0; j < points.length - 1; j++) {
+                        let p1 = points[j];
+                        let p2 = points[j + 1];
+                        if (j === 0) {
+                            this.ctx.beginPath();
+                            this.ctx.moveTo(p1[0], p1[1]);
+                            this.ctx.lineTo(p2[0], p2[1]);
+                            this.ctx.stroke();             
+                        } else if (j === points.length - 2) {
+                            this.ctx.beginPath();
+                            this.ctx.moveTo(p2[0], p2[1]);
+                            this.ctx.lineTo(p1[0], p1[1]);
+                            this.ctx.stroke();             
+                        } else {
+                            let intersect = [(p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2];
+                            this.ctx.beginPath();
+                            this.ctx.moveTo(p1[0], p1[1]);
+                            this.ctx.lineTo(intersect[0], intersect[1]);
+                            this.ctx.stroke();
+                            this.ctx.beginPath();
+                            this.ctx.moveTo(p2[0], p2[1]);
+                            this.ctx.lineTo(intersect[0], intersect[1]);
+                            this.ctx.stroke();
+                        }
+                    }
                 }
-                set_line_style(this.ctx, this[pu].cage[i] + 100);
-                if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
-                    this.ctx.strokeStyle = this[pu + "_col"].cage[i];
-                }
-                this.ctx.beginPath();
-                this.ctx.moveTo(pi1[0], pi1[1]);
-                this.ctx.lineTo(intersect[0], intersect[1]);
-                this.ctx.stroke();
-                this.ctx.beginPath();
-                this.ctx.moveTo(pi2[0], pi2[1]);
-                this.ctx.lineTo(intersect[0], intersect[1]);
-                this.ctx.stroke();
             }
         }
     }
 
     get_cage_coordinates(corner, radius) {
+        let regulars = ["square", "hex", "tri", "pyramid", "iso", "cairo_pentagonal", "sudoku", "kakuro", "tetrakis_square", "deltoidal_trihexagonal", "penrose_P3"];
         let cell = this.point[corner].neighbor[0];
         let vertex = this.point[corner].surround[0];
+        if (regulars.indexOf(this.gridtype) !== -1) {
+            return [radius*this.point[cell].x + (1-radius) * this.point[vertex].x, radius*this.point[cell].y + (1-radius) * this.point[vertex].y];
+        } 
+        let inward = [this.point[vertex].x - this.point[cell].x, this.point[vertex].y - this.point[cell].y];
+        let length = Math.sqrt(inward[0]**2 + inward[1]**2);
+        inward = [inward[0]/length, inward[1]/length];
 
-        return [radius*this.point[cell].x + (1-radius) * this.point[vertex].x, radius*this.point[cell].y + (1-radius) * this.point[vertex].y]
+        return [this.point[vertex].x -0.5*radius*this.size * inward[0], this.point[vertex].y -0.5*radius*this.size * inward[1]];
     }
 
     // Given a cage state, split the state into paths and loops so cages can be drawn "smartly". Unused for now
@@ -12957,14 +13258,108 @@ class Puzzle {
         return output;
     }
 
+
     remove_from_array(arr, val) {
         if (!!arr) {   
             if (arr.indexOf(val) !== -1) {
                 arr.splice(arr.indexOf(val), 1);
-            }
+            } 
         }
     }
     
+    
+    process_for_drawing(cage, pu) {
+        let output = [];
+        output[0] = []; // Inside the same cell
+        output[1] = []; // Not inside the same cell, with same style grouped
+        for (let i = 0; i < cage.length; i++) {
+            let temp = [];
+            let style = -1;
+            if (cage[i][0] == cage[i][cage[i].length - 1]) /* Loop */ {
+                let offset = -1;
+                for (let j = 0; j < cage[i].length - 1; j++) /* Find the first pair of corner in same cell */ { 
+                    if (this.point[cage[i][j]].neighbor[0] == this.point[cage[i][(j + 1)]].neighbor[0]) {
+                        offset = offset === -1 ? j : offset;
+                    }
+                }
+                if (offset === -1) /* This must be a loop around a vertex, put everything separately */{ 
+                    for (let j = 0; j < cage[i].length - 1; j++) {
+                        if (this.point[cage[i][j]].neighbor == this.point[cage[i][j + 1]].neighbor) {
+                            output[0].push([cage[i][j], cage[i][j + 1]]);
+                        } else {
+                            output[1].push([cage[i][j], cage[i][j + 1]]);
+                        }
+                    }
+                } else {
+                    for (let j = 0; j < cage[i].length - 1; j++) /* Found a candidate to offset, since it is a loop we can start anywhere */ {
+                        let k1 = (j + offset)%(cage[i].length - 1);
+                        let k2 = (j + offset + 1)%(cage[i].length - 1);
+                        if (this.point[cage[i][k1]].neighbor[0] == this.point[cage[i][k2]].neighbor[0]) /* Same cell */{
+                            if (temp.length > 0) 
+                                output[1].push(temp);
+                            temp = [];
+                            style = -1;
+                            output[0].push([cage[i][k1], cage[i][k2]]);
+                        } else {
+                            let key = (Math.min(cage[i][k1], cage[i][k2]).toString() + "," + Math.max(cage[i][k1], cage[i][k2]).toString());
+                            let current_style = this[pu].cage[key] + 100;
+                            if (UserSettings.custom_colors_on && this[pu + "_col"].cage[key]) {
+                                current_style = this[pu + "_col"].cage[key];
+                            }
+                            if (style === -1) /* temp must be empty */{
+                                style = current_style;
+                                temp.push(cage[i][k1]);
+                                temp.push(cage[i][k2]);
+                            } else if (style === current_style) /* Same style, combine */{
+                                temp.push(cage[i][k2]);
+                            } else {
+                                style = current_style;
+                                output[1].push(temp);
+                                temp = [];
+                                temp.push(cage[i][k1]);
+                                temp.push(cage[i][k2]);
+                            }
+                        }
+                    }
+                    if (temp.length > 0) 
+                        output[1].push(temp);
+                }
+            } else {
+                for (let j = 0; j < cage[i].length - 1; j++) {
+                    if (this.point[cage[i][j]].neighbor[0] == this.point[cage[i][j + 1]].neighbor[0]) {
+                        if (temp.length > 0) 
+                            output[1].push(temp);
+                        temp = [];
+                        style = -1;
+                        output[0].push([cage[i][j], cage[i][j + 1]]);
+                    } else {
+                        let key = (Math.min(cage[i][j], cage[i][j + 1]).toString() + "," + Math.max(cage[i][j], cage[i][j + 1]).toString());
+                        let current_style = this[pu].cage[key] + 100;
+                        if (UserSettings.custom_colors_on && this[pu + "_col"].cage[key]) {
+                            current_style = this[pu + "_col"].cage[key];
+                        }
+                        if (style === -1) {
+                            style = current_style;
+                            temp.push(cage[i][j]);
+                            temp.push(cage[i][j + 1]);
+                        } else if (style === current_style) {
+                            temp.push(cage[i][j + 1]);
+                        } else {
+                            style = current_style;
+                            output[1].push(temp);
+                            temp = [];
+                            temp.push(cage[i][j]);
+                            temp.push(cage[i][j + 1]);
+                        }
+                    }
+                }
+            if (temp.length > 0) 
+                output[1].push(temp);
+            }
+        }
+        return output;
+    }
+
     check_solution() {
         if (!this.multisolution) {
             if (this.solution) {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -12860,16 +12860,91 @@ class Puzzle {
             this.ctx.shadowColor = Color.TRANSPARENTBLACK;
         }
     }
-/*
+
+    // Need more detail to properly draw stuff so it looks centered
     draw_cage(pu) {
+        // assume corner_table is a 2D array with [cell][vertex] = corner
         let r = 0.16;
         for (var i in this[pu].cage) {
             var i1 = i.split(",")[0];
-            var i2 = 
+            var i2 = i.split(",")[1];
+            // Corners in same cell, simply connect them with a line
+            if (this.point[i1].neighbor[0] == this.point[i2].neighbor[0]) {
+                set_line_style(this.ctx, this[pu].cage[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].cage[i];
+                }
+                this.ctx.beginPath();
+                this.ctx.moveTo(this.get_cage_coordinates(i1));
+                this.ctx.moveTo(this.get_cage_coordinates(i2));
+                this.ctx.stroke();
+            }
+            // Corners in adjacent cells, find intersection of the side lines and connect corners to intersection
+            else {
+                if (this.point[i1].surround[0] != this.point[i2].surround[0]) {
+                    console.log("Cage corners should not be connected");
+                    return;
+                }
+                let vertex = this.point[i1].surround[0];
+                // The corners are next to a pair of edges within their cell. If two corners are connected and are in different cells, the line should pass
+                // through one of these edge (same for both corners). Find the other edge of the pair (different for both corners), find the other vertex
+                // that is incident to that edge and find the corner that corresponds to that other vertex and face combination
+                let k1 = 0;
+                let k2 = 0;
+                for (let j = 0; j < this.point[vertex].edge_to_vertex.length; j++) {
+                    if (this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i1].neighbor[0]) &&
+                       !this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i2].neighbor[0])) {
+                        k1 = this.point[this.point[vertex].edge_to.vertex[j].edge_to_vertex[!this.point[vertex.edge_to.vertex[j].edge_to_vertex.indexOf(vertex)]]];
+                    }
+                    if (this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i2].neighbor[0]) &&
+                       !this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i1].neighbor[0])) {
+                        k2 = this.point[this.point[vertex].edge_to.vertex[j].edge_to_vertex[!this.point[vertex.edge_to.vertex[j].edge_to_vertex.indexOf(vertex)]]];
+                    }
+                }
+                let j1 = corner_table[this.point[i1].neighbor[0]][k1];
+                let j2 = corner_table[this.point[i2].neighbor[0]][k2];
+                // i1-j1 and i2-j2 can define lines. Find the intersection of both lines, and connect the intersection to i1, then the intersection to i2
+                let pi1 = this.get_cage_coordinates(i1);
+                let pi2 = this.get_cage_coordinates(i2);
+                let pj1 = this.get_cage_coordinates(j1);
+                let pj2 = this.get_cage_coordinates(j2);
+                let intersect = [];
+
+                let denom = ((pj2[1] - pi2[1]) * (pj1[0] - pi1[0])) - ((pj2[0] - pi2[0]) * (pj1[1] - pi1[1]));
+                if (denom == 0) {
+                    // Undefined intersection, just take midpoint
+                    intersect = [(pi1[0] + pi2[0]) / 2, (pi1[1] + pi2[1]) / 2];
+                }
+                else {
+                    let deltY = pi1[1] - pi2[1];
+                    let deltX = pi1[0] - pi2[0];
+                    let numer = ((pj2[0] - pi2[0]) * deltY) - ((pj2[1] - pi2[1]) * deltX);
+                    let coeff = numer/denom;
+                    intersect = [pi1[0] + (coeff * (pj1[0] - pi1[0])), pi1[1] + (coeff * (pj1[1] - pi1[1]))];
+                }
+                set_line_style(this.ctx, this[pu].cage[i]);
+                if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
+                    this.ctx.strokeStyle = this[pu + "_col"].cage[i];
+                }
+                this.ctx.beginPath();
+                this.ctx.moveTo(intersect);
+                this.ctx.moveTo(pi1);
+                this.ctx.stroke();
+                this.ctx.beginPath();
+                this.ctx.moveTo(intersect);
+                this.ctx.moveTo(pi2);
+                this.ctx.stroke();
+            }
         }
     }
-*/
-    // Given a cage state, split the state into paths and loops so cages can be drawn "smartly"
+
+    get_cage_coordinates(corner) {
+        let cell = this.point[corner].neighbor[0];
+        let vertex = this.point[corner].surround[0];
+        return true; // Exact calculation to set up later
+    }
+
+    // Given a cage state, split the state into paths and loops so cages can be drawn "smartly". Unused for now
     preprocess_cage(cage) {
         let output = [];
         let neighbors = [];
@@ -12881,7 +12956,7 @@ class Puzzle {
             neighbors[i.split(",")[0]].push(i.split(",")[1]);
             neighbors[i.split(",")[1]].push(i.split(",")[0]);
         }
-        
+
         for (var i in neighbors) {
             let children = [];
             if (neighbors[i].length > 2) {
@@ -12935,6 +13010,7 @@ class Puzzle {
                 output.push(path);
             }
         }
+        return output;
     }
 
     remove_from_array(arr, val) {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -548,7 +548,7 @@ class Puzzle {
     // For this function to work correctly, cells need to have their surrond to be exact and their neighbor to contain all correct edges (there may be more edges than the correct ones)
     // This function fills in the rest of the fields, and modify incorrect fields if needed
 
-    fix_points(point, fix_adjacent = true) {
+    fix_points(point, fix_adjacent = true, off_centered = false) {
         // First pass - reset fields
         for (var i in point) {
             if (this.types[0].indexOf(point[i].type) !== -1 && fix_adjacent) {
@@ -584,7 +584,7 @@ class Puzzle {
                         if (Math.abs(vertex1.x - vertex2.x) < 0.001) {
                             for (let l = 0; l < edge_bank.length; l++) {
                                 if (Math.abs(point[edge_bank[l]].x - vertex1.x) < 0.001) {
-                                    if (Math.abs(vertex1.y + vertex2.y - 2*point[edge_bank[l]].y) < 0.001) {
+                                    if ((!off_centered && (Math.abs(vertex1.y + vertex2.y - 2*point[edge_bank[l]].y) < 0.001)) || (off_centered && (vertex1.y < point[edge_bank[l]].y === point[edge_bank[l]].y < vertex2.y))) {
                                         deltas.push({diff: 0,
                                                      v1: Math.min(vertices[j], vertices[k]),
                                                      v2: Math.max(vertices[j], vertices[k]),
@@ -595,7 +595,7 @@ class Puzzle {
                         } else if (Math.abs(vertex1.y - vertex2.y) < 0.001) {
                             for (let l = 0; l < edge_bank.length; l++) {
                                 if (Math.abs(point[edge_bank[l]].y - vertex1.y) < 0.001) {
-                                    if (Math.abs(vertex1.x + vertex2.x - 2*point[edge_bank[l]].x) < 0.001) {
+                                    if ((!off_centered && (Math.abs(vertex1.x + vertex2.x - 2*point[edge_bank[l]].x) < 0.001)) || (off_centered && (vertex1.x < point[edge_bank[l]].x === point[edge_bank[l]].x < vertex2.x))) {
                                         deltas.push({diff: 0,
                                                      v1: Math.min(vertices[j], vertices[k]),
                                                      v2: Math.max(vertices[j], vertices[k]),
@@ -607,7 +607,8 @@ class Puzzle {
                             for (let l = 0; l < edge_bank.length; l++) {
                                 let delta = Math.abs(((vertex1.y - point[edge_bank[l]].y)*(vertex2.x - point[edge_bank[l]].x)) -
                                                     ((vertex1.x - point[edge_bank[l]].x)*(vertex2.y - point[edge_bank[l]].y)));
-                                if ((vertex1.x > point[edge_bank[l]].x === point[edge_bank[l]].x > vertex2.x) && (vertex1.y > point[edge_bank[l]].y === point[edge_bank[l]].y > vertex2.y)) {
+                                if ((!off_centered && (Math.abs(vertex1.x + vertex2.x - 2*point[edge_bank[l]].x) < 0.001) && (Math.abs(vertex1.y + vertex2.y - 2*point[edge_bank[l]].y) < 0.001) ) ||
+                                (off_centered && (vertex1.x < point[edge_bank[l]].x === point[edge_bank[l]].x < vertex2.x) && (vertex1.y < point[edge_bank[l]].y === point[edge_bank[l]].y < vertex2.y))) {
                                     deltas.push({diff: delta,
                                                  v1: Math.min(vertices[j], vertices[k]),
                                                  v2: Math.max(vertices[j], vertices[k]),
@@ -620,21 +621,17 @@ class Puzzle {
                 // Sort the distance, and find the best matches
                 deltas.sort((a, b) => a.diff - b.diff);
                 let edges = [];
-                while (edges.length < vertices.length) {
-                    for (let j = 0; j < deltas.length; j++) {
-                        if (edges.indexOf(deltas[j].edge) === -1) {
-                            // Fill in the edge_to_vertex data, and add the cell to the edge's neighbour
-                            point[deltas[j].edge].edge_to_vertex = [deltas[j].v1, deltas[j].v2];
-                            if (point[deltas[j].v1].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
-                                point[deltas[j].v1].edge_to_vertex.push(deltas[j].edge);
-                            }
-                            if (point[deltas[j].v2].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
-                                point[deltas[j].v2].edge_to_vertex.push(deltas[j].edge);
-                            }
-                            point[deltas[j].edge].neighbor.push(parseInt(i));
-                            edges.push(deltas[j].edge);
-                        }
+                for (let j = 0; j < vertices.length; j++) {
+                    // Fill in the edge_to_vertex data, and add the cell to the edge's neighbour
+                    point[deltas[j].edge].edge_to_vertex = [deltas[j].v1, deltas[j].v2];
+                    if (point[deltas[j].v1].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
+                        point[deltas[j].v1].edge_to_vertex.push(deltas[j].edge);
                     }
+                    if (point[deltas[j].v2].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
+                        point[deltas[j].v2].edge_to_vertex.push(deltas[j].edge);
+                    }
+                    point[deltas[j].edge].neighbor.push(parseInt(i));
+                    edges.push(deltas[j].edge);
                 }
                 point[i].neighbor = edges;
             }
@@ -12851,7 +12848,7 @@ class Puzzle {
     draw_cursol() {
         let edit_mode = this.mode[this.mode.qa].edit_mode;
         /*cursol*/
-        if ((edit_mode === "number" && !this.number_multi_enabled()) || edit_mode === "symbol") {
+        if (((edit_mode === "number" && !this.number_multi_enabled()) || edit_mode === "symbol") && this.point[this.cursol]) {
             set_line_style(this.ctx, 99);
             if (edit_mode === "symbol" && UserSettings.panel_shown && !pu.onoff_symbolmode_list[pu.mode[this.mode.qa].symbol[0]]) {
                 this.ctx.strokeStyle = Color.BLUE_DARK_VERY;
@@ -12859,7 +12856,7 @@ class Puzzle {
             this.ctx.fillStyle = Color.TRANSPARENTBLACK;
             let submode = this.mode[this.mode.qa][edit_mode][0];
             if (edit_mode === "number" && (submode === "3" || submode === "9")) {
-                if (this.cursolS) {
+                if (this.cursolS && this.point[this.cursolS]) {
                     this.draw_polygon(this.ctx, this.point[this.cursolS].x, this.point[this.cursolS].y, 0.2, 4, 45);
                 } else {
                     this.default_cursol();

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -9433,6 +9433,49 @@ class Puzzle {
                     // let min_cell = Math.min(...this.cageselection);
                     // let max_cell = Math.max(...this.cageselection);
 
+                    // assume corner_table is a 2D array with [cell][vertex] = corner 
+                    // assume add_line is the function to add the line to the array
+/*
+                    let cage_vertices = [];
+                    let cage_edges = [];
+                    let inside_vertices = [];
+                    for (let i = 0; i < this.cageselection.length; i++) {
+                        cage_edges.push(this.point[k].surround);
+                        cage_vertices.push(this.point[k].neighbor);
+                    }
+
+                    for (let i = 0; i < cage_vertices.length; i++) {
+                        if (this.point[cage_vertices[i]].surround.every(val=> this.cageselection.includes(val))) {
+                            inside_vertices.push(cage_vertices[i]);
+                        }
+                    }
+
+                    for (let i = 0; i < cage_edges.length; i++) {
+                        let edge = this.point[cage_edges[i]];
+                        let cell_0_in = this.cageselection.includes(edge.neighbor[0]);
+                        let cell_1_in = this.cageselection.includes(edge.neighbor[1]);
+                        if (cell_0_in !== cell_1_in) {
+                            let p0 = corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[0]];
+                            let p1 = corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[1]];
+                            key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
+                            if (this[this.mode.qa][array][key] !== line_style) {
+                                this.re_line(array, key, line_style, this.undoredo_counter);
+                            }
+                        }
+                        else if (cell_0_in && cell_1_in) {
+                            for (let j = 0; j < 2; j++) {
+                                if (!inside_vertices.includes(edge.edge_to_vertex[i])) {
+                                    let p0 = corner_table[edge.neighbor[0]][edge.edge_to_vertex[j]];
+                                    let p1 = corner_table[edge.neighbor[1]][edge.edge_to_vertex[j]];
+                                    key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
+                                    if (this[this.mode.qa][array][key] !== line_style) {
+                                        this.re_line(array, key, line_style, this.undoredo_counter);
+                                    }
+                                }
+                            }
+                        }
+                    }*/
+
                     // cage cell locations
                     for (let i = 0; i < row_size; i++) {
                         grid_matrix[i] = new Array(parseInt(col_size)).fill(0);
@@ -12817,7 +12860,91 @@ class Puzzle {
             this.ctx.shadowColor = Color.TRANSPARENTBLACK;
         }
     }
+/*
+    draw_cage(pu) {
+        let r = 0.16;
+        for (var i in this[pu].cage) {
+            var i1 = i.split(",")[0];
+            var i2 = 
+        }
+    }
+*/
+    // Given a cage state, split the state into paths and loops so cages can be drawn "smartly"
+    preprocess_cage(cage) {
+        let output = [];
+        let neighbors = [];
+        for (var i in cage) {
+            if (!neighbors[i.split(",")[0]])
+                neighbors[i.split(",")[0]] = []
+            if (!neighbors[i.split(",")[1]])
+                neighbors[i.split(",")[1]] = []
+            neighbors[i.split(",")[0]].push(i.split(",")[1]);
+            neighbors[i.split(",")[1]].push(i.split(",")[0]);
+        }
+        
+        for (var i in neighbors) {
+            let children = [];
+            if (neighbors[i].length > 2) {
+                children.push(i);
+                while (children.length > 0) {
+                    let subchildren = [];
+                    while (children.length > 0) {
+                        let j = children.shift();
+                        if (!!neighbors[j]) {
+                            for (let k = 0; k < neighbors[j].length; k++) {
+                                let neighbor = neighbors[j][k]
+                                output.push([Math.min(neighbor,j), Math.max(neighbor,j)]);
+                                this.remove_from_array(neighbors[neighbor], j);
+                                if (neighbors[neighbor].length > 1)
+                                    subchildren.push(neighbor);
+                            }
+                            neighbors[j] = [];
+                        }
+                    }
+                    children = subchildren;
+                }
+            }
+        }
 
+        for (var i in neighbors) {
+            let path = [];
+            if (neighbors[i].length == 1) {
+                let j = i;
+                while (!!neighbors[j]) {
+                    path.push(parseInt(j));
+                    let k = neighbors[j][0];
+                    neighbors[j] = [];
+                    this.remove_from_array(neighbors[k], j);
+                    j = k;
+                }
+                output.push(path);
+            }
+        }
+
+        for (var i in neighbors) {
+            let path = [];
+            if (neighbors[i].length == 2) {
+                let j = i;
+                while (!!neighbors[j]) {
+                    path.push(parseInt(j));
+                    let k = neighbors[j][0];
+                    neighbors[j] = [];
+                    this.remove_from_array(neighbors[k], j);
+                    j = k;
+                }
+                output.push(path);
+            }
+        }
+    }
+
+    remove_from_array(arr, val) {
+        if (!!arr) {   
+            if (arr.indexOf(val) !== -1) {
+                arr.splice(arr.indexOf(val), 1);
+            }
+        }
+    }
+    
     check_solution() {
         if (!this.multisolution) {
             if (this.solution) {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -141,6 +141,8 @@ class Puzzle {
         this.select_remove = false;
         this.surface_remove = false;
         this.panelflag = false;
+        this.corner_table = []; // Table for quick lookup for cage drawing. First coordinate is cell, second is vertex
+        this.types = [];
         this.custom_colors = {};
         // Drawing mode
         this.mmode = ""; // Problem mode
@@ -520,6 +522,16 @@ class Puzzle {
         this.cellsoutsideFrame = [...new Set(this.cellsoutsideFrame.sort(function(a, b) {
             return a - b; // Ascending
         }))]
+    }
+
+    // Returns an array grouping the types in center, vertex, edge, corner and compass
+    get_grouped_types() {
+        let output = [[],[],[],[],[]];
+        for (let i = 0; i < this.types.length; i++) {
+            let type = this.types[i];
+            output[type%10].push(type);
+        }
+        return output;
     }
 
     point_move(x, y, theta) {
@@ -12863,7 +12875,6 @@ class Puzzle {
 
     // Need more detail to properly draw stuff so it looks centered
     draw_cage(pu) {
-        // assume corner_table is a 2D array with [cell][vertex] = corner
         let r = 0.16;
         for (var i in this[pu].cage) {
             var i1 = i.split(",")[0];
@@ -12874,16 +12885,19 @@ class Puzzle {
                 if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].cage[i];
                 }
+                let p1 = this.get_cage_coordinates(i1, r);
+                let p2 = this.get_cage_coordinates(i2, r);
                 this.ctx.beginPath();
-                this.ctx.moveTo(this.get_cage_coordinates(i1));
-                this.ctx.moveTo(this.get_cage_coordinates(i2));
+                this.ctx.moveTo(p1[0], p1[1]);
+                this.ctx.lineTo(p2[0], p2[1]);
                 this.ctx.stroke();
             }
             // Corners in adjacent cells, find intersection of the side lines and connect corners to intersection
             else {
                 if (this.point[i1].surround[0] != this.point[i2].surround[0]) {
-                    console.log("Cage corners should not be connected");
-                    return;
+                    // If this is printed, something has gone wrong
+                    console.log("Cage corners that should not be connected are connected");
+                    continue;
                 }
                 let vertex = this.point[i1].surround[0];
                 // The corners are next to a pair of edges within their cell. If two corners are connected and are in different cells, the line should pass
@@ -12892,22 +12906,22 @@ class Puzzle {
                 let k1 = 0;
                 let k2 = 0;
                 for (let j = 0; j < this.point[vertex].edge_to_vertex.length; j++) {
-                    if (this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i1].neighbor[0]) &&
-                       !this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i2].neighbor[0])) {
-                        k1 = this.point[this.point[vertex].edge_to.vertex[j].edge_to_vertex[!this.point[vertex.edge_to.vertex[j].edge_to_vertex.indexOf(vertex)]]];
+                    if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0]) &&
+                       !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0])) {
+                        k1 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
                     }
-                    if (this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i2].neighbor[0]) &&
-                       !this.point[this.point[vertex].edge_to_vertex[j].neighbor].includes(this.point[i1].neighbor[0])) {
-                        k2 = this.point[this.point[vertex].edge_to.vertex[j].edge_to_vertex[!this.point[vertex.edge_to.vertex[j].edge_to_vertex.indexOf(vertex)]]];
+                    if (this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i2].neighbor[0]) &&
+                       !this.point[this.point[vertex].edge_to_vertex[j]].neighbor.includes(this.point[i1].neighbor[0])) {
+                        k2 = this.point[this.point[vertex].edge_to_vertex[j]].edge_to_vertex.filter(v => v != vertex)[0];
                     }
                 }
-                let j1 = corner_table[this.point[i1].neighbor[0]][k1];
-                let j2 = corner_table[this.point[i2].neighbor[0]][k2];
+                let j1 = this.corner_table[this.point[i1].neighbor[0]][k1];
+                let j2 = this.corner_table[this.point[i2].neighbor[0]][k2];
                 // i1-j1 and i2-j2 can define lines. Find the intersection of both lines, and connect the intersection to i1, then the intersection to i2
-                let pi1 = this.get_cage_coordinates(i1);
-                let pi2 = this.get_cage_coordinates(i2);
-                let pj1 = this.get_cage_coordinates(j1);
-                let pj2 = this.get_cage_coordinates(j2);
+                let pi1 = this.get_cage_coordinates(i1, r);
+                let pi2 = this.get_cage_coordinates(i2, r);
+                let pj1 = this.get_cage_coordinates(j1, r);
+                let pj2 = this.get_cage_coordinates(j2, r);
                 let intersect = [];
 
                 let denom = ((pj2[1] - pi2[1]) * (pj1[0] - pi1[0])) - ((pj2[0] - pi2[0]) * (pj1[1] - pi1[1]));
@@ -12922,26 +12936,27 @@ class Puzzle {
                     let coeff = numer/denom;
                     intersect = [pi1[0] + (coeff * (pj1[0] - pi1[0])), pi1[1] + (coeff * (pj1[1] - pi1[1]))];
                 }
-                set_line_style(this.ctx, this[pu].cage[i]);
+                set_line_style(this.ctx, this[pu].cage[i] + 100);
                 if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
                     this.ctx.strokeStyle = this[pu + "_col"].cage[i];
                 }
                 this.ctx.beginPath();
-                this.ctx.moveTo(intersect);
-                this.ctx.moveTo(pi1);
+                this.ctx.moveTo(pi1[0], pi1[1]);
+                this.ctx.lineTo(intersect[0], intersect[1]);
                 this.ctx.stroke();
                 this.ctx.beginPath();
-                this.ctx.moveTo(intersect);
-                this.ctx.moveTo(pi2);
+                this.ctx.moveTo(pi2[0], pi2[1]);
+                this.ctx.lineTo(intersect[0], intersect[1]);
                 this.ctx.stroke();
             }
         }
     }
 
-    get_cage_coordinates(corner) {
+    get_cage_coordinates(corner, radius) {
         let cell = this.point[corner].neighbor[0];
         let vertex = this.point[corner].surround[0];
-        return true; // Exact calculation to set up later
+
+        return [radius*this.point[cell].x + (1-radius) * this.point[vertex].x, radius*this.point[cell].y + (1-radius) * this.point[vertex].y]
     }
 
     // Given a cage state, split the state into paths and loops so cages can be drawn "smartly". Unused for now

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -704,30 +704,13 @@ class Puzzle {
                 let vertex = point[cell.surround[j]];
                 let min = Number.MAX_VALUE;
                 let corner = 0;
-                if (Math.abs(vertex.x - cell.x) < 0.001) {
-                    for (let k = 0; k < corners.length; k++) {
-                        if (Math.abs(point[corners[k]].x - vertex.x) < 0.001) {
-                            if (vertex.y > point[corners[k]].y === point[corners[k]].y > cell.y) {
-                                corner = corners[k];
-                            }
-                        }
-                    }
-                } else if (Math.abs(vertex.y - cell.y) < 0.001) {
-                    for (let k = 0; k < corners.length; k++) {
-                        if (Math.abs(point[corners[k]].y - vertex.y) < 0.001) {
-                            if (vertex.x > point[corners[k]].x === point[corners[k]].x > cell.x) {
-                                corner = corners[k];
-                            }
-                        }
-                    }
-                } else {
-                    for (let k = 0; k < corners.length; k++) {
-                        let diff = Math.abs(((vertex.y - point[corners[k]].y)*(cell.x - point[corners[k]].x)) -
-                                            ((vertex.x - point[corners[k]].x)*(cell.y - point[corners[k]].y)));
-                        if (min > diff && (vertex.x > point[corners[k]].x === point[corners[k]].x > cell.x) && (vertex.y > point[corners[k]].y === point[corners[k]].y > cell.y)) {
-                            min = diff;
-                            corner = corners[k];
-                        }
+                  for (let k = 0; k < corners.length; k++) {
+                    let corner_point = point[corners[k]];
+                    let diff = Math.abs((cell.y - vertex.y)*corner_point.x - (cell.x - vertex.x)*corner_point.y + (cell.x * vertex.y) - (cell.y * vertex.x)) / 
+                                Math.sqrt((cell.y - vertex.y)**2 + (cell.x - vertex.x)**2);
+                    if ((min > diff) && (cell.x > point[corners[k]].x === point[corners[k]].x > vertex.x) && (cell.y > point[corners[k]].y === point[corners[k]].y > vertex.y)) {
+                        min = diff;
+                        corner = corners[k];
                     }
                 }
                 if (corner !== 0) {

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -534,6 +534,114 @@ class Puzzle {
         return output;
     }
 
+    // Fill the neighbor array for edges and vertices
+
+    fill_neighbors(point) {
+        for (var i in point) {
+            if (point[i].type%10 == 0) {
+                for (let j = 0; j < point[i].neighbor.length; j++) {
+                    point[point[i].neighbor[j]].neighbor.push(parseInt(i));
+                }
+                for (let j = 0; j < point[i].surround.length; j++) {
+                    point[point[i].surround[j]].neighbor.push(parseInt(i));
+                }
+            }
+        }
+        for (var i in point) {
+            if (point[i].type%10 == 1 || point[i].type%10 == 2) {
+                point[i].neighbor = [...new Set(point[i].neighbor)];
+            }    
+        }
+        return point;
+    }
+
+    // For this function to work correctly, cells need to have their surrond to be exact and their neighbor to contain all correct edges (there may be more edges than the correct ones)
+    // This function fills in the rest of the fields, and modify incorrect fields if needed
+
+    fix_points(point) {
+        // First pass - reset fields
+        for (var i in point) {
+            if (point[i].type%10 == 0) {
+                point[i].adjacent = [];
+            }
+            if (point[i].type%10 == 1) {
+                point[i].adjacent = [];
+                point[i].neighbor = [];
+                point[i].edge_to_vertex = [];
+            }
+            if (point[i].type%10 == 2) {
+                point[i].adjacent = [];
+                point[i].neighbor = [];
+                point[i].edge_to_vertex = [];
+            }
+        }
+
+        // Second pass - correctly link edges with their incident vertices, and vice versa
+        for (var i in point) {
+            // For all cells
+            if (point[i].type%10 == 0) {
+                let deltas = [];
+                let vertices = point[i].surround;
+                let edge_bank = point[i].neighbor;
+                // Find all possible pairs of vertices
+                for (let j = 0; j < vertices.length; j++) {
+                    if (point[j].neighbor.length > 0) {
+                        point[j].neighbor = [];
+                    }
+                    point[j].neighbor.push(i);
+                    for (let k = j + 1; k < vertices.length; k++) {
+                        // Store how far the midpoints of these pairs lie from the edge coordinates.
+                        // If an edge is incident to two vertices, its coordinate should be roughly
+                        // at the midpoint of the two vertices
+                        let midpoint = [0.5 * point[vertices[j]].x + 0.5 * point[vertices[k]].x, 0.5 * point[vertices[j]].y + 0.5 * point[vertices[k]].y];
+                        for (let l = 0; l < edge_bank.length; l++) {
+                            deltas.push({diff: (Math.abs(point[edge_bank[l]].x - midpoint[0]) +  Math.abs(point[edge_bank[l]].y - midpoint[1])), 
+                                         v1: Math.min(vertices[j], vertices[k]), 
+                                         v2: Math.max(vertices[j], vertices[k]),
+                                         edge: edge_bank[l]});
+                        }
+                    }
+                }
+                // Sort the distance, and find the best matches
+                deltas.sort((a, b) => a.diff - b.diff);
+                let edges = [];
+                for (let j = 0; j < vertices.length; j++) {
+                    // Fill in the edge_to_vertex data, and add the cell to the edge's neighbour
+                    point[deltas[j].edge].edge_to_vertex = [deltas[j].v1, deltas[j].v2];
+                    if (point[deltas[j].v1].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
+                        point[deltas[j].v1].edge_to_vertex.push(deltas[j].edge);
+                    }
+                    if (point[deltas[j].v2].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
+                        point[deltas[j].v2].edge_to_vertex.push(deltas[j].edge);
+                    }
+                    point[deltas[j].edge].neighbor.push(parseInt(i));
+                    edges.push(deltas[j].edge);
+                }
+                point[i].neighbor = edges;
+            }
+        }
+        // Third pass - fix cells and vertices' adjacent fields
+        for (var i in point) {
+            // For all edges, which now have correct edge_to_vertex and neighbor data
+            if (point[i].type%10 == 2) {
+                let edge = point[i];
+                for (let j = 0; j < 2; j++) {
+                    // Fix vertices adjacent
+                    if (!!edge.edge_to_vertex) {
+                        if (edge.edge_to_vertex.length == 2) {
+                            point[edge.edge_to_vertex[j]].adjacent.push(parseInt(edge.edge_to_vertex[(j + 1) % 2]));
+                        }
+                    }
+                    // Fix cells adjacent
+                    if (edge.neighbor.length == 2) {
+                        point[edge.neighbor[j]].adjacent.push(parseInt(edge.neighbor[(j + 1) % 2]));
+                    }     
+                }
+            }
+        }
+        return point;
+    }
+
     point_move(x, y, theta) {
         var x0 = this.canvasx * 0.5 + 0.5; // Rotate the canvas center +0.5, enter x,y +0.5 when moving in parallel
         var y0 = this.canvasy * 0.5 + 0.5;
@@ -9444,20 +9552,22 @@ class Puzzle {
                     this[this.mode.qa][arraykill].push(sortedcages);
                     // let min_cell = Math.min(...this.cageselection);
                     // let max_cell = Math.max(...this.cageselection);
+                    // remember drawing_mode
+                    let draw_mode = this.drawing_mode;
+                    this.drawing_mode = 100;
 
-                    // assume corner_table is a 2D array with [cell][vertex] = corner 
-                    // assume add_line is the function to add the line to the array
-/*
                     let cage_vertices = [];
                     let cage_edges = [];
                     let inside_vertices = [];
                     for (let i = 0; i < this.cageselection.length; i++) {
-                        cage_edges.push(this.point[k].surround);
-                        cage_vertices.push(this.point[k].neighbor);
+                        cage_edges = cage_edges.concat(this.point[this.cageselection[i]].neighbor);
+                        cage_vertices = cage_vertices.concat(this.point[this.cageselection[i]].surround);
                     }
+                    cage_edges = [...new Set(cage_edges)];
+                    cage_vertices = [...new Set(cage_vertices)];
 
                     for (let i = 0; i < cage_vertices.length; i++) {
-                        if (this.point[cage_vertices[i]].surround.every(val=> this.cageselection.includes(val))) {
+                        if (this.point[cage_vertices[i]].neighbor.every(val => this.cageselection.includes(val))) {
                             inside_vertices.push(cage_vertices[i]);
                         }
                     }
@@ -9467,8 +9577,8 @@ class Puzzle {
                         let cell_0_in = this.cageselection.includes(edge.neighbor[0]);
                         let cell_1_in = this.cageselection.includes(edge.neighbor[1]);
                         if (cell_0_in !== cell_1_in) {
-                            let p0 = corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[0]];
-                            let p1 = corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[1]];
+                            let p0 = this.corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[0]];
+                            let p1 = this.corner_table[cell_0_in ? edge.neighbor[0] : edge.neighbor[1]][edge.edge_to_vertex[1]];
                             key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
                             if (this[this.mode.qa][array][key] !== line_style) {
                                 this.re_line(array, key, line_style, this.undoredo_counter);
@@ -9476,9 +9586,9 @@ class Puzzle {
                         }
                         else if (cell_0_in && cell_1_in) {
                             for (let j = 0; j < 2; j++) {
-                                if (!inside_vertices.includes(edge.edge_to_vertex[i])) {
-                                    let p0 = corner_table[edge.neighbor[0]][edge.edge_to_vertex[j]];
-                                    let p1 = corner_table[edge.neighbor[1]][edge.edge_to_vertex[j]];
+                                if (!inside_vertices.includes(edge.edge_to_vertex[j])) {
+                                    let p0 = this.corner_table[edge.neighbor[0]][edge.edge_to_vertex[j]];
+                                    let p1 = this.corner_table[edge.neighbor[1]][edge.edge_to_vertex[j]];
                                     key = (Math.min(p0, p1).toString() + "," + Math.max(p0, p1).toString());
                                     if (this[this.mode.qa][array][key] !== line_style) {
                                         this.re_line(array, key, line_style, this.undoredo_counter);
@@ -9486,196 +9596,10 @@ class Puzzle {
                                 }
                             }
                         }
-                    }*/
-
-                    // cage cell locations
-                    for (let i = 0; i < row_size; i++) {
-                        grid_matrix[i] = new Array(parseInt(col_size)).fill(0);
                     }
-                    for (let i = 0; i < sortedcages.length; i++) {
-                        let col_num = (sortedcages[i] % (this.nx0)) - 2;
-                        let row_num = parseInt(sortedcages[i] / this.nx0) - 2;
-                        grid_matrix[row_num][col_num] = 1;
-                    }
-
-                    // remember drawing_mode
-                    let draw_mode = this.drawing_mode;
-                    this.drawing_mode = 100;
-
-                    // Find the corner coordinates of the cell
-                    for (let i = 0; i < sortedcages.length; i++) {
-                        let col_num = (sortedcages[i] % (this.nx0)) - 2;
-                        let row_num = parseInt(sortedcages[i] / this.nx0) - 2;
-
-                        // current cell
-                        let top_left = 4 * (sortedcages[i] + this.nx0 * this.ny0);
-                        let top_right = top_left + 1;
-                        let bottom_left = top_left + 2;
-                        let bottom_right = top_left + 3;
-
-                        // check if left cell is shared
-                        if (col_num !== 0) {
-                            if (grid_matrix[row_num][col_num - 1]) {
-
-                                // left shared cell
-                                let top_left_left = 4 * (sortedcages[i] - 1 + this.nx0 * this.ny0);
-                                let top_right_left = top_left_left + 1;
-                                let bottom_left_left = top_left_left + 2;
-                                let bottom_right_left = top_left_left + 3;
-
-                                if ((row_num !== 0) && (grid_matrix[row_num - 1][col_num - 1]) && (grid_matrix[row_num - 1][col_num])) {
-                                    // dont do anything
-                                } else {
-                                    key = (top_right_left.toString() + "," + top_left.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-
-                                if ((row_num !== row_size - 1) && (grid_matrix[row_num + 1][col_num - 1]) && (grid_matrix[row_num + 1][col_num])) {
-                                    // dont do anything
-                                } else {
-                                    key = (bottom_right_left.toString() + "," + bottom_left.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-                            } else {
-                                key = (top_left.toString() + "," + bottom_left.toString());
-                                if (this[this.mode.qa][array][key] !== line_style) {
-                                    this.re_line(array, key, line_style, this.undoredo_counter); // left line
-                                }
-                            }
-                        } else {
-                            key = (top_left.toString() + "," + bottom_left.toString());
-                            if (this[this.mode.qa][array][key] !== line_style) {
-                                this.re_line(array, key, line_style, this.undoredo_counter); // left line
-                            }
-                        }
-
-                        // check if top cell is shared
-                        if (row_num !== 0) {
-                            if (grid_matrix[row_num - 1][col_num]) {
-
-                                // top shared cell
-                                let top_left_top = 4 * (sortedcages[i] - this.nx0 + this.nx0 * this.ny0);
-                                let top_right_top = top_left_top + 1;
-                                let bottom_left_top = top_left_top + 2;
-                                let bottom_right_top = top_left_top + 3;
-
-                                if ((col_num !== 0) && (grid_matrix[row_num - 1][col_num - 1]) && (grid_matrix[row_num][col_num - 1])) {
-                                    // dont do anything
-                                } else {
-                                    key = (bottom_left_top.toString() + "," + top_left.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-
-                                if ((col_num !== col_size - 1) && (grid_matrix[row_num - 1][col_num + 1]) && (grid_matrix[row_num][col_num + 1])) {
-                                    // dont do anything
-                                } else {
-                                    key = (bottom_right_top.toString() + "," + top_right.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-                            } else {
-                                key = (top_left.toString() + "," + top_right.toString());
-                                if (this[this.mode.qa][array][key] !== line_style) {
-                                    this.re_line(array, key, line_style, this.undoredo_counter); // top line
-                                }
-                            }
-                        } else {
-                            key = (top_left.toString() + "," + top_right.toString());
-                            if (this[this.mode.qa][array][key] !== line_style) {
-                                this.re_line(array, key, line_style, this.undoredo_counter); // top line
-                            }
-                        }
-
-                        // check if right cell is shared
-                        if (col_num !== col_size - 1) {
-                            if (grid_matrix[row_num][col_num + 1]) {
-
-                                // top shared cell
-                                let top_left_right = 4 * (sortedcages[i] + 1 + this.nx0 * this.ny0);
-                                let top_right_right = top_left_right + 1;
-                                let bottom_left_right = top_left_right + 2;
-                                let bottom_right_right = top_left_right + 3;
-
-                                if ((row_num !== 0) && (grid_matrix[row_num - 1][col_num]) && (grid_matrix[row_num - 1][col_num + 1])) {
-                                    // dont do anything
-                                } else {
-                                    key = (top_right.toString() + "," + top_left_right.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-
-                                if ((row_num !== row_size - 1) && (grid_matrix[row_num + 1][col_num]) && (grid_matrix[row_num + 1][col_num + 1])) {
-                                    // dont do anything
-                                } else {
-                                    key = (bottom_right.toString() + "," + bottom_left_right.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-                            } else {
-                                key = (top_right.toString() + "," + bottom_right.toString());
-                                if (this[this.mode.qa][array][key] !== line_style) {
-                                    this.re_line(array, key, line_style, this.undoredo_counter); // right line
-                                }
-                            }
-                        } else {
-                            key = (top_right.toString() + "," + bottom_right.toString());
-                            if (this[this.mode.qa][array][key] !== line_style) {
-                                this.re_line(array, key, line_style, this.undoredo_counter); // right line
-                            }
-                        }
-
-                        // check if bottom cell is shared
-                        if (row_num !== row_size - 1) {
-                            if (grid_matrix[row_num + 1][col_num]) {
-
-                                // top shared cell
-                                let top_left_bottom = 4 * (sortedcages[i] + this.nx0 + this.nx0 * this.ny0);
-                                let top_right_bottom = top_left_bottom + 1;
-                                let bottom_left_bottom = top_left_bottom + 2;
-                                let bottom_right_bottom = top_left_bottom + 3;
-
-                                if ((col_num !== 0) && (grid_matrix[row_num][col_num - 1]) && (grid_matrix[row_num + 1][col_num - 1])) {
-                                    // dont do anything
-                                } else {
-                                    key = (bottom_left.toString() + "," + top_left_bottom.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-
-                                if ((col_num !== col_size - 1) && (grid_matrix[row_num][col_num + 1]) && (grid_matrix[row_num + 1][col_num + 1])) {
-                                    // dont do anything
-                                } else {
-                                    key = (bottom_right.toString() + "," + top_right_bottom.toString());
-                                    if (this[this.mode.qa][array][key] !== line_style) {
-                                        this.re_line(array, key, line_style, this.undoredo_counter);
-                                    }
-                                }
-                            } else {
-                                key = (bottom_left.toString() + "," + bottom_right.toString());
-                                if (this[this.mode.qa][array][key] !== line_style) {
-                                    this.re_line(array, key, line_style, this.undoredo_counter); // bottom line
-                                }
-                            }
-                        } else {
-                            key = (bottom_left.toString() + "," + bottom_right.toString());
-                            if (this[this.mode.qa][array][key] !== line_style) {
-                                this.re_line(array, key, line_style, this.undoredo_counter); // bottom line
-                            }
-                        }
-                    }
-                    this.record_replay(arraykill, -1, this.undoredo_counter);
-
+                
                     // reset variables
+                    this.record_replay(arraykill, -1, this.undoredo_counter);
                     this.cageselection = [];
                     this.selection = [];
                     this.drawing_mode = draw_mode;
@@ -12887,8 +12811,13 @@ class Puzzle {
                 }
                 let p1 = this.get_cage_coordinates(i1, r);
                 let p2 = this.get_cage_coordinates(i2, r);
+                let intersect = [(p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2];
                 this.ctx.beginPath();
-                this.ctx.moveTo(p1[0], p1[1]);
+                this.ctx.moveTo(intersect[0], intersect[1]);
+                this.ctx.lineTo(p1[0], p1[1]);
+                this.ctx.stroke();
+                this.ctx.beginPath();
+                this.ctx.moveTo(intersect[0], intersect[1]);
                 this.ctx.lineTo(p2[0], p2[1]);
                 this.ctx.stroke();
             }

--- a/docs/js/class_p.js
+++ b/docs/js/class_p.js
@@ -548,10 +548,10 @@ class Puzzle {
     // For this function to work correctly, cells need to have their surrond to be exact and their neighbor to contain all correct edges (there may be more edges than the correct ones)
     // This function fills in the rest of the fields, and modify incorrect fields if needed
 
-    fix_points(point, fix_adjacent = true, off_centered = false) {
+    fix_points(point) {
         // First pass - reset fields
         for (var i in point) {
-            if (this.types[0].indexOf(point[i].type) !== -1 && fix_adjacent) {
+            if (this.types[0].indexOf(point[i].type) !== -1) {
                 point[i].adjacent = [];
             }
             if (this.types[1].indexOf(point[i].type) !== -1) {
@@ -579,40 +579,24 @@ class Puzzle {
                 for (let j = 0; j < vertices.length; j++) {
                     point[vertices[j]].neighbor.push(parseInt(i));
                     for (let k = j + 1; k < vertices.length; k++) {
+                        let not_connected = false;
                         let vertex1 = point[vertices[j]];
                         let vertex2 = point[vertices[k]];
-                        if (Math.abs(vertex1.x - vertex2.x) < 0.001) {
-                            for (let l = 0; l < edge_bank.length; l++) {
-                                if (Math.abs(point[edge_bank[l]].x - vertex1.x) < 0.001) {
-                                    if ((!off_centered && (Math.abs(vertex1.y + vertex2.y - 2*point[edge_bank[l]].y) < 0.001)) || (off_centered && (vertex1.y < point[edge_bank[l]].y === point[edge_bank[l]].y < vertex2.y))) {
-                                        deltas.push({diff: 0,
-                                                     v1: Math.min(vertices[j], vertices[k]),
-                                                     v2: Math.max(vertices[j], vertices[k]),
-                                                     edge: edge_bank[l]});
-                                    }
+                        for (let l = 0; l < vertices.length; l++) {
+                            if (l !== j && l !== k) {
+                                if ((this.distance_to_line(vertex1, vertex2, point[vertices[l]]) < 0.001) && this.between_points(vertex1, vertex2, point[vertices[l]])) {
+                                    not_connected = true;
                                 }
                             }
-                        } else if (Math.abs(vertex1.y - vertex2.y) < 0.001) {
+                        }
+                        if (!not_connected) {
                             for (let l = 0; l < edge_bank.length; l++) {
-                                if (Math.abs(point[edge_bank[l]].y - vertex1.y) < 0.001) {
-                                    if ((!off_centered && (Math.abs(vertex1.x + vertex2.x - 2*point[edge_bank[l]].x) < 0.001)) || (off_centered && (vertex1.x < point[edge_bank[l]].x === point[edge_bank[l]].x < vertex2.x))) {
-                                        deltas.push({diff: 0,
-                                                     v1: Math.min(vertices[j], vertices[k]),
-                                                     v2: Math.max(vertices[j], vertices[k]),
-                                                     edge: edge_bank[l]});
-                                    }
-                                }
-                            }
-                        } else {
-                            for (let l = 0; l < edge_bank.length; l++) {
-                                let delta = Math.abs(((vertex1.y - point[edge_bank[l]].y)*(vertex2.x - point[edge_bank[l]].x)) -
-                                                    ((vertex1.x - point[edge_bank[l]].x)*(vertex2.y - point[edge_bank[l]].y)));
-                                if ((!off_centered && (Math.abs(vertex1.x + vertex2.x - 2*point[edge_bank[l]].x) < 0.001) && (Math.abs(vertex1.y + vertex2.y - 2*point[edge_bank[l]].y) < 0.001) ) ||
-                                (off_centered && (vertex1.x < point[edge_bank[l]].x === point[edge_bank[l]].x < vertex2.x) && (vertex1.y < point[edge_bank[l]].y === point[edge_bank[l]].y < vertex2.y))) {
+                                let delta = this.distance_to_line(vertex1, vertex2, point[edge_bank[l]]);
+                                if (this.between_points(vertex1, vertex2, point[edge_bank[l]])) {
                                     deltas.push({diff: delta,
-                                                 v1: Math.min(vertices[j], vertices[k]),
-                                                 v2: Math.max(vertices[j], vertices[k]),
-                                                 edge: edge_bank[l]});
+                                                    v1: Math.min(vertices[j], vertices[k]),
+                                                    v2: Math.max(vertices[j], vertices[k]),
+                                                    edge: edge_bank[l]});
                                 }
                             }
                         }
@@ -624,12 +608,6 @@ class Puzzle {
                 for (let j = 0; j < vertices.length; j++) {
                     // Fill in the edge_to_vertex data, and add the cell to the edge's neighbour
                     point[deltas[j].edge].edge_to_vertex = [deltas[j].v1, deltas[j].v2];
-                    if (point[deltas[j].v1].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
-                        point[deltas[j].v1].edge_to_vertex.push(deltas[j].edge);
-                    }
-                    if (point[deltas[j].v2].edge_to_vertex.indexOf(deltas[j].edge) < 0) {
-                        point[deltas[j].v2].edge_to_vertex.push(deltas[j].edge);
-                    }
                     point[deltas[j].edge].neighbor.push(parseInt(i));
                     edges.push(deltas[j].edge);
                 }
@@ -649,9 +627,14 @@ class Puzzle {
                         }
                     }
                     // Fix cells adjacent
-                    if (edge.neighbor.length == 2 && fix_adjacent) {
+                    if (edge.neighbor.length == 2) {
                         point[edge.neighbor[j]].adjacent.push(parseInt(edge.neighbor[(j + 1) % 2]));
                     }     
+                }
+                // Fix vertices' edge_to_vertex
+                if (!!edge.edge_to_vertex) {
+                    for (let j = 0; j < edge.edge_to_vertex.length; j++)
+                    point[edge.edge_to_vertex[j]].edge_to_vertex.push(parseInt(i));
                 }
             }
         }
@@ -667,14 +650,18 @@ class Puzzle {
                 let vertices = edge.edge_to_vertex;
                 if (vertices.length == 2) {
                     for (let j = 0; j < cells.length; j++) {
-                        point[this.corner_table[cells[j]][vertices[0]]].adjacent.push(parseInt(this.corner_table[cells[j]][vertices[1]]));
-                        point[this.corner_table[cells[j]][vertices[1]]].adjacent.push(parseInt(this.corner_table[cells[j]][vertices[0]]));
+                        if (!!point[this.corner_table[cells[j]][vertices[0]]] && !!point[this.corner_table[cells[j]][vertices[1]]]) {
+                            point[this.corner_table[cells[j]][vertices[0]]].adjacent.push(parseInt(this.corner_table[cells[j]][vertices[1]]));
+                            point[this.corner_table[cells[j]][vertices[1]]].adjacent.push(parseInt(this.corner_table[cells[j]][vertices[0]]));
+                        }
                     }
                 }
                 if (cells.length == 2) {
                     for (let j = 0; j < 2; j++) {
-                        point[this.corner_table[cells[1]][vertices[j]]].adjacent.push(parseInt(this.corner_table[cells[0]][vertices[j]]));
-                        point[this.corner_table[cells[0]][vertices[j]]].adjacent.push(parseInt(this.corner_table[cells[1]][vertices[j]]));
+                        if (!!point[this.corner_table[cells[0]][vertices[j]]] && !!point[this.corner_table[cells[1]][vertices[j]]]) {
+                            point[this.corner_table[cells[1]][vertices[j]]].adjacent.push(parseInt(this.corner_table[cells[0]][vertices[j]]));
+                            point[this.corner_table[cells[0]][vertices[j]]].adjacent.push(parseInt(this.corner_table[cells[1]][vertices[j]]));
+                        }
                     }
                 }
             }
@@ -687,7 +674,7 @@ class Puzzle {
         let cells = [];
         let corners = [];
         for (var i in point) {
-            if (this.types[0].indexOf(point[i].type) !== -1 && point[i].use !== -1) {
+            if (this.types[0].indexOf(point[i].type) !== -1) {
                 cells.push(parseInt(i));
             }
             if (this.types[3].indexOf(point[i].type) !== -1) {
@@ -702,13 +689,12 @@ class Puzzle {
             let cell = point[cells[i]];
             for (let j = 0; j < cell.surround.length; j++) {
                 let vertex = point[cell.surround[j]];
-                let min = Number.MAX_VALUE;
+                let min = 1;
                 let corner = 0;
                   for (let k = 0; k < corners.length; k++) {
                     let corner_point = point[corners[k]];
-                    let diff = Math.abs((cell.y - vertex.y)*corner_point.x - (cell.x - vertex.x)*corner_point.y + (cell.x * vertex.y) - (cell.y * vertex.x)) / 
-                                Math.sqrt((cell.y - vertex.y)**2 + (cell.x - vertex.x)**2);
-                    if ((min > diff) && (cell.x > point[corners[k]].x === point[corners[k]].x > vertex.x) && (cell.y > point[corners[k]].y === point[corners[k]].y > vertex.y)) {
+                    let diff = this.distance_to_line(cell, vertex, corner_point);
+                    if ((min > diff) && (Math.min(vertex.use, cell.use) !== -1) && this.between_points(vertex, cell, corner_point)) {
                         min = diff;
                         corner = corners[k];
                     }
@@ -717,12 +703,29 @@ class Puzzle {
                     point[corner].surround.push(parseInt(cell.surround[j]));
                     point[corner].neighbor.push(parseInt(cells[i]));
                     this.corner_table[cells[i]][cell.surround[j]] = corner;
-                    this.remove_from_array(corners, corner);
                 }
             }
         }
         return point;
     }
+
+    // Helper functions
+    distance_to_line(line1, line2, point) {
+        if (!line1 || !line2 || !point) {
+            return Number.MAX_VALUE;
+        }
+        return Math.abs((line1.y - line2.y)*point.x - (line1.x - line2.x)*point.y + (line1.x * line2.y) - (line1.y * line2.x)) / 
+               Math.sqrt((line1.y - line2.y)**2 + (line1.x - line2.x)**2);
+    }
+
+    between_points(p1, p2, test) {
+        if (!p1 || !p2 || !test) {
+            return false;
+        }
+        return (Math.min(p1.x,p2.x) <= (test.x + 0.00001)) && ((test.x - 0.00001) <= Math.max(p1.x, p2.x)) &&
+               (Math.min(p1.y,p2.y) <= (test.y + 0.00001)) && ((test.y - 0.00001) <= Math.max(p1.y, p2.y));
+    }
+
 
     // Create corners to be used by the puzzle
     create_corners(point, radius, k) {
@@ -9624,9 +9627,9 @@ class Puzzle {
 
 
                 let line_style = this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][1];
-                // Find if any cell of the new cage (if square grid) has outside half grid cells then skip
+                // Find if any cell of the new cage has outside half grid cells then skip
                 for (let i = 0; i < this.cageselection.length; i++) {
-                    if (this.cell_outside_for_square(this.cageselection[i])) {
+                    if (this.cell_outside(this.cageselection[i])) {
                         cageexist_status = true;
                         skip_cages = true;
                         break;
@@ -9834,7 +9837,7 @@ class Puzzle {
         while (cage_queue.length > 0) {
             let cell = cage_queue.shift();
             found_cage.push(cell);
-            if (this.cell_outside_for_square(cell) || !this.corner_table[cell]) {
+            if (this.cell_outside(cell) || !this.corner_table[cell]) {
                 not_in_cage = true;
                 break;
             }
@@ -9883,7 +9886,7 @@ class Puzzle {
         while (flood_queue.length > 0) {
             let cell = flood_queue.shift();
             context.push(cell);
-            if (this.cell_outside_for_square(cell)) {
+            if (this.cell_outside(cell)) {
                 full = true;
                 break;
             }
@@ -9928,7 +9931,7 @@ class Puzzle {
                 while (temp_queue.length > 0) {
                     let cell = temp_queue.shift();
                     temp_area.push(cell);
-                    if (this.cell_outside_for_square(cell) || !this.corner_table[cell]) {
+                    if (this.cell_outside(cell) || !this.corner_table[cell]) {
                         reached_outside = true;
                         break;
                     }
@@ -9962,15 +9965,13 @@ class Puzzle {
         return output;
     }
 
-    // Returns true if a cell is partly outside on a square grid
-    cell_outside_for_square(cell) {
-        if (this.grid_is_square()) {
-            let row_size = parseInt(this.ny0 - 4);
-            let col_size = parseInt(this.nx0 - 4);
-            let col_num = (cell % (this.nx0)) - 2;
-            let row_num = parseInt(cell / this.nx0) - 2;
-
-            if ((row_num < 0) || (row_num >= row_size) || (col_num < 0) || (col_num >= col_size)) {
+    // Returns true if a cell is partly outside
+    cell_outside(cell) {
+        if (!cell) {
+            return true;
+        }
+        for (let i = 0; i < this.point[cell].surround.length; i++) {
+            if (!this.between_points({x: -1, y: -1}, {x: this.canvasx + 1, y: this.canvasy + 1}, this.point[this.point[cell].surround[i]])) {
                 return true;
             }
         }
@@ -13023,11 +13024,19 @@ class Puzzle {
                     // i1-j1 and i2-j2 can define lines. Find the intersection of both lines, and connect the intersection to i1, then the intersection to i2
                     let pi1 = this.get_cage_coordinates(i1, r);
                     let pi2 = this.get_cage_coordinates(i2, r);
-                    let pj1 = this.get_cage_coordinates(j1, r);
-                    let pj2 = this.get_cage_coordinates(j2, r);
+                    let pj1, pj2, denom;
+                    let skip = false;
                     let intersect = [];
-
-                    let denom = ((pj2[1] - pi2[1]) * (pj1[0] - pi1[0])) - ((pj2[0] - pi2[0]) * (pj1[1] - pi1[1]));
+                    if (!this.point[j1] || !this.point[j2]) {
+                        // Cannot find the other points for some reason
+                        skip = true;
+                        denom = 0;
+                    }
+                    if (!skip) {
+                        pj1 = this.get_cage_coordinates(j1, r);
+                        pj2 = this.get_cage_coordinates(j2, r);
+                        denom = ((pj2[1] - pi2[1]) * (pj1[0] - pi1[0])) - ((pj2[0] - pi2[0]) * (pj1[1] - pi1[1]));
+                    }
                     if (Math.abs(denom) < 0.0001 ) {
                         // Undefined intersection, just take midpoint
                         intersect = [(pi1[0] + pi2[0]) / 2, (pi1[1] + pi2[1]) / 2];

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -226,8 +226,9 @@ class Puzzle_pyramid extends Puzzle {
 
     type_set() {
         var type;
-        let grouped_types = this.types;
-        switch (this.mode[this.mode.qa].edit_mode) {
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -242,7 +243,7 @@ class Puzzle_pyramid extends Puzzle {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                if (submode === "3") {
                     type = [4];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -253,14 +254,14 @@ class Puzzle_pyramid extends Puzzle {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2, 3];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2, 3];
                 } else {
                     type = [1];
@@ -274,7 +275,7 @@ class Puzzle_pyramid extends Puzzle {
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0];
@@ -282,14 +283,14 @@ class Puzzle_pyramid extends Puzzle {
                 break;
             case "cage":
                 case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [4, 6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -337,7 +338,7 @@ class Puzzle_pyramid extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type%10 === 2) {
+                    if (this.types[2].indexOf(this.point[i].type) !== -1) {
                         if (min0 > (0.7 * this.size) ** 2) {
                             break;
                         }
@@ -357,7 +358,7 @@ class Puzzle_pyramid extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type%10 === 1 || this.point[i].type%10 === 2) {
+                    if (this.types[1].concat(this.types[2]).indexOf(this.point[i].type) !== -1) {
                         if (min0 > (hitboxfactor * this.size) ** 2) {
                             break;
                         }

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -189,17 +189,18 @@ class Puzzle_pyramid extends Puzzle {
         }
         */
         this.types = [[0], [1], [2, 3], [4, 6], []];
-        this.point = this.point_connect_corners(this.point_fillin_corners(this.fix_points(point, false)));
+        this.point = this.point_connect_corners(this.point_fillin_corners(this.fix_points(point)));
     }
 
     listappend(centerlist) {
         var n = centerlist.length;
         for (var j = 0; j < n; j++) {
-            if (centerlist.indexOf(this.point[centerlist[j]].adjacent[4]) === -1) {
-                centerlist.push(this.point[centerlist[j]].adjacent[4]);
-            }
-            if (centerlist.indexOf(this.point[centerlist[j]].adjacent[5]) === -1) {
-                centerlist.push(this.point[centerlist[j]].adjacent[5]);
+            for (let k = 0; k < this.point[centerlist[j]].adjacent.length; k++) {
+                if (this.point[centerlist[j]].y < this.point[this.point[centerlist[j]].adjacent[k]].y) {
+                    if (centerlist.indexOf(this.point[centerlist[j]].adjacent[k]) === -1) {
+                        centerlist.push(this.point[centerlist[j]].adjacent[k])
+                    }
+                }
             }
         }
         return centerlist;

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -101,7 +101,7 @@ class Puzzle_pyramid extends Puzzle {
             }
         }
 
-        type = 3;
+        type = 12;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -122,7 +122,7 @@ class Puzzle_pyramid extends Puzzle {
 
         //  1/4
         var r = 0.25;
-        type = 4;
+        type = 3;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -162,7 +162,7 @@ class Puzzle_pyramid extends Puzzle {
           }
         }
         */
-
+        this.types = [0, 1, 2, 12, 3];
         this.point = point;
     }
 
@@ -200,43 +200,44 @@ class Puzzle_pyramid extends Puzzle {
 
     type_set() {
         var type;
+        let grouped_types = this.get_grouped_types();
         switch (this.mode[this.mode.qa].edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
-                type = [0];
+                type = grouped_types[0];
                 break;
             case "symbol":
             case "move":
                 if (!UserSettings.draw_edges) {
-                    type = [0];
+                    type = grouped_types[0];
                 } else {
-                    type = [0, 1, 2, 3];
+                    type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
                 }
                 break;
             case "number":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
-                    type = [4];
+                    type = [3];
                 } else {
                     if (!UserSettings.draw_edges) {
-                        type = [0];
+                        type = grouped_types[0];
                     } else {
-                        type = [0, 1, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
                     }
                 }
                 break;
             case "line":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
-                    type = [2, 3];
+                    type = grouped_types[2];
                 } else {
-                    type = [0];
+                    type = grouped_types[0];
                 }
                 break;
             case "lineE":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
-                    type = [2, 3];
+                    type = grouped_types[2];
                 } else {
-                    type = [1];
+                    type = grouped_types[1];
                 }
                 break;
             case "wall":
@@ -248,9 +249,9 @@ class Puzzle_pyramid extends Puzzle {
                 break;
             case "special":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
-                    type = [1];
+                    type = grouped_types[1];
                 } else {
-                    type = [0];
+                    type = grouped_types[0];
                 }
                 break;
             case "combi":
@@ -258,12 +259,12 @@ class Puzzle_pyramid extends Puzzle {
                     case "tents":
                     case "linex":
                     case "yajilin":
-                        type = [0, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[2]);
                         break;
                     case "edgex":
                     case "edgexoi":
                     case "star":
-                        type = [0, 1, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
                         break;
                     case "blpo":
                     case "blwh":
@@ -275,21 +276,21 @@ class Puzzle_pyramid extends Puzzle {
                     case "shaka":
                     case "numfl":
                     case "alfl":
-                        type = [0];
+                        type = grouped_types[0];
                         break;
                     case "edgesub":
-                        type = [0, 1];
+                        type = grouped_types[0].concat(grouped_types[1]);
                         break;
                     case "akari":
-                        type = [0, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[2]);
                         break;
                     case "mines":
-                        type = [0, 1, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
                         break;
                 }
                 break;
             case "sudoku":
-                type = [0];
+                type = grouped_types[0];
                 break;
         }
         return type;
@@ -302,7 +303,7 @@ class Puzzle_pyramid extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type === 2 || this.point[i].type === 3) {
+                    if (this.point[i].type%10 === 2) {
                         if (min0 > (0.7 * this.size) ** 2) {
                             break;
                         }
@@ -322,7 +323,7 @@ class Puzzle_pyramid extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type === 1 || this.point[i].type === 2 || this.point[i].type === 3) {
+                    if (this.point[i].type%10 === 1 || this.point[i].type%10 === 2) {
                         if (min0 > (hitboxfactor * this.size) ** 2) {
                             break;
                         }

--- a/docs/js/class_pyramid.js
+++ b/docs/js/class_pyramid.js
@@ -40,7 +40,9 @@ class Puzzle_pyramid extends Puzzle {
         var nx = this.nx0;
         var ny = this.ny0;
         var adjacent, surround, type, use;
+        var vertex_start, vertex_end;
         var point = [];
+        this.corner_table = [];
         //center
         type = 0;
         for (var j = 0; j < ny; j++) {
@@ -56,6 +58,7 @@ class Puzzle_pyramid extends Puzzle {
                 k++;
             }
         }
+        vertex_start = k;
         //vertex
         type = 1;
         for (var j = 0; j < ny; j++) {
@@ -84,7 +87,7 @@ class Puzzle_pyramid extends Puzzle {
                 k++;
             }
         }
-
+        vertex_end = k;
         //centervertex
         type = 2;
         for (var j = 0; j < ny; j++) {
@@ -97,11 +100,13 @@ class Puzzle_pyramid extends Puzzle {
                 adjacent = [];
                 surround = [k - 1, k + 1]; //for wall
                 point[k] = new Point(point[i + j * nx].x + 0.5 * this.size, point[i + j * nx].y, type, adjacent, surround, use);
+                point[i + j * nx].neighbor.push(k);
+                point[i + 1 + j * nx].neighbor.push(k);
                 k++;
             }
         }
 
-        type = 12;
+        type = 3;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -112,17 +117,31 @@ class Puzzle_pyramid extends Puzzle {
                 adjacent = [];
                 surround = [];
                 point[k] = new Point(point[i + j * nx].x - 0.25 * this.size, point[i + j * nx].y + 0.5 * this.size, type, adjacent, surround, use);
+                point[i + j * nx].neighbor.push(k);
+                for (let num = 0; num < point[i + j * nx].adjacent.length; num++) {
+                    if (!!point[point[i + j * nx].adjacent[num]]) {
+                        if (point[point[i + j * nx].adjacent[num]].x < point[i + j * nx].x && point[point[i + j * nx].adjacent[num]].y > point[i + j * nx].y) 
+                            point[point[i + j * nx].adjacent[num]].neighbor.push(k); 
+                    }
+                }
                 k++;
                 adjacent = [];
                 surround = [];
                 point[k] = new Point(point[i + j * nx].x + 0.25 * this.size, point[i + j * nx].y + 0.5 * this.size, type, adjacent, surround, use);
+                point[i + j * nx].neighbor.push(k);
+                for (let num = 0; num < point[i + j * nx].adjacent.length; num++) {
+                    if (!!point[point[i + j * nx].adjacent[num]]) {
+                        if (point[point[i + j * nx].adjacent[num]].x > point[i + j * nx].x && point[point[i + j * nx].adjacent[num]].y > point[i + j * nx].y) 
+                            point[point[i + j * nx].adjacent[num]].neighbor.push(k); 
+                    }
+                }
                 k++;
             }
         }
 
-        //  1/4
+        //  corner
         var r = 0.25;
-        type = 3;
+        type = 4;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -141,6 +160,13 @@ class Puzzle_pyramid extends Puzzle {
                 point[k] = new Point(point[i + j * nx].x + r * this.size, point[i + j * nx].y + r * this.size, type, adjacent, surround, use);
                 k++;
             }
+        }
+        type = 6;
+        for (var i = vertex_start; i < vertex_end; i++) {
+            surround = [];
+            adjacent = [];
+            point[k] = new Point(point[i].x, (1 - r) * point[i].y + r * point[point[i].surround[0]].y, type, adjacent, surround, Math.min(point[i].use, point[point[i].surround[0]].use));
+            k++;
         }
         /*
         //  compass
@@ -162,8 +188,8 @@ class Puzzle_pyramid extends Puzzle {
           }
         }
         */
-        this.types = [0, 1, 2, 12, 3];
-        this.point = point;
+        this.types = [[0], [1], [2, 3], [4, 6], []];
+        this.point = this.point_connect_corners(this.point_fillin_corners(this.fix_points(point, false)));
     }
 
     listappend(centerlist) {
@@ -200,44 +226,44 @@ class Puzzle_pyramid extends Puzzle {
 
     type_set() {
         var type;
-        let grouped_types = this.get_grouped_types();
+        let grouped_types = this.types;
         switch (this.mode[this.mode.qa].edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
-                type = grouped_types[0];
+                type = [0];
                 break;
             case "symbol":
             case "move":
                 if (!UserSettings.draw_edges) {
-                    type = grouped_types[0];
+                    type = [0];
                 } else {
-                    type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
+                    type = [0, 1, 2, 3];
                 }
                 break;
             case "number":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
-                    type = [3];
+                    type = [4];
                 } else {
                     if (!UserSettings.draw_edges) {
-                        type = grouped_types[0];
+                        type = [0];
                     } else {
-                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
+                        type = [0, 1, 2, 3];
                     }
                 }
                 break;
             case "line":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
-                    type = grouped_types[2];
+                    type = [2, 3];
                 } else {
-                    type = grouped_types[0];
+                    type = [0];
                 }
                 break;
             case "lineE":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
-                    type = grouped_types[2];
+                    type = [2, 3];
                 } else {
-                    type = grouped_types[1];
+                    type = [1];
                 }
                 break;
             case "wall":
@@ -249,9 +275,17 @@ class Puzzle_pyramid extends Puzzle {
                 break;
             case "special":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
-                    type = grouped_types[1];
+                    type = [1];
                 } else {
-                    type = grouped_types[0];
+                    type = [0];
+                }
+                break;
+            case "cage":
+                case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [4, 6];
                 }
                 break;
             case "combi":
@@ -259,12 +293,12 @@ class Puzzle_pyramid extends Puzzle {
                     case "tents":
                     case "linex":
                     case "yajilin":
-                        type = grouped_types[0].concat(grouped_types[2]);
+                        type = [0, 2, 3];
                         break;
                     case "edgex":
                     case "edgexoi":
                     case "star":
-                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
+                        type = [0, 1, 2, 3];
                         break;
                     case "blpo":
                     case "blwh":
@@ -276,21 +310,21 @@ class Puzzle_pyramid extends Puzzle {
                     case "shaka":
                     case "numfl":
                     case "alfl":
-                        type = grouped_types[0];
+                        type = [0];
                         break;
                     case "edgesub":
-                        type = grouped_types[0].concat(grouped_types[1]);
+                        type = [0, 1];
                         break;
                     case "akari":
-                        type = grouped_types[0].concat(grouped_types[2]);
+                        type = [0, 2, 3];
                         break;
                     case "mines":
-                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
+                        type = [0, 1, 2, 3];
                         break;
                 }
                 break;
             case "sudoku":
-                type = grouped_types[0];
+                type = [0];
                 break;
         }
         return type;
@@ -527,6 +561,8 @@ class Puzzle_pyramid extends Puzzle {
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -547,6 +583,7 @@ class Puzzle_pyramid extends Puzzle {
             this.draw_lattice();
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -217,79 +217,78 @@ class Puzzle_square extends Puzzle {
 
     type_set() {
         var type
-        let grouped_types = this.types;
         let edit_mode = this.mode[this.mode.qa].edit_mode;
         let submode = this.mode[this.mode.qa][edit_mode][0];
         switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
-                type = grouped_types[0];
+                type = [0];
                 break;
             case "symbol":
             case "move":
                 if (!UserSettings.draw_edges) {
-                    type = grouped_types[0];
+                    type = [0];
                 } else {
-                    type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
+                    type = [0, 1, 2, 3];
                 }
                 break;
             case "number":
                 if (submode === "2") {
-                    type = grouped_types[0];
+                    type = [0];
                 } else if (submode === "3") {
-                    type = grouped_types[3];
+                    type = [4];
                 } else if (submode === "9") {
-                    type = grouped_types[4];
+                    type = [5];
                 } else {
                     if (!UserSettings.draw_edges) {
-                        type = grouped_types[0];
+                        type = [0];
                     } else {
-                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
+                        type = [0, 1, 2, 3];
                     }
                 }
                 break;
             case "line":
                 if (submode === "4") {
-                    type = grouped_types[2];
+                    type = [2, 3];
                 } else if (submode === "2") {
-                    type = grouped_types[0].concat(grouped_types[1]);
+                    type = [0, 1];
                 } else if (submode === "5") {
-                    type = grouped_types[0].concat(grouped_types[2]);
+                    type = [0, 2, 3];
                 } else {
-                    type = grouped_types[0];
+                    type = [0];
                 }
                 break;
             case "lineE":
                 if (submode === "4") {
-                    type = grouped_types[2];
+                    type = [2, 3];
                 } else if (submode === "2") {
-                    type = grouped_types[0].concat(grouped_types[1]);
+                    type = [0, 1];
                 } else if (submode === "6") {
-                    type = grouped_types[1].concat(grouped_types[2]);
+                    type = [1, 2, 3];
                 } else {
-                    type = grouped_types[1];
+                    type = [1];
                 }
                 break;
             case "wall":
                 if (this.drawing) {
                     type = [this.point[this.last].type];
                 } else {
-                    type = grouped_types[2];
+                    type = [2, 3];
                 }
                 break;
             case "cage":
                 if (submode === "1") {
-                    type = grouped_types[0];
+                    type = [0];
                 } else if (submode === "2") {
-                    type = grouped_types[3];
+                    type = [4];
                 }
                 break;
             case "special":
                 if (submode === "polygon") {
-                    type = grouped_types[1];
+                    type = [1];
                 } else {
-                    type = grouped_types[0].concat(grouped_types[1]);
+                    type = [0, 1];
                 }
                 break;
             case "combi":
@@ -299,14 +298,14 @@ class Puzzle_square extends Puzzle {
                     case "linedir":
                     case "yajilin":
                     case "akari":
-                        type = grouped_types[0].concat(grouped_types[2]);
+                        type = [0, 2, 3];
                         break;
                     case "edgex":
                     case "edgexoi":
                     case "star":
                     case "mines":
                     case "doublemines":
-                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
+                        type = [0, 1, 2, 3];
                         break;
                     case "blpo":
                     case "blwh":
@@ -319,18 +318,18 @@ class Puzzle_square extends Puzzle {
                     case "numfl":
                     case "alfl":
                     case "rassisillai":
-                        type = grouped_types[0]
+                        type = [0]
                         break;
                     case "edgesub":
-                        type = grouped_types[0].concat(grouped_types[1]);
+                        type = [0, 1];
                         break;
                 }
                 break;
             case "sudoku":
                 if (UserSettings.draw_edges) {
-                    type = grouped_types[0].concat(grouped_types[2]);
+                    type = [0, 2, 3];
                 } else {
-                    type = grouped_types[0];
+                    type = [0];
                 }
                 break;
         }
@@ -344,7 +343,7 @@ class Puzzle_square extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type%10 === 2) {
+                    if (this.types[2].indexOf(this.point[i].type) !== -1) {
                         if (min0 > (hitboxfactor * this.size) ** 2) {
                             break;
                         }
@@ -364,7 +363,7 @@ class Puzzle_square extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type%10 === 1 || this.point[i].type%10 === 2) {
+                    if (this.types[1].concat(this.types[2]).indexOf(this.point[i].type) !== -1) {
                         if (min0 > (hitboxfactor * this.size) ** 2) {
                             break;
                         }
@@ -1395,12 +1394,12 @@ class Puzzle_square extends Puzzle {
                     this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
                     this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
                 } else {
-                    if (this.point[i1].type%10 === 2) { //for centerline
+                    if (this.types[2].indexOf(this.point[i].type) !== -1) { //for centerline
                         this.ctx.moveTo(this.point[i2].x, this.point[i2].y);
                         this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
                         this.ctx.stroke();
                         this.ctx.lineCap = "butt";
-                    } else if (this.point[i2].type%10 === 2) {
+                    } else if (this.types[2].indexOf(this.point[i].type) !== -1) {
                         this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
                         this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
                         this.ctx.stroke();
@@ -1658,7 +1657,7 @@ class Puzzle_square extends Puzzle {
 
                     // If the clue is quad (like in a sudoku) render it differently
                     // Conditions - Clue is on the corner (type 1), style is with background circle
-                    let quad = (this.point[i].type%10 === 1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
+                    let quad = (this.types[1].indexOf(this.point[i].type) !== -1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
                     if (quad) {
                         set_font_style(this.ctx, 0.31 * this.size.toString(10), this[pu].number[i][1]);
                         if (values.length === 1) {
@@ -1902,7 +1901,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
                     break;
                 case "4": //tapa
-                    let quad = (this.point[i].type%10 === 1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
+                    let quad = (this.types[1].indexOf(this.point[i].type) !== -1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
                     this.draw_numbercircle(pu, i, p_x, p_y, quad ? 0.31 : 0.44);
                     break;
                 case "5": //small

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -104,7 +104,7 @@ class Puzzle_square extends Puzzle {
                 k++;
             }
         }
-        type = 12;
+        type = 3;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -123,7 +123,7 @@ class Puzzle_square extends Puzzle {
 
         //  corner
         var r = 0.25;
-        type = 3;
+        type = 4;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -154,7 +154,7 @@ class Puzzle_square extends Puzzle {
 
         //  compass
         var r = 0.3;
-        type = 4;
+        type = 5;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -175,7 +175,8 @@ class Puzzle_square extends Puzzle {
             }
         }
 
-        this.types = [0, 1, 2, 12, 3, 4];
+        this.types = [[0], [1], [2, 3], [4], [5]];
+        point = this.fill_neighbors(point);
         this.point = point;
         
     }
@@ -216,7 +217,7 @@ class Puzzle_square extends Puzzle {
 
     type_set() {
         var type
-        let grouped_types = this.get_grouped_types();
+        let grouped_types = this.types;
         let edit_mode = this.mode[this.mode.qa].edit_mode;
         let submode = this.mode[this.mode.qa][edit_mode][0];
         switch (edit_mode) {
@@ -1471,80 +1472,7 @@ class Puzzle_square extends Puzzle {
             this.ctx.stroke();
         }
     }
-/*
-    draw_cage(pu) {
-        var r = 0.16; //space between grid
-        var a = [0, 1, 2, 3],
-            c;
-        if (this.theta === 90) {
-            a = [2, 0, 3, 1];
-        } else if (this.theta === 180) {
-            a = [3, 2, 1, 0];
-        } else if (this.theta === 270) {
-            a = [1, 3, 0, 2];
-        }
-        if (this.reflect[0] === -1) {
-            c = a[0];
-            a[0] = a[1];
-            a[1] = c;
-            c = a[2];
-            a[2] = a[3];
-            a[3] = c;
-        }
-        if (this.reflect[1] === -1) {
-            c = a[0];
-            a[0] = a[2];
-            a[2] = c;
-            c = a[1];
-            a[1] = a[3];
-            a[3] = c;
-        }
-        for (var i in this[pu].cage) {
-            var i1 = i.split(",")[0];
-            var i2 = i.split(",")[1];
-            var x1, y1, x2, y2;
 
-            if (i1 % 4 === a[0]) {
-                x1 = this.point[i1].x - r * this.size;
-                y1 = this.point[i1].y - r * this.size;
-            } else if (i1 % 4 === a[1]) {
-                x1 = this.point[i1].x + r * this.size;
-                y1 = this.point[i1].y - r * this.size;
-            } else if (i1 % 4 === a[2]) {
-                x1 = this.point[i1].x - r * this.size;
-                y1 = this.point[i1].y + r * this.size;
-            } else if (i1 % 4 === a[3]) {
-                x1 = this.point[i1].x + r * this.size;
-                y1 = this.point[i1].y + r * this.size;
-            }
-            if (i2 % 4 === a[0]) {
-                x2 = this.point[i2].x - r * this.size;
-                y2 = this.point[i2].y - r * this.size;
-            } else if (i2 % 4 === a[1]) {
-                x2 = this.point[i2].x + r * this.size;
-                y2 = this.point[i2].y - r * this.size;
-            } else if (i2 % 4 === a[2]) {
-                x2 = this.point[i2].x - r * this.size;
-                y2 = this.point[i2].y + r * this.size;
-            } else if (i2 % 4 === a[3]) {
-                x2 = this.point[i2].x + r * this.size;
-                y2 = this.point[i2].y + r * this.size;
-            }
-            if (i1 % 4 === 3 || i2 % 4 === 0) {
-                set_line_style(this.ctx, this[pu].cage[i] + 100);
-            } else {
-                set_line_style(this.ctx, this[pu].cage[i]);
-            }
-            if (UserSettings.custom_colors_on && this[pu + "_col"].cage[i]) {
-                this.ctx.strokeStyle = this[pu + "_col"].cage[i];
-            }
-            this.ctx.beginPath();
-            this.ctx.moveTo(x1, y1);
-            this.ctx.lineTo(x2, y2);
-            this.ctx.stroke();
-        }
-    }
-*/
     draw_symbol(pu, layer) {
         /*symbol_layer*/
         var p_x, p_y;

--- a/docs/js/class_square.js
+++ b/docs/js/class_square.js
@@ -104,7 +104,7 @@ class Puzzle_square extends Puzzle {
                 k++;
             }
         }
-        type = 3;
+        type = 12;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -121,9 +121,9 @@ class Puzzle_square extends Puzzle {
             }
         }
 
-        //  1/4
+        //  corner
         var r = 0.25;
-        type = 4;
+        type = 3;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -131,25 +131,30 @@ class Puzzle_square extends Puzzle {
                 } else {
                     use = 1;
                 }
-                surround = [];
+                neighbor = [i + j * nx];
+                this.corner_table[i + j * nx] = [];
+                this.corner_table[i + j * nx][point[i + j * nx].surround[0]] = k;
+                this.corner_table[i + j * nx][point[i + j * nx].surround[1]] = k + 1;
+                this.corner_table[i + j * nx][point[i + j * nx].surround[3]] = k + 2;
+                this.corner_table[i + j * nx][point[i + j * nx].surround[2]] = k + 3;
                 adjacent = [k - 4 * nx + 2, k - 3, k + 1, k + 2];
-                point[k] = new Point(point[i + j * nx].x - r * this.size, point[i + j * nx].y - r * this.size, type, adjacent, surround, use, [], [], 0, index(i, j));
+                point[k] = new Point(point[i + j * nx].x - r * this.size, point[i + j * nx].y - r * this.size, type, adjacent, [point[i + j * nx].surround[0]], use, neighbor, [], 0, index(i, j));
                 k++;
                 adjacent = [k - 4 * nx + 2, k - 1, k + 3, k + 2];
-                point[k] = new Point(point[i + j * nx].x + r * this.size, point[i + j * nx].y - r * this.size, type, adjacent, surround, use, [], [], 0, index(i, j));
+                point[k] = new Point(point[i + j * nx].x + r * this.size, point[i + j * nx].y - r * this.size, type, adjacent, [point[i + j * nx].surround[1]], use, neighbor, [], 0, index(i, j));
                 k++;
                 adjacent = [k - 2, k - 3, k + 1, k + 4 * nx - 2];
-                point[k] = new Point(point[i + j * nx].x - r * this.size, point[i + j * nx].y + r * this.size, type, adjacent, surround, use, [], [], 0, index(i, j));
+                point[k] = new Point(point[i + j * nx].x - r * this.size, point[i + j * nx].y + r * this.size, type, adjacent, [point[i + j * nx].surround[3]], use, neighbor, [], 0, index(i, j));
                 k++;
                 adjacent = [k - 2, k - 1, k + 3, k + 4 * nx - 2];
-                point[k] = new Point(point[i + j * nx].x + r * this.size, point[i + j * nx].y + r * this.size, type, adjacent, surround, use, [], [], 0, index(i, j));
+                point[k] = new Point(point[i + j * nx].x + r * this.size, point[i + j * nx].y + r * this.size, type, adjacent, [point[i + j * nx].surround[2]], use, neighbor, [], 0, index(i, j));
                 k++;
             }
         }
 
         //  compass
         var r = 0.3;
-        type = 5;
+        type = 4;
         for (var j = 0; j < ny; j++) {
             for (var i = 0; i < nx; i++) {
                 if (i === 0 || i === nx - 1 || j === 0 || j === ny - 1) {
@@ -170,10 +175,13 @@ class Puzzle_square extends Puzzle {
             }
         }
 
+        this.types = [0, 1, 2, 12, 3, 4];
         this.point = point;
+        
     }
 
     reset_frame() {
+        this.corner_table = [];
         this.create_point();
         this.space = [
             parseInt(document.getElementById("nb_space1").value, 10),
@@ -208,78 +216,79 @@ class Puzzle_square extends Puzzle {
 
     type_set() {
         var type
+        let grouped_types = this.get_grouped_types();
         let edit_mode = this.mode[this.mode.qa].edit_mode;
         let submode = this.mode[this.mode.qa][edit_mode][0];
         switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
-                type = [0];
+                type = grouped_types[0];
                 break;
             case "symbol":
             case "move":
                 if (!UserSettings.draw_edges) {
-                    type = [0];
+                    type = grouped_types[0];
                 } else {
-                    type = [0, 1, 2, 3];
+                    type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
                 }
                 break;
             case "number":
                 if (submode === "2") {
-                    type = [0];
+                    type = grouped_types[0];
                 } else if (submode === "3") {
-                    type = [4];
+                    type = grouped_types[3];
                 } else if (submode === "9") {
-                    type = [5];
+                    type = grouped_types[4];
                 } else {
                     if (!UserSettings.draw_edges) {
-                        type = [0];
+                        type = grouped_types[0];
                     } else {
-                        type = [0, 1, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
                     }
                 }
                 break;
             case "line":
                 if (submode === "4") {
-                    type = [2, 3];
+                    type = grouped_types[2];
                 } else if (submode === "2") {
-                    type = [0, 1];
+                    type = grouped_types[0].concat(grouped_types[1]);
                 } else if (submode === "5") {
-                    type = [0, 2, 3];
+                    type = grouped_types[0].concat(grouped_types[2]);
                 } else {
-                    type = [0];
+                    type = grouped_types[0];
                 }
                 break;
             case "lineE":
                 if (submode === "4") {
-                    type = [2, 3];
+                    type = grouped_types[2];
                 } else if (submode === "2") {
-                    type = [0, 1];
+                    type = grouped_types[0].concat(grouped_types[1]);
                 } else if (submode === "6") {
-                    type = [1, 2, 3];
+                    type = grouped_types[1].concat(grouped_types[2]);
                 } else {
-                    type = [1];
+                    type = grouped_types[1];
                 }
                 break;
             case "wall":
                 if (this.drawing) {
                     type = [this.point[this.last].type];
                 } else {
-                    type = [2, 3];
+                    type = grouped_types[2];
                 }
                 break;
             case "cage":
                 if (submode === "1") {
-                    type = [0];
+                    type = grouped_types[0];
                 } else if (submode === "2") {
-                    type = [4];
+                    type = grouped_types[3];
                 }
                 break;
             case "special":
                 if (submode === "polygon") {
-                    type = [1];
+                    type = grouped_types[1];
                 } else {
-                    type = [0, 1];
+                    type = grouped_types[0].concat(grouped_types[1]);
                 }
                 break;
             case "combi":
@@ -289,14 +298,14 @@ class Puzzle_square extends Puzzle {
                     case "linedir":
                     case "yajilin":
                     case "akari":
-                        type = [0, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[2]);
                         break;
                     case "edgex":
                     case "edgexoi":
                     case "star":
                     case "mines":
                     case "doublemines":
-                        type = [0, 1, 2, 3];
+                        type = grouped_types[0].concat(grouped_types[1], grouped_types[2]);
                         break;
                     case "blpo":
                     case "blwh":
@@ -309,18 +318,18 @@ class Puzzle_square extends Puzzle {
                     case "numfl":
                     case "alfl":
                     case "rassisillai":
-                        type = [0];
+                        type = grouped_types[0]
                         break;
                     case "edgesub":
-                        type = [0, 1];
+                        type = grouped_types[0].concat(grouped_types[1]);
                         break;
                 }
                 break;
             case "sudoku":
                 if (UserSettings.draw_edges) {
-                    type = [0, 2, 3];
+                    type = grouped_types[0].concat(grouped_types[2]);
                 } else {
-                    type = [0];
+                    type = grouped_types[0];
                 }
                 break;
         }
@@ -334,7 +343,7 @@ class Puzzle_square extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type === 2 || this.point[i].type === 3) {
+                    if (this.point[i].type%10 === 2) {
                         if (min0 > (hitboxfactor * this.size) ** 2) {
                             break;
                         }
@@ -354,7 +363,7 @@ class Puzzle_square extends Puzzle {
             if (this.type.indexOf(this.point[i].type) != -1) {
                 min0 = (x - this.point[i].x) ** 2 + (y - this.point[i].y) ** 2;
                 if (min0 < min) {
-                    if (this.point[i].type === 1 || this.point[i].type === 2 || this.point[i].type === 3) {
+                    if (this.point[i].type%10 === 1 || this.point[i].type%10 === 2) {
                         if (min0 > (hitboxfactor * this.size) ** 2) {
                             break;
                         }
@@ -1385,12 +1394,12 @@ class Puzzle_square extends Puzzle {
                     this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
                     this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
                 } else {
-                    if (this.point[i1].type === 2 || this.point[i1].type === 3) { //for centerline
+                    if (this.point[i1].type%10 === 2) { //for centerline
                         this.ctx.moveTo(this.point[i2].x, this.point[i2].y);
                         this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
                         this.ctx.stroke();
                         this.ctx.lineCap = "butt";
-                    } else if (this.point[i2].type === 2 || this.point[i2].type === 3) {
+                    } else if (this.point[i2].type%10 === 2) {
                         this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
                         this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
                         this.ctx.stroke();
@@ -1462,7 +1471,7 @@ class Puzzle_square extends Puzzle {
             this.ctx.stroke();
         }
     }
-
+/*
     draw_cage(pu) {
         var r = 0.16; //space between grid
         var a = [0, 1, 2, 3],
@@ -1535,7 +1544,7 @@ class Puzzle_square extends Puzzle {
             this.ctx.stroke();
         }
     }
-
+*/
     draw_symbol(pu, layer) {
         /*symbol_layer*/
         var p_x, p_y;
@@ -1721,7 +1730,7 @@ class Puzzle_square extends Puzzle {
 
                     // If the clue is quad (like in a sudoku) render it differently
                     // Conditions - Clue is on the corner (type 1), style is with background circle
-                    let quad = (this.point[i].type === 1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
+                    let quad = (this.point[i].type%10 === 1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
                     if (quad) {
                         set_font_style(this.ctx, 0.31 * this.size.toString(10), this[pu].number[i][1]);
                         if (values.length === 1) {
@@ -1965,7 +1974,7 @@ class Puzzle_square extends Puzzle {
                     this.draw_numbercircle(pu, i, p_x, p_y, 0.42);
                     break;
                 case "4": //tapa
-                    let quad = (this.point[i].type === 1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
+                    let quad = (this.point[i].type%10 === 1) && [5, 6, 7, 11].includes(this[pu].number[i][1]) && this.version_ge(3, 1, 2);
                     this.draw_numbercircle(pu, i, p_x, p_y, quad ? 0.31 : 0.44);
                     break;
                 case "5": //small

--- a/docs/js/class_tri.js
+++ b/docs/js/class_tri.js
@@ -241,7 +241,9 @@ class Puzzle_tri extends Puzzle {
 
     type_set() {
         var type;
-        switch (this.mode[this.mode.qa].edit_mode) {
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -256,7 +258,7 @@ class Puzzle_tri extends Puzzle {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                if (submode === "3") {
                     type = [6];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -267,18 +269,18 @@ class Puzzle_tri extends Puzzle {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2, 3, 4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2, 3, 4];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2, 3, 4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "6") {
+                } else if (submode === "6") {
                     type = [1, 2, 3, 4];
                 } else {
                     type = [1];
@@ -292,21 +294,21 @@ class Puzzle_tri extends Puzzle {
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":

--- a/docs/js/class_tri.js
+++ b/docs/js/class_tri.js
@@ -188,7 +188,7 @@ class Puzzle_tri extends Puzzle {
                 k++;
             }
         }
-        this.point = point;
+        this.point = this.point_connect_corners(this.point_fillin_corners(this.fix_points(point)));
     }
 
 
@@ -199,11 +199,10 @@ class Puzzle_tri extends Puzzle {
             if (centerlist[j] < 2 * (this.n0) ** 2 && newlist.indexOf(this.point[centerlist[j]].adjacent[2]) === -1) {
                 newlist.push(this.point[centerlist[j]].adjacent[2]);
             } else if (centerlist[j] > 2 * (this.n0) ** 2) {
-                if (newlist.indexOf(this.point[centerlist[j]].adjacent[1]) === -1) {
-                    newlist.push(this.point[centerlist[j]].adjacent[1]);
-                }
-                if (newlist.indexOf(this.point[centerlist[j]].adjacent[2]) === -1) {
-                    newlist.push(this.point[centerlist[j]].adjacent[2]);
+                for (var k = 0; k < 3; k++) {
+                    if (newlist.indexOf(this.point[centerlist[j]].adjacent[k]) === -1 && this.point[this.point[centerlist[j]].adjacent[k]].y >= this.point[centerlist[j]].y) {
+                        newlist.push(this.point[centerlist[j]].adjacent[k]);
+                    }
                 }
             }
         }
@@ -300,7 +299,11 @@ class Puzzle_tri extends Puzzle {
                 }
                 break;
             case "cage":
-                type = [];
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
+                }
                 break;
             case "combi":
                 switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
@@ -553,6 +556,8 @@ class Puzzle_tri extends Puzzle {
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -572,6 +577,7 @@ class Puzzle_tri extends Puzzle {
             this.draw_lattice();
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -2968,7 +2968,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                 point[point[i].surround[k]].use = 1;
             }
         }
-        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point, true, true), 0.25, this.fix_points(point, true, true).length + 1)[0]);
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {
@@ -7020,7 +7020,7 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
                 point[i].surround[3] = s0;
             }
         }
-        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point, true, true), 0.25, this.fix_points(point, true, true).length + 1)[0]);
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -4907,7 +4907,6 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 }
             }
         }
-        [point, k] = this.create_corners(point, 0.25, k);
         // 重複判定
         var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
@@ -5029,7 +5028,9 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 }
             }
         }
-        this.point = this.point_connect_corners(this.point_fillin_corners(this.fix_points(point)));
+        point = this.fix_points(point);
+
+        this.point = this.point_connect_corners(this.create_corners(point, 0.25, point.length + 1)[0]);
     }
 
     reset_frame() {
@@ -5356,45 +5357,39 @@ class Puzzle_iso extends Puzzle_truncated_square {
                     if (this.point[i2].neighbor.indexOf(this.point[i1].neighbor[j]) !== -1) {
                         i3 = this.point[i1].neighbor[j];
                     }
-                    this.ctx.beginPath();
-                    if (this[pu].line[i] === 40) {
-                        var r = 0.6;
-                        var x1 = r * this.point[i1].x + (1 - r) * this.point[i3].x;
-                        var y1 = r * this.point[i1].y + (1 - r) * this.point[i3].y;
-                        var x2 = (1 - r) * this.point[i3].x + r * this.point[i2].x;
-                        var y2 = (1 - r) * this.point[i3].y + r * this.point[i2].y;
-                        this.ctx.moveTo(x1, y1);
-                        this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
-                        this.ctx.lineTo(x2, y2);
-                    } else if (this[pu].line[i] === 30) {
-                        var r = 0.15 * this.size;
-                        var dx = this.point[i1].x - this.point[i2].x;
-                        var dy = this.point[i1].y - this.point[i2].y;
-                        var d = Math.sqrt(dx ** 2 + dy ** 2);
-                        this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                        this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                        this.ctx.stroke();
-                        this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                        this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-                    } else {
-                        if (this.point[i1].type === 2 || this.point[i1].type === 3) { //for centerline
-                            this.ctx.moveTo(this.point[i2].x, this.point[i2].y);
-                            this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
-                            this.ctx.stroke();
-                            this.ctx.lineCap = "butt";
-                        } else if (this.point[i2].type === 2 || this.point[i2].type === 3) {
-                            this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                            this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
-                            this.ctx.stroke();
-                            this.ctx.lineCap = "butt";
-                        }
-                        this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                        this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
-                        this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-                    }
+                }
+                this.ctx.beginPath();
+                if (this[pu].line[i] === 40) {
+                    var r = 0.6;
+                    var x1 = r * this.point[i1].x + (1 - r) * this.point[i3].x;
+                    var y1 = r * this.point[i1].y + (1 - r) * this.point[i3].y;
+                    var x2 = (1 - r) * this.point[i3].x + r * this.point[i2].x;
+                    var y2 = (1 - r) * this.point[i3].y + r * this.point[i2].y;
+                    this.ctx.moveTo(x1, y1);
+                    this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
+                    this.ctx.lineTo(x2, y2);
+                } else if (this[pu].line[i] === 30) {
+                    var r = 0.15 * this.size;
+                    var dx = this.point[i1].x - this.point[i2].x;
+                    var dy = this.point[i1].y - this.point[i2].y;
+                    var d = Math.sqrt(dx ** 2 + dy ** 2);
+                    this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
+                    this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
                     this.ctx.stroke();
+                    this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
+                    this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
                 } else {
-                    this.ctx.beginPath();
+                    if (this.point[i1].type === 2 || this.point[i1].type === 3) { //for centerline
+                        this.ctx.moveTo(this.point[i2].x, this.point[i2].y);
+                        this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
+                        this.ctx.stroke();
+                        this.ctx.lineCap = "butt";
+                    } else if (this.point[i2].type === 2 || this.point[i2].type === 3) {
+                        this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
+                        this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
+                        this.ctx.stroke();
+                        this.ctx.lineCap = "butt";
+                    }
                     this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
 
                     // If neighbor then break the line at midpoint or else directly draw a line between two ends (freeline)
@@ -5402,8 +5397,8 @@ class Puzzle_iso extends Puzzle_truncated_square {
                         this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
                     }
                     this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
-                    this.ctx.stroke();
                 }
+                this.ctx.stroke();
             }
         }
         for (var i in this[pu].lineE) {

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -36,6 +36,7 @@ class Puzzle_truncated_square extends Puzzle {
     }
 
     create_point() {
+        this.corner_table = [];
         var k = 0,
             k0;
         var nx = this.nx0;
@@ -214,7 +215,7 @@ class Puzzle_truncated_square extends Puzzle {
                 }
             }
         }
-        this.point = point;
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {
@@ -238,6 +239,7 @@ class Puzzle_truncated_square extends Puzzle {
         this.make_frameline();
         this.cursol = this.centerlist[0];
         this.cursolS = 4 * (this.nx0) * (this.ny0) + 4 + 4 * (this.nx0);
+
     }
 
     search_center() {
@@ -335,13 +337,24 @@ class Puzzle_truncated_square extends Puzzle {
                 }
                 break;
             case "cage":
-                type = [4];
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
+                }
                 break;
             case "special":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
+                }
+                break;
+            case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
                 }
                 break;
             case "combi":
@@ -835,6 +848,8 @@ class Puzzle_truncated_square extends Puzzle {
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -849,6 +864,7 @@ class Puzzle_truncated_square extends Puzzle {
             this.draw_selection();
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();
@@ -2747,6 +2763,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
     }
 
     create_point() {
+        this.corner_table = [];
         var k = 0,
             k0;
         var nx = this.nx0;
@@ -2953,7 +2970,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                 point[point[i].surround[k]].use = 1;
             }
         }
-        this.point = point;
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {
@@ -3071,6 +3088,13 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                     type = [1];
                 } else {
                     type = [0, 1];
+                }
+                break;
+            case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
                 }
                 break;
             case "combi":
@@ -3194,6 +3218,8 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -3208,6 +3234,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
             this.draw_lattice();
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();
@@ -3396,6 +3423,7 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
     }
 
     create_point() {
+        this.corner_table = [];
         var k = 0,
             k0;
         var nx = this.nx0;
@@ -3669,7 +3697,7 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
                 point[point[i].surround[k]].use = 1;
             }
         }
-        this.point = point;
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {
@@ -3787,6 +3815,13 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
                     type = [1];
                 } else {
                     type = [0, 1];
+                }
+                break;
+            case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
                 }
                 break;
             case "combi":
@@ -3910,6 +3945,8 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -3924,6 +3961,7 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
             this.draw_selection();
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();
@@ -4076,6 +4114,7 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
     }
 
     create_point() {
+        this.corner_table = [];
         var k = 0,
             k0;
         var nx = this.nx0;
@@ -4100,7 +4139,7 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
                 } else {
                     use = 1;
                 }
-                point[k] = new Point(offsetx * this.size, (offsety) * this.size, type, adjacent, surround, use, neighbor, [], 0);
+                point[k] = new Point(offsetx * this.size, (offsety) * this.size, type, adjacent, surround, use, neighbor, [], 1);
                 k++;
                 point[k] = new Point((offsetx + 0.5 + Math.sqrt(3) / 6) * this.size, (offsety) * this.size, type, adjacent, surround, use, neighbor, [], 1);
                 k++;
@@ -4738,6 +4777,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
     }
 
     create_point() {
+        this.corner_table = [];
         var k = 0,
             k0;
         var nx = this.nx0;
@@ -4873,10 +4913,9 @@ class Puzzle_iso extends Puzzle_truncated_square {
                     }
                     k++;
                 }
-
             }
         }
-
+        [point, k] = this.create_corners(point, 0.25, k);
         // 重複判定
         var renumber = new Array(point.length);
         for (var i = 0; i < point.length; i++) {
@@ -4998,7 +5037,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 }
             }
         }
-        this.point = point;
+        this.point = this.point_connect_corners(this.point_fillin_corners(this.fix_points(point)));
     }
 
     reset_frame() {
@@ -5116,6 +5155,13 @@ class Puzzle_iso extends Puzzle_truncated_square {
                     type = [1];
                 } else {
                     type = [0, 1];
+                }
+                break;
+            case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
                 }
                 break;
             case "combi":
@@ -5266,6 +5312,8 @@ class Puzzle_iso extends Puzzle_truncated_square {
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -5280,6 +5328,7 @@ class Puzzle_iso extends Puzzle_truncated_square {
             this.draw_lattice();
             this.draw_selection();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();
@@ -5311,50 +5360,57 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 }
                 var i1 = i.split(",")[0];
                 var i2 = i.split(",")[1];
-                var i3;
-                //search neighbor
-                for (var j = 0; j < 4; j++) {
-                    if (this.point[i2].neighbor.indexOf(this.point[i1].neighbor[j]) != -1) {
-                        i3 = this.point[i1].neighbor[j];
+                if (this.point[i2].adjacent.includes(parseInt(i1))) {
+                    var i3;
+                    //search neighbor
+                    for (var j = 0; j < 4; j++) {
+                        if (this.point[i2].neighbor.indexOf(this.point[i1].neighbor[j]) != -1) {
+                            i3 = this.point[i1].neighbor[j];
+                        }
                     }
-                }
-                this.ctx.beginPath();
-                if (this[pu].line[i] === 40) {
-                    var r = 0.6;
-                    var x1 = r * this.point[i1].x + (1 - r) * this.point[i3].x;
-                    var y1 = r * this.point[i1].y + (1 - r) * this.point[i3].y;
-                    var x2 = (1 - r) * this.point[i3].x + r * this.point[i2].x;
-                    var y2 = (1 - r) * this.point[i3].y + r * this.point[i2].y;
-                    this.ctx.moveTo(x1, y1);
-                    this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
-                    this.ctx.lineTo(x2, y2);
-                } else if (this[pu].line[i] === 30) {
-                    var r = 0.15 * this.size;
-                    var dx = this.point[i1].x - this.point[i2].x;
-                    var dy = this.point[i1].y - this.point[i2].y;
-                    var d = Math.sqrt(dx ** 2 + dy ** 2);
-                    this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
-                    this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
-                    this.ctx.stroke();
-                    this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
-                    this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
-                } else {
-                    if (this.point[i1].type === 2 || this.point[i1].type === 3) { //for centerline
-                        this.ctx.moveTo(this.point[i2].x, this.point[i2].y);
-                        this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
+                    this.ctx.beginPath();
+                    if (this[pu].line[i] === 40) {
+                        var r = 0.6;
+                        var x1 = r * this.point[i1].x + (1 - r) * this.point[i3].x;
+                        var y1 = r * this.point[i1].y + (1 - r) * this.point[i3].y;
+                        var x2 = (1 - r) * this.point[i3].x + r * this.point[i2].x;
+                        var y2 = (1 - r) * this.point[i3].y + r * this.point[i2].y;
+                        this.ctx.moveTo(x1, y1);
+                        this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
+                        this.ctx.lineTo(x2, y2);
+                    } else if (this[pu].line[i] === 30) {
+                        var r = 0.15 * this.size;
+                        var dx = this.point[i1].x - this.point[i2].x;
+                        var dy = this.point[i1].y - this.point[i2].y;
+                        var d = Math.sqrt(dx ** 2 + dy ** 2);
+                        this.ctx.moveTo(this.point[i1].x - r / d * dy, this.point[i1].y + r / d * dx);
+                        this.ctx.lineTo(this.point[i2].x - r / d * dy, this.point[i2].y + r / d * dx);
                         this.ctx.stroke();
-                        this.ctx.lineCap = "butt";
-                    } else if (this.point[i2].type === 2 || this.point[i2].type === 3) {
+                        this.ctx.moveTo(this.point[i1].x + r / d * dy, this.point[i1].y - r / d * dx);
+                        this.ctx.lineTo(this.point[i2].x + r / d * dy, this.point[i2].y - r / d * dx);
+                    } else {
+                        if (this.point[i1].type === 2 || this.point[i1].type === 3) { //for centerline
+                            this.ctx.moveTo(this.point[i2].x, this.point[i2].y);
+                            this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
+                            this.ctx.stroke();
+                            this.ctx.lineCap = "butt";
+                        } else if (this.point[i2].type === 2 || this.point[i2].type === 3) {
+                            this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
+                            this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
+                            this.ctx.stroke();
+                            this.ctx.lineCap = "butt";
+                        }
                         this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                        this.ctx.lineTo((this.point[i1].x + this.point[i2].x) * 0.5, (this.point[i1].y + this.point[i2].y) * 0.5);
-                        this.ctx.stroke();
-                        this.ctx.lineCap = "butt";
+                        this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
+                        this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
                     }
+                    this.ctx.stroke();
+                } else {
+                    this.ctx.beginPath();
                     this.ctx.moveTo(this.point[i1].x, this.point[i1].y);
-                    this.ctx.lineTo(this.point[i3].x, this.point[i3].y);
                     this.ctx.lineTo(this.point[i2].x, this.point[i2].y);
+                    this.ctx.stroke();
                 }
-                this.ctx.stroke();
             }
         }
         for (var i in this[pu].lineE) {
@@ -5960,6 +6016,7 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
     }
 
     create_point() {
+        this.corner_table = [];
         var k = 0,
             k0;
         var nx = this.nx0;
@@ -6250,7 +6307,7 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
                 point[point[i].surround[k]].use = 1;
             }
         }
-        this.point = point;
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {
@@ -6368,6 +6425,13 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
                     type = [1];
                 } else {
                     type = [0, 1];
+                }
+                break;
+            case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
                 }
                 break;
             case "combi":
@@ -6491,6 +6555,8 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -6505,6 +6571,7 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
             this.draw_selection();
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();
@@ -6657,6 +6724,7 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
     }
 
     create_point() {
+        this.corner_table = [];
         var k = 0,
             k0;
         var nx = this.nx0;
@@ -6966,7 +7034,7 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
                 point[i].surround[3] = s0;
             }
         }
-        this.point = point;
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {
@@ -7084,6 +7152,13 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
                     type = [1];
                 } else {
                     type = [0, 1];
+                }
+                break;
+            case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
                 }
                 break;
             case "combi":
@@ -7207,6 +7282,8 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -7221,6 +7298,7 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
             this.draw_selection();
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();
@@ -7386,6 +7464,7 @@ class Puzzle_penrose_P3 extends Puzzle {
     }
 
     create_point() {
+        this.corner_table = [];
         const PI = Math.PI;
         // Express the size of tiling required as a region of the dual graph.
         // The dual graph contains O(ngrids^2) tiles per grid period,
@@ -7669,7 +7748,7 @@ class Puzzle_penrose_P3 extends Puzzle {
             }
         }
 
-        this.point = point;
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
     }
 
     reset_frame() {
@@ -7789,13 +7868,24 @@ class Puzzle_penrose_P3 extends Puzzle {
                 }
                 break;
             case "cage":
-                type = [4];
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
+                }
                 break;
             case "special":
                 if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
+                }
+                break;
+            case "cage":
+                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                    type = [0];
+                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                    type = [6];
                 }
                 break;
             case "combi":
@@ -8055,6 +8145,8 @@ class Puzzle_penrose_P3 extends Puzzle {
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
             this.draw_symbol("pu_a", 2);
+            this.draw_cage("pu_q");
+            this.draw_cage("pu_a");
             this.draw_number("pu_q");
             this.draw_number("pu_a");
             this.draw_cursol();
@@ -8069,6 +8161,7 @@ class Puzzle_penrose_P3 extends Puzzle {
             this.draw_selection();
             this.draw_frameBold();
             this.draw_symbol("pu_q", 2);
+            this.draw_cage("pu_q");
             this.draw_number("pu_q");
             this.draw_cursol();
             this.draw_freecircle();

--- a/docs/js/class_uniform.js
+++ b/docs/js/class_uniform.js
@@ -279,8 +279,10 @@ class Puzzle_truncated_square extends Puzzle {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -295,11 +297,11 @@ class Puzzle_truncated_square extends Puzzle {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [5];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -310,20 +312,20 @@ class Puzzle_truncated_square extends Puzzle {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
@@ -337,28 +339,28 @@ class Puzzle_truncated_square extends Puzzle {
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -2970,7 +2972,7 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                 point[point[i].surround[k]].use = 1;
             }
         }
-        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point, true, true), 0.25, this.fix_points(point, true, true).length + 1)[0]);
     }
 
     reset_frame() {
@@ -3033,8 +3035,10 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -3049,11 +3053,11 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [5];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [6];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -3064,41 +3068,41 @@ class Puzzle_tetrakis_square extends Puzzle_truncated_square {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [3, 4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2, 3];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [3, 4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -3760,8 +3764,10 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -3776,11 +3782,11 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [5];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [6];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -3791,41 +3797,41 @@ class Puzzle_snub_square extends Puzzle_truncated_square {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -4475,8 +4481,10 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -4491,11 +4499,11 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [5];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [6];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -4506,34 +4514,34 @@ class Puzzle_cairo_pentagonal extends Puzzle_truncated_square {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -5100,8 +5108,10 @@ class Puzzle_iso extends Puzzle_truncated_square {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -5116,11 +5126,11 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [5];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [6];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -5131,41 +5141,41 @@ class Puzzle_iso extends Puzzle_truncated_square {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -6370,8 +6380,10 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -6386,11 +6398,11 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [5];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [6];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -6401,41 +6413,41 @@ class Puzzle_rhombitrihexagonal extends Puzzle_truncated_square {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -7034,7 +7046,7 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
                 point[i].surround[3] = s0;
             }
         }
-        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point), 0.25, this.fix_points(point).length + 1)[0]);
+        this.point = this.point_connect_corners(this.create_corners(this.fix_points(point, true, true), 0.25, this.fix_points(point, true, true).length + 1)[0]);
     }
 
     reset_frame() {
@@ -7097,8 +7109,10 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "multicolor":
             case "board":
@@ -7113,11 +7127,11 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [5];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [6];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -7128,41 +7142,41 @@ class Puzzle_deltoidal_trihexagonal extends Puzzle_truncated_square {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":
@@ -7811,8 +7825,10 @@ class Puzzle_penrose_P3 extends Puzzle {
     }
 
     type_set() {
-        var type
-        switch (this.mode[this.mode.qa].edit_mode) {
+        var type;
+        let edit_mode = this.mode[this.mode.qa].edit_mode;
+        let submode = this.mode[this.mode.qa][edit_mode][0];
+        switch (edit_mode) {
             case "surface":
             case "board":
                 type = [0];
@@ -7826,11 +7842,11 @@ class Puzzle_penrose_P3 extends Puzzle {
                 }
                 break;
             case "number":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                if (submode === "2") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "3") {
+                } else if (submode === "3") {
                     type = [4];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "9") {
+                } else if (submode === "9") {
                     type = [5];
                 } else {
                     if (!UserSettings.draw_edges) {
@@ -7841,20 +7857,20 @@ class Puzzle_penrose_P3 extends Puzzle {
                 }
                 break;
             case "line":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "5") {
+                } else if (submode === "5") {
                     type = [0, 2];
                 } else {
                     type = [0];
                 }
                 break;
             case "lineE":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "4") {
+                if (submode === "4") {
                     type = [2];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [0, 1];
                 } else {
                     type = [1];
@@ -7868,28 +7884,28 @@ class Puzzle_penrose_P3 extends Puzzle {
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "special":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "polygon") {
+                if (submode === "polygon") {
                     type = [1];
                 } else {
                     type = [0, 1];
                 }
                 break;
             case "cage":
-                if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "1") {
+                if (submode === "1") {
                     type = [0];
-                } else if (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0] === "2") {
+                } else if (submode === "2") {
                     type = [6];
                 }
                 break;
             case "combi":
-                switch (this.mode[this.mode.qa][this.mode[this.mode.qa].edit_mode][0]) {
+                switch (submode) {
                     case "tents":
                     case "linex":
                     case "yajilin":

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -217,7 +217,7 @@ const penpa_modes = {
         //submodes
         'sub': ['line1', 'line3', 'line5', 'line4',
             'lineE1', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
-            'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number4', 'number2', 'number8',
+            'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number9', 'number4', 'number2', 'number8',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
             'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'

--- a/docs/js/modes.js
+++ b/docs/js/modes.js
@@ -219,7 +219,7 @@ const penpa_modes = {
             'lineE1', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number4', 'number2', 'number8',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -267,13 +267,13 @@ const penpa_modes = {
     },
     'tri': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board', 'move'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line3', 'line5', 'line4',
             'lineE1', 'lineE3', 'lineE4', 'lineE5', 'lineE6',
             'number1', 'number6', 'number5', 'number7', 'number3', 'number4', 'number2', 'number8',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -320,13 +320,13 @@ const penpa_modes = {
     },
     'pyramid': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'wall', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board', 'move'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'wall', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number3', 'number4', 'number2', 'number8',
             'specialthermo', 'specialnobulbthermo', 'specialarrows', 'specialdirection', 'specialsquareframe', 'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -374,13 +374,13 @@ const penpa_modes = {
     },
     'iso': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board', 'move'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'lineE2', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number4', 'number2', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -427,13 +427,13 @@ const penpa_modes = {
     },
     'tetrakis_square': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board', 'move'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number4', 'number2', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -480,13 +480,13 @@ const penpa_modes = {
     },
     'truncated_square': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'number10', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number6', 'number5', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -533,13 +533,13 @@ const penpa_modes = {
     },
     'snub_square': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'number10', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number6', 'number5', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -592,7 +592,7 @@ const penpa_modes = {
             'lineE1', 'number10', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number6', 'number5', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -639,13 +639,13 @@ const penpa_modes = {
     },
     'rhombitrihexagonal': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'number10', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number6', 'number5', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -692,13 +692,13 @@ const penpa_modes = {
     },
     'deltoidal_trihexagonal': {
         //modes
-        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board'],
+        'mode': ['surface', 'multicolor', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'number10', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number6', 'number5', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes
@@ -745,13 +745,13 @@ const penpa_modes = {
     },
     'penrose_P3': {
         //modes
-        'mode': ['surface', 'line', 'lineE', 'number', 'symbol', 'special', 'combi', 'sudoku', 'board', 'move'],
+        'mode': ['surface', 'line', 'lineE', 'number', 'symbol', 'special', 'cage', 'combi', 'sudoku', 'board', 'move'],
         //submodes
         'sub': ['line1', 'line3', 'line4',
             'lineE1', 'lineE3', 'lineE4', 'lineE5',
             'number1', 'number10', 'number6', 'number5', 'number7', 'number4', 'number2', 'number8',
             'specialpolygon',
-            'cage2', 'move1', 'move2', 'move3',
+            'cage1', 'cage2', 'move1', 'move2', 'move3',
             'sudoku1', 'sudoku3'
         ],
         //composite modes

--- a/docs/points.md
+++ b/docs/points.md
@@ -1,0 +1,51 @@
+# Point data
+This document details the format of the different point types.
+### Type 0 - Center/Cell
+Cells that can be shaded, contain numbers, contain shapes, etc. Assuming the cell is `C`
+  Subfield  |      Expected value      
+:----------:|:-------------:|
+`adjacent` |  Cells that are orthogonally connected to the cell `C`
+`adjacent_dia` | Cells that have a vertex in common with `C`, but are not orthogonally adjacent 
+`surround` | Edges that make up the contour of the cell `C`
+`neighbor` | Vertices that are on the contour of the cell `C`
+`edge_to_vertex` | Blank
+
+### Type 1 - Vertex
+Assuming the vertex is `V`
+  Subfield  |      Expected value      
+:----------:|:-------------:|
+`adjacent` |  Opposite endpoints of all edges in `edge_to_vertex`
+`adjacent_dia` | Vertices that are part of the contour of the cells around `V`, but are not connected by an edge to `V`
+`surround` | Cells for which `V` is one of their vertices
+`neighbor` | Blank
+`edge_to_vertex` | Edges that are incident to `V`
+
+### Type 2 - Edge
+`type2` may be used for orientation. Assuming the edge is `E`
+  Subfield  |      Expected value      
+:----------:|:-------------:|
+`adjacent` |  Edges that are parallel (or almost) which share a cell with `E`. These are used to draw walls. Usually of the same `type2` as `E` 
+`adjacent_dia` | Blank
+`surround` | Blank
+`neighbor` | Cells for which `E` is one of their edges
+`edge_to_vertex` | The vertices at both ends of `E`
+
+### Type 3 - Corner
+These are used for corner numbers and cage. These should usually be defined as a linear combination of a cell and a vertex. Assuming `C` is the corner
+  Subfield  |      Expected value      
+:----------:|:-------------:|
+`adjacent` |  Corners that are either in a different cell than `C` but are neighbor to the same vertex, or corners that are in the same cell as `C`, and are neighbor to a vertex that is adjacent of the vertex of `C`
+`adjacent_dia` | Blank
+`surround` | Cell that contains `C`
+`neighbor` | Vertex of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`edge_to_vertex` | Blank
+
+### Type 4 - Compass
+These are used for compass clues, principally. These should usually be defined as a linear combination of a cell and an edge. Assuming `C` is the compass location
+  Subfield  |      Expected value      
+:----------:|:-------------:|
+`adjacent` |  Blank
+`adjacent_dia` | Blank
+`surround` | Cell that contains `C`
+`neighbor` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`edge_to_vertex` | Blank

--- a/docs/points.md
+++ b/docs/points.md
@@ -1,27 +1,27 @@
 # Point data
-This document details the format of the different point types. Points are integer where the unit digit is the type of the point. For maximal compability, the following fields must be filled with their respective expected values.
-### Type XX0 - Center/Cell
+This document details the format of the different point types.
+### Type 0 - Center/Cell
 Cells that can be shaded, contain numbers, contain shapes, etc. Assuming the cell is `C`
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Cells that are orthogonally connected to the cell `C`
 `adjacent_dia` | Cells that have a vertex in common with `C`, but are not orthogonally adjacent 
-`surround` | Vertices that are on the contour of the cell `C`
-`neighbor` | Edges that make up the contour of the cell `C`
+`surround` | Edges that make up the contour of the cell `C`
+`neighbor` | Vertices that are on the contour of the cell `C`
 `edge_to_vertex` | Blank
 
-### Type XX1 - Vertex
+### Type 1 - Vertex
 Assuming the vertex is `V`
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Opposite endpoints of all edges in `edge_to_vertex`
 `adjacent_dia` | Vertices that are part of the contour of the cells around `V`, but are not connected by an edge to `V`
-`surround` | Blank
-`neighbor` | Cells for which `V` is one of their vertices
+`surround` | Cells for which `V` is one of their vertices
+`neighbor` | Blank
 `edge_to_vertex` | Edges that are incident to `V`
 
-### Type XX2 - Edge
-`type2` may be used for orientation. Future update will collapse all edge points to the same type. Assuming the edge is `E`
+### Type 2 - Edge
+`type2` may be used for orientation. Assuming the edge is `E`
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Edges that are parallel (or almost) which share a cell with `E`. These are used to draw walls. Usually of the same `type2` as `E` 
@@ -30,24 +30,37 @@ Assuming the vertex is `V`
 `neighbor` | Cells for which `E` is one of their edges
 `edge_to_vertex` | The vertices at both ends of `E`
 
-### Type XX3 - Corner
+### Type 3 - Corner
 These are used for corner numbers and cage. These should usually be defined as a linear combination of a cell and a vertex. Assuming `C` is the corner
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Corners that are either in a different cell than `C` but are neighbor to the same vertex, or corners that are in the same cell as `C`, and are neighbor to a vertex that is adjacent of the vertex of `C`
 `adjacent_dia` | Blank
-`surround` | Vertex of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
-`neighbor` | Cell that contains `C`
+`surround` | Cell that contains `C`
+`neighbor` | Vertex of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
 `edge_to_vertex` | Blank
 
-### Type XX4 - Compass
+### Type 4 - Compass
 These are used for compass clues, principally. These should usually be defined as a linear combination of a cell and an edge. Assuming `C` is the compass location
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Blank
 `adjacent_dia` | Blank
-`surround` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
-`neighbor` | Cell that contains `C`
+`surround` | Cell that contains `C`
+`neighbor` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
 `edge_to_vertex` | Blank
 
-A built-in function `get_grouped_types` returns an array of array that returns `[center, vertex, edge, corner, compass]` in that order if the `types` attribute of puzzle has been filled in with all possible types. 
+## Helper functions
+### `get_grouped_types()`
+Returns an array of array that returns `[center, vertex, edge, corner, compass]` in that order if the `types` attribute of puzzle has been filled in with all possible types.
+
+### `fix_points(point)`
+Build some associations given the following are defined within `point`:
+- Vertices and edges' coordinates.
+- Cells' `surround` 
+- Cells' `neighbor` (there can be incorrect edges, as long as all correct ones are present)
+
+The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes.
+
+### `point_connect_corners()`
+Fill in the `adjacent` field of corners. `corner_table`, edges' `edge_to_vertex` and edges' `neighbor` must be filled beforehand,

--- a/docs/points.md
+++ b/docs/points.md
@@ -1,26 +1,26 @@
 # Point data
-This document details the format of the different point types.
-### Type 0 - Center/Cell
+This document details the format of the different point types. Points are integer where the unit digit is the type of the point. For maximal compability, the following fields must be filled with their respective expected values.
+### Type XX0 - Center/Cell
 Cells that can be shaded, contain numbers, contain shapes, etc. Assuming the cell is `C`
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Cells that are orthogonally connected to the cell `C`
 `adjacent_dia` | Cells that have a vertex in common with `C`, but are not orthogonally adjacent 
-`surround` | Edges that make up the contour of the cell `C`
-`neighbor` | Vertices that are on the contour of the cell `C`
+`surround` | Vertices that are on the contour of the cell `C`
+`neighbor` | Edges that make up the contour of the cell `C`
 `edge_to_vertex` | Blank
 
-### Type 1 - Vertex
+### Type XX1 - Vertex
 Assuming the vertex is `V`
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Opposite endpoints of all edges in `edge_to_vertex`
 `adjacent_dia` | Vertices that are part of the contour of the cells around `V`, but are not connected by an edge to `V`
-`surround` | Cells for which `V` is one of their vertices
-`neighbor` | Blank
+`surround` | Blank
+`neighbor` | Cells for which `V` is one of their vertices
 `edge_to_vertex` | Edges that are incident to `V`
 
-### Type 2 - Edge
+### Type XX2 - Edge
 `type2` may be used for orientation. Assuming the edge is `E`
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -30,24 +30,24 @@ Assuming the vertex is `V`
 `neighbor` | Cells for which `E` is one of their edges
 `edge_to_vertex` | The vertices at both ends of `E`
 
-### Type 3 - Corner
+### Type XX3 - Corner
 These are used for corner numbers and cage. These should usually be defined as a linear combination of a cell and a vertex. Assuming `C` is the corner
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Corners that are either in a different cell than `C` but are neighbor to the same vertex, or corners that are in the same cell as `C`, and are neighbor to a vertex that is adjacent of the vertex of `C`
 `adjacent_dia` | Blank
-`surround` | Cell that contains `C`
-`neighbor` | Vertex of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`surround` | Vertex of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`neighbor` | Cell that contains `C`
 `edge_to_vertex` | Blank
 
-### Type 4 - Compass
+### Type XX4 - Compass
 These are used for compass clues, principally. These should usually be defined as a linear combination of a cell and an edge. Assuming `C` is the compass location
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Blank
 `adjacent_dia` | Blank
-`surround` | Cell that contains `C`
-`neighbor` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`surround` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`neighbor` | Cell that contains `C`
 `edge_to_vertex` | Blank
 
 ## Helper functions
@@ -63,4 +63,4 @@ Build some associations given the following are defined within `point`:
 The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes.
 
 ### `point_connect_corners()`
-Fill in the `adjacent` field of corners. `corner_table`, edges' `edge_to_vertex` and edges' `neighbor` must be filled beforehand,
+Fill in the `adjacent` field of corners. `corner_table`, edges' `edge_to_vertex` and edges' `neighbor` must be filled beforehand.

--- a/docs/points.md
+++ b/docs/points.md
@@ -1,16 +1,16 @@
 # Point data
-This document details the format of the different point types.
-### Type 0 - Center/Cell
+This document details the format of the different point types. Points are integer where the unit digit is the type of the point. For maximal compability, the following fields must be filled with their respective expected values.
+### Type XX0 - Center/Cell
 Cells that can be shaded, contain numbers, contain shapes, etc. Assuming the cell is `C`
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Cells that are orthogonally connected to the cell `C`
 `adjacent_dia` | Cells that have a vertex in common with `C`, but are not orthogonally adjacent 
-`surround` | Edges that make up the contour of the cell `C`
-`neighbor` | Vertices that are on the contour of the cell `C`
+`surround` | Vertices that are on the contour of the cell `C`
+`neighbor` | Edges that make up the contour of the cell `C`
 `edge_to_vertex` | Blank
 
-### Type 1 - Vertex
+### Type XX1 - Vertex
 Assuming the vertex is `V`
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -20,7 +20,7 @@ Assuming the vertex is `V`
 `neighbor` | Cells for which `V` is one of their vertices
 `edge_to_vertex` | Edges that are incident to `V`
 
-### Type 2 - Edge
+### Type XX2 - Edge
 `type2` may be used for orientation. Future update will collapse all edge points to the same type. Assuming the edge is `E`
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -30,7 +30,7 @@ Assuming the vertex is `V`
 `neighbor` | Cells for which `E` is one of their edges
 `edge_to_vertex` | The vertices at both ends of `E`
 
-### Type 3 - Corner
+### Type XX3 - Corner
 These are used for corner numbers and cage. These should usually be defined as a linear combination of a cell and a vertex. Assuming `C` is the corner
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -40,7 +40,7 @@ These are used for corner numbers and cage. These should usually be defined as a
 `neighbor` | Cell that contains `C`
 `edge_to_vertex` | Blank
 
-### Type 4 - Compass
+### Type XX4 - Compass
 These are used for compass clues, principally. These should usually be defined as a linear combination of a cell and an edge. Assuming `C` is the compass location
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -49,3 +49,5 @@ These are used for compass clues, principally. These should usually be defined a
 `surround` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
 `neighbor` | Cell that contains `C`
 `edge_to_vertex` | Blank
+
+A built-in function `get_grouped_types` returns an array of array that returns `[center, vertex, edge, corner, compass]` in that order if the `types` attribute of puzzle has been filled in with all possible types. 

--- a/docs/points.md
+++ b/docs/points.md
@@ -20,8 +20,8 @@ Assuming the vertex is `V`
 `neighbor` | Blank
 `edge_to_vertex` | Edges that are incident to `V`
 
-### Type 2 - Edge
-`type2` may be used for orientation. Assuming the edge is `E`
+### Type 2* - Edge
+`type2` may be used for orientation. Future update will collapse all edge points to the same type. Assuming the edge is `E`
   Subfield  |      Expected value      
 :----------:|:-------------:|
 `adjacent` |  Edges that are parallel (or almost) which share a cell with `E`. These are used to draw walls. Usually of the same `type2` as `E` 
@@ -49,3 +49,5 @@ These are used for compass clues, principally. These should usually be defined a
 `surround` | Cell that contains `C`
 `neighbor` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
 `edge_to_vertex` | Blank
+
+Corners and Compass can be something else than 3 and 4 for now, but they need to be consistent.

--- a/docs/points.md
+++ b/docs/points.md
@@ -54,13 +54,15 @@ These are used for compass clues, principally. These should usually be defined a
 
 ## Helper functions
 
-### `fix_points(point)`
+### `fix_points(point, fix_adjacent, off_centered)`
 Build some associations given the following are defined within `point`:
 - Vertices and edges' coordinates.
 - Cells' `surround` 
 - Cells' `neighbor` (there can be incorrect edges, as long as all correct ones are present). Returns the updated point array.
 
-The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes. Returns the updated point array.
+The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes. Returns the updated point array. `fix_adjacent` defaults to being true, but
+can be set to false if the cells' adjacent are already filled. `off_centered` defaults to false, but can be
+set to true if the edges' "centers" are not in the middle of the edge.
 
 ### `point_connect_corners(point)`
 Fill in the `adjacent` field of corners. `corner_table`, edges' `edge_to_vertex` and edges' `neighbor` must be filled beforehand. Returns the updated point array.

--- a/docs/points.md
+++ b/docs/points.md
@@ -1,6 +1,8 @@
 # Point data
-This document details the format of the different point types. Points are integer where the unit digit is the type of the point. For maximal compability, the following fields must be filled with their respective expected values.
-### Type XX0 - Center/Cell
+This document details the format of the different point type groups. Two points of the same groups can have different types. Points are integer where the unit digit is the type of the point. For maximal compability, the following fields must be filled with their respective expected values. Puzzles have an attribute called `types`, which must be filled as `[[Cells], [Vertices], [Edges], [Corners], [Compass]]` in that exact order, where `[Cells]`, for instance, is the array containing all the types of the cell group. By default, it is set to `[[0], [1], [2, 3, 4], [6], [5]]` as this is the pattern most currently implemented grid use. 
+
+Points must be defined in the `create_points` function. This is where any helpers must be called, as well as defining the specific `types` for the grid.  
+### Center/Cell
 Cells that can be shaded, contain numbers, contain shapes, etc. Assuming the cell is `C`
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -10,7 +12,7 @@ Cells that can be shaded, contain numbers, contain shapes, etc. Assuming the cel
 `neighbor` | Edges that make up the contour of the cell `C`
 `edge_to_vertex` | Blank
 
-### Type XX1 - Vertex
+### Vertex
 Assuming the vertex is `V`
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -20,7 +22,7 @@ Assuming the vertex is `V`
 `neighbor` | Cells for which `V` is one of their vertices
 `edge_to_vertex` | Edges that are incident to `V`
 
-### Type XX2 - Edge
+### Edge
 `type2` may be used for orientation. Assuming the edge is `E`
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -30,7 +32,7 @@ Assuming the vertex is `V`
 `neighbor` | Cells for which `E` is one of their edges
 `edge_to_vertex` | The vertices at both ends of `E`
 
-### Type XX3 - Corner
+### Corner
 These are used for corner numbers and cage. These should usually be defined as a linear combination of a cell and a vertex. Assuming `C` is the corner
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -40,7 +42,7 @@ These are used for corner numbers and cage. These should usually be defined as a
 `neighbor` | Cell that contains `C`
 `edge_to_vertex` | Blank
 
-### Type XX4 - Compass
+### Compass
 These are used for compass clues, principally. These should usually be defined as a linear combination of a cell and an edge. Assuming `C` is the compass location
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -51,16 +53,20 @@ These are used for compass clues, principally. These should usually be defined a
 `edge_to_vertex` | Blank
 
 ## Helper functions
-### `get_grouped_types()`
-Returns an array of array that returns `[center, vertex, edge, corner, compass]` in that order if the `types` attribute of puzzle has been filled in with all possible types.
 
 ### `fix_points(point)`
 Build some associations given the following are defined within `point`:
 - Vertices and edges' coordinates.
 - Cells' `surround` 
-- Cells' `neighbor` (there can be incorrect edges, as long as all correct ones are present)
+- Cells' `neighbor` (there can be incorrect edges, as long as all correct ones are present). Returns the updated point array.
 
-The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes.
+The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes. Returns the updated point array.
 
-### `point_connect_corners()`
-Fill in the `adjacent` field of corners. `corner_table`, edges' `edge_to_vertex` and edges' `neighbor` must be filled beforehand.
+### `point_connect_corners(point)`
+Fill in the `adjacent` field of corners. `corner_table`, edges' `edge_to_vertex` and edges' `neighbor` must be filled beforehand. Returns the updated point array.
+
+### `point_fillin_corners(point)`
+Fill in the `neighbor` and `surround` field of corners. Cells' `surround` must be filled beforehand. Returns the updated point array.
+
+### `create_corners(point, radius, k)`
+Create corners with each of the cells, defined as a linear combination of the cells and their vertices (`radius` x coordinates of the cell + (1 - `radius`) x coordinates of the vertices). `k` is the current max point id. Returns `[point, k]`, where `k` is the new max `id` and `point` is the point array, with the added corners.

--- a/docs/points.md
+++ b/docs/points.md
@@ -54,15 +54,13 @@ These are used for compass clues, principally. These should usually be defined a
 
 ## Helper functions
 
-### `fix_points(point, fix_adjacent, off_centered)`
+### `fix_points(point)`
 Build some associations given the following are defined within `point`:
 - Vertices and edges' coordinates.
 - Cells' `surround` 
-- Cells' `neighbor` (there can be incorrect edges, as long as all correct ones are present). Returns the updated point array.
+- Cells' `neighbor` (there can be incorrect edges, as long as all correct ones are present). 
 
-The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes. Returns the updated point array. `fix_adjacent` defaults to being true, but
-can be set to false if the cells' adjacent are already filled. `off_centered` defaults to false, but can be
-set to true if the edges' "centers" are not in the middle of the edge.
+The function will not build cells' `adjacent_dia`, vertices' `adjacent_dia`, edges' `adjacent` and all compass and corner attributes. Returns the updated point array.
 
 ### `point_connect_corners(point)`
 Fill in the `adjacent` field of corners. `corner_table`, edges' `edge_to_vertex` and edges' `neighbor` must be filled beforehand. Returns the updated point array.

--- a/docs/points.md
+++ b/docs/points.md
@@ -16,11 +16,11 @@ Assuming the vertex is `V`
 :----------:|:-------------:|
 `adjacent` |  Opposite endpoints of all edges in `edge_to_vertex`
 `adjacent_dia` | Vertices that are part of the contour of the cells around `V`, but are not connected by an edge to `V`
-`surround` | Cells for which `V` is one of their vertices
-`neighbor` | Blank
+`surround` | Blank
+`neighbor` | Cells for which `V` is one of their vertices
 `edge_to_vertex` | Edges that are incident to `V`
 
-### Type 2* - Edge
+### Type 2 - Edge
 `type2` may be used for orientation. Future update will collapse all edge points to the same type. Assuming the edge is `E`
   Subfield  |      Expected value      
 :----------:|:-------------:|
@@ -36,8 +36,8 @@ These are used for corner numbers and cage. These should usually be defined as a
 :----------:|:-------------:|
 `adjacent` |  Corners that are either in a different cell than `C` but are neighbor to the same vertex, or corners that are in the same cell as `C`, and are neighbor to a vertex that is adjacent of the vertex of `C`
 `adjacent_dia` | Blank
-`surround` | Cell that contains `C`
-`neighbor` | Vertex of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`surround` | Vertex of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`neighbor` | Cell that contains `C`
 `edge_to_vertex` | Blank
 
 ### Type 4 - Compass
@@ -46,8 +46,6 @@ These are used for compass clues, principally. These should usually be defined a
 :----------:|:-------------:|
 `adjacent` |  Blank
 `adjacent_dia` | Blank
-`surround` | Cell that contains `C`
-`neighbor` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`surround` | Edge of the cell that contains `C` closest to `C` (if pushed outwards, this would be where `C` ends up)
+`neighbor` | Cell that contains `C`
 `edge_to_vertex` | Blank
-
-Corners and Compass can be something else than 3 and 4 for now, but they need to be consistent.


### PR DESCRIPTION
This PR totally revamps how cages are drawn, to be grid agnostic. Every grid type now uses the same `draw_cage` function, defined in `class_p.js`

The `mouse_cage` has been totally redone, to work as the following:
When clicking on a cage, it will attempt to restyle it. If restyling is impossible, it will delete it.

Several new helper functions to "fix" the point data have been added, making the point data of all but cairo pentagonal grids to be consistent. 

Puzzles have now two new fields: `types` and `corner_table`, which are used for uniformity and speedup.

Finally, a document detailing how points should be defined have been created.

*cairo pentagonal is not included, re-implementing cairo pentagonal might be required