### PR TITLE
Excessively long link warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## History
+
+* to-release...
+    * Add warning on very long links that may require load via UI
 * 2026/06/02 ver 3.2.4
     * Cage mode in all grid types except cairo pentagonal
     * Bug fixes and code improvement

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -8,7 +8,7 @@
 * Help icon made by <a href="https://www.flaticon.com/authors/roundicons" title="Roundicons">Roundicons</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a>
 * Thanks to <a href="https://github.com/william42"> William42 </a> for SVG Screenshot code.
 * Thanks to <a href="https://github.com/nmay231"> nmay231 </a> for contributions to puzz.link parser in Penpa+.
-* Thanks to <a href="https://thegriddle.net"> davmillar </a> for contributions to redesign the GUI, language support and refactoring the code.
+* Thanks to <a href="https://thegriddle.net"> David "Taco Dave" Millar </a> for contributions to redesign the GUI, language support and refactoring the code.
 * Thanks to <a href="https://github.com/kieranclancy"> Kieran Clancy </a> for contributions to smart checking in Penpa+.
 * Thanks to <a href="https://github.com/BenceJoful"> BenceJoful </a> for contributions to hexgrid and replay improvements in Penpa+.
 * Thanks to <a href="https://github.com/marknn3"> Mark Langezaal </a> for contributions to improve Penpa+.

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,6 +123,7 @@
             "./js/class_uniform.js",
             "./js/class_panel.js",
             "./js/style.js",
+            "./js/io.js",
             "./js/general.js",
             "./js/customcolor.js",
             "./js/translate.js"
@@ -1190,7 +1191,9 @@
             <input type="checkbox" name="save_undo" id="save_undo"><br/>
             <label class="label_nb" for="auto_shorten_chk" id="auto_shorten_chk_lb">Automatically Shorten with
                 TinyURL</label>
-            <input type="checkbox" name="auto_shorten_chk" id="auto_shorten_chk"/>
+            <input type="checkbox" name="auto_shorten_chk" id="auto_shorten_chk"/><br/>
+            <label class="label_nb" for="warn_long_links_chk" id="warn_long_links_chk_lb">Warn on Very Long Links</label>
+            <input type="checkbox" name="warn_long_links_chk" id="warn_long_links_chk" checked />
         </div>
         <div class="nb_button">
             <input type="button" id="address_edit" value="Editing URL"/>
@@ -1754,6 +1757,17 @@
                         <select id="shorten_links_dropdown">
                             <option value="1" class="lb_generic_on">ON</option>
                             <option value="0" selected class="lb_generic_off">OFF</option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label id="lb_settings_warn_long_links">Warn on Very Long Links:</label>
+                    </td>
+                    <td>
+                        <select id="warn_long_links_dropdown">
+                            <option value="1" selected class="lb_generic_on">ON</option>
+                            <option value="0" class="lb_generic_off">OFF</option>
                         </select>
                     </td>
                 </tr>

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -1914,55 +1914,53 @@ function export_sudoku() {
 
 async function import_url(urlstring) {
     urlstring = urlstring || document.getElementById("urlstring").value;
-    if (urlstring !== "") {
-        if (urlstring.indexOf("/penpa-edit/") !== -1 || urlstring.match(/m=(?:edit|solve)/gi)) {
 
-            let param = urlstring.split('&');
-            let paramArray = [];
+    if (urlstring === "") {
+        return;
+    }
 
-            // Decompose address into elements
-            for (var i = 0; i < param.length; i++) {
-                let paramItem = param[i].split('=');
-                paramArray[paramItem[0]] = paramItem[1];
-            }
+    if (urlstring.indexOf("/penpa-edit/") !== -1 || urlstring.match(/m=(?:edit|solve)/gi)) {
+        let param = urlstring.split('&');
+        let paramArray = [];
 
-            const hash = PenpaProgress.getHash(paramArray.p);
-
-            // Decrypt puzzle data
-            let local_data = await PenpaProgress.tryLoad(hash);
-
-            if (local_data && local_data.includes('&p=')) {
-                // This is to account for old links and new links together
-                var url;
-                if (local_data.includes("#")) {
-                    url = local_data.split('#')[1];
-                } else {
-                    url = local_data.split('?')[1];
-                }
-                load(url, type = 'localstorage', origurl = paramArray.p);
-            } else {
-                if (urlstring.includes("#")) {
-                    urlstring = urlstring.split("/penpa-edit/#")[1];
-                } else {
-                    urlstring = urlstring.split("/penpa-edit/?")[1];
-                }
-                load(urlstring, 'local');
-            }
-
-            document.getElementById("modal-load").style.display = 'none';
-            if (UserSettings.tab_settings > 0) {
-                selectBox.setValue(UserSettings.tab_settings);
-            }
-        } else if (urlstring.match(/\/puzz.link\/p\?|pzprxs\.vercel\.app\/p\?|\/pzv\.jp\/p(\.html)?\?/)) {
-            decode_puzzlink(urlstring);
-            document.getElementById("modal-load").style.display = 'none';
-        } else {
-            Swal.fire({
-                html: PenpaText.get('invalid_url'),
-                icon: 'error',
-                confirmButtonText: PenpaText.get('close'),
-            });
+        // Decompose address into elements
+        for (var i = 0; i < param.length; i++) {
+            let paramItem = param[i].split('=');
+            paramArray[paramItem[0]] = paramItem[1];
         }
+
+        const hash = PenpaProgress.getHash(paramArray.p);
+
+        // Decrypt puzzle data
+        let local_data = await PenpaProgress.tryLoad(hash);
+
+        if (local_data && local_data.includes('&p=')) {
+            // This is to account for old links and new links together
+            load(
+                PenpaIO.getPuzzleDataFromUrl(local_data),
+                'localstorage',
+                paramArray.p
+            );
+        } else {
+            load(
+                PenpaIO.getPuzzleDataFromUrl(urlstring),
+                'local'
+            );
+        }
+
+        document.getElementById("modal-load").style.display = 'none';
+        if (UserSettings.tab_settings > 0) {
+            selectBox.setValue(UserSettings.tab_settings);
+        }
+    } else if (urlstring.match(/\/puzz.link\/p\?|pzprxs\.vercel\.app\/p\?|\/pzv\.jp\/p(\.html)?\?/)) {
+        decode_puzzlink(urlstring);
+        document.getElementById("modal-load").style.display = 'none';
+    } else {
+        Swal.fire({
+            html: PenpaText.get('invalid_url'),
+            icon: 'error',
+            confirmButtonText: PenpaText.get('close'),
+        });
     }
 }
 

--- a/docs/js/general.js
+++ b/docs/js/general.js
@@ -1615,6 +1615,18 @@ async function request_shortlink(url) {
 
 async function update_textarea(text) {
     let newText = text;
+
+    if (
+        newText.length > PenpaIO.MAX_URI_LENGTH &&
+        UserSettings.warn_long_links
+    ) {
+        Swal.fire({
+            html: PenpaText.get('long_link_warning'),
+            icon: 'info',
+            confirmButtonText: PenpaText.get('close'),
+        });
+    }
+
     if (UserSettings.shorten_links) {
         let shortened = await request_shortlink(newText);
         if (shortened && pu.isReplay) {

--- a/docs/js/io.js
+++ b/docs/js/io.js
@@ -1,0 +1,27 @@
+class IO {
+    /**
+     * Estimated "URI too long" limit to use when checking for a URI's length after generating an
+     * export link.
+     */
+    MAX_URI_LENGTH = 8000;
+
+    /**
+     * Attempts to get the puzzle data from the URL passed in.
+     *
+     * @param {string} loadUrl URL to attempt to parse for puzzle data.
+     */
+    getPuzzleDataFromUrl = function (loadUrl) {
+        const urlAsUrl = new URL(loadUrl);
+        let puzzleData;
+
+        if (loadUrl.includes("#")) {
+            puzzleData = urlAsUrl.hash.split("#")[1];
+        } else {
+            puzzleData = urlAsUrl.search.split("?")[1];
+        }
+
+        return puzzleData;
+    };
+};
+
+const PenpaIO = new IO();

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2282,6 +2282,14 @@ onload = function() {
         UserSettings.shorten_links = this.checked;
     }
 
+    // Warn on long links setting
+    document.getElementById("warn_long_links_dropdown").onchange = function() {
+        UserSettings.warn_long_links = String(this.value) === "1";
+    }
+    document.getElementById("warn_long_links_chk").onchange = function() {
+        UserSettings.warn_long_links = this.checked;
+    }
+
     // Timer pause and unpause
     document.getElementById("sw_pause").addEventListener("click", pauseTimer);
     document.getElementById("sw_start").addEventListener("click", startTimer);

--- a/docs/js/settings.js
+++ b/docs/js/settings.js
@@ -22,6 +22,25 @@ function deleteCookie(name) {
     setCookie(name, '', -1);
 }
 
+/**
+ * Helper that attempts to parse the value as a boolean flag (true/false) to make the settings
+ * code more concise.
+ *
+ * @param {any} value
+ */
+function parseBooleanish(value) {
+    if (!value) { return false; }
+
+    if (typeof value === 'string') {
+        if (value === "true" || value === "1") { return true; }
+        if (value === "false" || value === "0" || value == "") { return false; }
+    } else if (typeof value === "number") {
+        return value > 0;
+    }
+
+    return Boolean(value);
+}
+
 const UserSettings = {
     // Cookie Expiry Constant
     _expDate: 2147483647,
@@ -417,6 +436,24 @@ const UserSettings = {
         return this._shorten_links;
     },
 
+    /** @private Stored value for warn_long_links setting. */
+    _warn_long_links: true,
+    /**
+     * When enabled, warn the user that the generated link may be too long and cause "URI too long"
+     * error when attempting to visit as normal. Infrequent/new Penpa users may not know that this
+     * issue can happen and requires working around via the "Load" button.
+     *
+     * @param {boolean} newValue New value to set.
+     */
+    set warn_long_links(newValue) {
+        this._warn_long_links = parseBooleanish(newValue);
+        document.getElementById("warn_long_links_dropdown").value = this._warn_long_links ? 1 : 0;
+        document.getElementById("warn_long_links_chk").checked = this._warn_long_links ? 'checked' : null;
+    },
+    get warn_long_links() {
+        return this._warn_long_links;
+    },
+
     _panel_shown: false,
     set panel_shown(newValue) {
         if (newValue === undefined) { newValue = false; }
@@ -453,7 +490,7 @@ const UserSettings = {
     get quick_panel_button() {
         return this._quick_panel_btn;
     },
-    
+
     _resize_whitespace: false,
     set resize_whitespace(newValue) {
         const button = document.getElementById("resize_whitespace_button");
@@ -483,18 +520,19 @@ const UserSettings = {
         'starbattle_dots',
         'sudoku_centre_size',
         'sudoku_normal_size',
-        'timerbar_status'
+        'timerbar_status',
+        'warn_long_links'
     ],
     gridtype_size: [
         'gridtype',
         'displaysize'
     ],
 
-    clearSettings: function() {
-        this.can_save.forEach(function(setting) {
+    clearSettings: function () {
+        this.can_save.forEach(function (setting) {
             deleteCookie(setting);
         });
-        this.gridtype_size.forEach(function(setting) {
+        this.gridtype_size.forEach(function (setting) {
             deleteCookie(setting);
         });
         deleteCookie('tab_settings');
@@ -541,8 +579,11 @@ const UserSettings = {
 
             this._settingsLoaded = true;
         } else {
-            this.gridtype_size.forEach(function(setting) {
-                UserSettings[setting] = getCookie(setting);
+            this.gridtype_size.forEach(function (setting) {
+                let cookieValue = getCookie(setting);
+                if (cookieValue !== null) {
+                    UserSettings[setting] = cookieValue;
+                }
             });
         }
     }

--- a/docs/js/settings.js
+++ b/docs/js/settings.js
@@ -147,7 +147,7 @@ const UserSettings = {
     // Check conflicts on pencil marks
     _check_pencil_marks: false,
     set check_pencil_marks(newValue) {
-        this._check_pencil_marks = newValue === "1" || newValue === "true" || newValue === true;
+        this._check_pencil_marks = parseBooleanish(newValue);
         document.getElementById("check_pencil_marks_opt").value = this._check_pencil_marks ? "1" : "0";
         if (window.pu)
             pu.redraw();
@@ -213,7 +213,7 @@ const UserSettings = {
 
     _outline_text: false,
     set outline_text(newValue) {
-        this._outline_text = newValue === "1" || newValue === "true" || newValue === true;
+        this._outline_text = parseBooleanish(newValue);
         document.getElementById("outline_text_opt").value = this._outline_text ? "1" : "0";
         if (window.pu)
             pu.redraw();
@@ -249,7 +249,7 @@ const UserSettings = {
     // Setting to ignore all
     _ignore_line_style: false,
     set ignore_line_style(newValue) {
-        this._ignore_line_style = newValue === "1" || newValue === "true" || newValue === true;
+        this._ignore_line_style = parseBooleanish(newValue);
         document.getElementById("ignore_line_style_opt").value = this._ignore_line_style ? "1" : "0";
         this.attemptSave();
     },
@@ -422,14 +422,9 @@ const UserSettings = {
 
     _shorten_links: false,
     set shorten_links(newValue) {
-        if (newValue === undefined) { newValue = false; }
-        // [ZW] Not sure how this is happening but a value of "false" can get stored in
-        // the settings which is interpreted as true
-        if (newValue === "false") { newValue = false; }
-        this._shorten_links = newValue;
-
-        document.getElementById("shorten_links_dropdown").value = newValue ? 1 : 0;
-        document.getElementById("auto_shorten_chk").checked = newValue ? 'checked' : null;
+        const parsedValue = parseBooleanish(newValue);
+        document.getElementById("shorten_links_dropdown").value = this._shorten_links ? 1 : 0;
+        document.getElementById("auto_shorten_chk").checked = this._shorten_links ? 'checked' : null;
         this.attemptSave();
     },
     get shorten_links() {
@@ -544,24 +539,24 @@ const UserSettings = {
     _settingsLoaded: false,
 
     // Handle saving settings if needed
-    attemptSave: function() {
+    attemptSave: function () {
         if (!this._settingsLoaded) {
             return;
         }
 
-        this.can_save.forEach(function(setting) {
+        this.can_save.forEach(function (setting) {
             setCookie(setting, UserSettings[setting], this._expDate);
         });
-        this.gridtype_size.forEach(function(setting) {
+        this.gridtype_size.forEach(function (setting) {
             setCookie(setting, UserSettings[setting], this._expDate);
         });
         setCookie("tab_settings", JSON.stringify(getValues('mode_choices')), this._expDate);
         // setCookie("different_solution_tab", document.getElementById("multitab_settings_opt").value, this._expDate);
     },
 
-    loadFromCookies: function(load = "others") {
+    loadFromCookies: function (load = "others") {
         if (load === "others") {
-            this.can_save.forEach(function(setting) {
+            this.can_save.forEach(function (setting) {
                 let cookieQuery = getCookie(setting);
                 if (cookieQuery !== null) {
                     UserSettings[setting] = cookieQuery;

--- a/docs/js/translate.js
+++ b/docs/js/translate.js
@@ -472,6 +472,11 @@ function trans() {
             EN: "Automatically Shorten with TinyURL",
             ZH: "自动使用TinyURL缩短链接"
         },
+        "warn_long_links_chk_lb": {
+            EN: 'Warn on Very Long Links',
+            JP: '非常に長いリンクについて警告してください',
+            ZH: '警告：关于非常长的链接'
+        },
         "filename_lb": {JP: "ファイル名：", EN: "File name:", ZH: "文件名："},
         "extend_lb": {JP: "拡張出力", EN: "Extended Output", ZH: "输出扩展"},
         "save3texttitle": {
@@ -643,6 +648,7 @@ const PenpaText = {
         'lb_settings_surface_second_orange',
         'lb_settings_surface_second_purple',
         'lb_settings_surface_second_brown',
+        'lb_settings_warn_long_links',
         'lb_settings_tools',
         'lb_settings_custom_colors',
         'lb_settings_floating_panel',
@@ -831,6 +837,7 @@ const PenpaText = {
         lb_settings_surface_second_orange: {EN: 'Orange', JP: '橙', ZH: '橙'},
         lb_settings_surface_second_purple: {EN: 'Purple', JP: '紫', ZH: '紫'},
         lb_settings_surface_second_brown: {EN: 'Brown', JP: '茶', ZH: '棕'},
+        lb_settings_warn_long_links: {EN: 'Warn on Very Long Links', JP: '非常に長いリンクについて警告してください', ZH: '警告：关于非常长的链接'},
         lb_settings_tools: {EN: 'Tools', JP: '機能', ZH: '工具'},
         lb_settings_custom_colors: {EN: 'Custom Colors (Beta):', JP: '色の設定', ZH: '自定义颜色'},
         lb_settings_floating_panel: {EN: 'Floating Panel:', JP: 'パネル', ZH: '浮窗面板'},
@@ -1154,6 +1161,11 @@ const PenpaText = {
             EN: 'In case of \"URL too long Error\". Type/Paste Penpa-edit URL here and click on Load button. You can also load puzz.link puzzles here',
             JP: "URLが長すぎるエラーの時はここに入力。puzz.linkの一部のリンクにも対応。",
             ZH: '如果出现“链接过长”错误，可在此处输入/粘贴Penpa-edit链接并点击加载按钮。也可以在此处加载puzz.link谜题。'
+        },
+        long_link_warning: {
+            EN: 'Your link may be too long to load normally. In case of \"URL too long Error\", open Penpa, click \"Load\", and type/paste the URL into the box.',
+            JP: "リンクが長すぎて通常読み込めないかもしれません。「URLが長すぎるエラー」が出た場合は、Penpaを開き、「読み込み」をクリックし、URLを入力してボックスに貼り付けてください。",
+            ZH: '你的链接可能太长，无法正常加载。如果出现"URL 太长错误"，打开Penpa，点击"加载"，然后输入并粘贴URL到框里。'
         },
 
         "answer_check_shading exact color": {


### PR DESCRIPTION
- Adds a warning popup when exporting a link and it's very long -- likely to trigger the "URI too long" error.
- Adds a setting to the Settings popup and the export popup allowing the warning to be turned off.
- Cleanup of a few settings-related handlers.
- Cleanup/fix load method to parse URLs that don't contain "penpa-edit" to allow local dev URLs to load more easily.